### PR TITLE
Override FileSystem.getScheme()

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -184,6 +184,11 @@ public class GoogleHadoopFileSystem
   public String getHadoopScheme() {
     return GoogleCloudStorageFileSystem.SCHEME;
   }
+  
+  @Override
+  public String getScheme() {
+    return GoogleCloudStorageFileSystem.SCHEME;
+  }
 
   @Override
   public Path getFileSystemRoot() {


### PR DESCRIPTION
My application is accessing the FileSystem.getScheme() method, which leads to the following exception:

``` java
throw new UnsupportedOperationException("Not implemented by the " + getClass().getSimpleName() + " FileSystem implementation");
```

I have done this change using the GitHub Web UI because I was too lazy to check out the code. I think my code is building but I haven't tested it ;)
