### PR TITLE
Fix infinite wait if there is no 0-record file

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
@@ -282,7 +282,7 @@ public class DynamicFileListRecordReader<K, V>
    *     files we plan to read.
    */
   private boolean shouldExpectMoreFiles() {
-    if (endFileNumber == -1 || knownFileSet.size() <= endFileNumber) {
+    if ((endFileNumber == -1 && recordsRead < estimatedNumRecords) || knownFileSet.size() <= endFileNumber) {
       return true;
     }
     return false;


### PR DESCRIPTION
Fix infinite wait if there is no 0-record file and all records are already read.
This fixes  #23