### PR TITLE
Fix infinite loop

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -77,6 +77,11 @@ public class BigQueryConfiguration {
       "mapred.bq.dynamic.file.list.record.reader.poll.interval";
   public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT = 10000;
 
+  public static final String DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_KEY =
+      "mapred.bq.dynamic.file.list.record.reader.max.attempts";
+  public static final int DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_DEFAULT = 15;
+
+
   /** A list of all necessary Configuration keys for input connector. */
   public static final List<String> MANDATORY_CONFIG_PROPERTIES_INPUT = ImmutableList.of(
       PROJECT_ID_KEY, INPUT_PROJECT_ID_KEY, INPUT_DATASET_ID_KEY, INPUT_TABLE_ID_KEY);

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
@@ -44,6 +44,9 @@ public class DynamicFileListRecordReader<K, V>
   // The estimated number of records we will read in total.
   private long estimatedNumRecords;
 
+  // maximum number of attempts to wait for next file
+  private int maxAttempts;
+
   // The interval we will poll listStatus/globStatus inside nextKeyValue() if we don't already
   // have a file ready for reading.
   private int pollIntervalMs;
@@ -115,6 +118,10 @@ public class DynamicFileListRecordReader<K, V>
     pollIntervalMs = context.getConfiguration().getInt(
         BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_KEY,
         BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT);
+    // max number of attempts to wait for next file
+    maxAttempts = context.getConfiguration().getInt(
+        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_KEY,
+        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_DEFAULT);
 
     fileSystem = inputDirectoryAndPattern.getFileSystem(context.getConfiguration());
 
@@ -149,8 +156,10 @@ public class DynamicFileListRecordReader<K, V>
     }
 
     boolean needRefresh = !isNextFileReady() && shouldExpectMoreFiles();
-    while (needRefresh) {
+    int numAttempt = 0;
+    while (needRefresh && numAttempt < maxAttempts) {
       LOG.debug("No files available, but more are expected; refreshing...");
+      LOG.debug(String.format("Current attempt: %s", numAttempt));
       refreshFileList();
       needRefresh = !isNextFileReady() && shouldExpectMoreFiles();
       if (needRefresh) {
@@ -161,7 +170,13 @@ public class DynamicFileListRecordReader<K, V>
         } catch (InterruptedException ie) {
           LOG.warn("Interrupted while sleeping.", ie);
         }
+        numAttempt++;
       }
+    }
+
+    if (numAttempt == maxAttempts) {
+        throw new IllegalStateException(String.format("Couldn't obtain any files after %s retries. This could happen ",
+                maxAttempts));
     }
 
     if (isNextFileReady()) {


### PR DESCRIPTION
There is a problem with infinite loop in record reader in two cases:
1. BigQuery returned 0 records, but didn't create 0-record file
2. First task attempt failed. In that case on the second task attempt record reader will wait indefinitely, but no files will appear.
