### PR TITLE
Update google-apis, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+bin/
+*.iml
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <bigdataoss.gcs.version>1.4.1-SNAPSHOT</bigdataoss.gcs.version>
     <bigdataoss.gcsio.version>1.4.1-SNAPSHOT</bigdataoss.gcsio.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <google.api.version>1.19.0</google.api.version>
+    <google.api.version>1.20.0</google.api.version>
     <google.guava.version>18.0</google.guava.version>
     <build.java.source.version>7</build.java.source.version>
     <build.java.target.version>7</build.java.target.version>
@@ -200,7 +200,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-storage</artifactId>
-        <version>v1-rev16-${google.api.version}</version>
+        <version>v1-rev35-${google.api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.oauth-client</groupId>
@@ -215,7 +215,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-bigquery</artifactId>
-        <version>v2-rev171-${google.api.version}</version>
+        <version>v2-rev213-${google.api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Updated to 1.20 google-api, rev35 and rev213 gcs and biq query dependencies to fix certificate errors when using the GCS connector from a GCE instance: www.googleapis.com/##.##.##.## does not match *.googleapis.com...etc

Added .gitignore to stop accidental garbage commits