### PR TITLE
Add location support for temporary datasets.

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -101,6 +101,15 @@ public class BigQueryConfiguration {
   /** 64MB default write buffer size. */
   public static final int OUTPUT_WRITE_BUFFER_SIZE_DEFAULT = 64 * 1024 * 1024;
 
+  /**
+   * Configure the location of the temporary dataset.
+   * Currently supported values are "US" and "EU".
+   */
+  public static final String DATA_LOCATION_KEY = "mapred.bq.output.location";
+
+    /** The default dataset location is US */
+  public static final String DATA_LOCATION_DEFAULT = "US";
+
   /** A list of all necessary Configuration keys. */
   public static final List<String> MANDATORY_CONFIG_PROPERTIES_OUTPUT =
       ImmutableList.of(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputCommitter.java
@@ -91,8 +91,11 @@ public class BigQueryOutputCommitter
     datasetReference.setProjectId(tempTableRef.getProjectId());
     datasetReference.setDatasetId(tempTableRef.getDatasetId());
 
+    Configuration config = context.getConfiguration();
     Dataset tempDataset = new Dataset();
     tempDataset.setDatasetReference(datasetReference);
+    tempDataset.setLocation(config.get(BigQueryConfiguration.DATA_LOCATION_KEY,
+                                       BigQueryConfiguration.DATA_LOCATION_DEFAULT));
 
     // Insert dataset into Bigquery.
     Bigquery.Datasets datasets = bigQueryHelper.getRawBigquery().datasets();

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputCommitterTest.java
@@ -116,7 +116,9 @@ public class BigQueryOutputCommitterTest {
     expectedTempDataset = new Dataset()
         .setDatasetReference(new DatasetReference()
             .setProjectId(TEMP_PROJECT_ID)
-            .setDatasetId(TEMP_DATASET_ID));
+            .setDatasetId(TEMP_DATASET_ID))
+        .setLocation(conf.get(BigQueryConfiguration.DATA_LOCATION_KEY,
+                              BigQueryConfiguration.DATA_LOCATION_DEFAULT));
     CredentialConfigurationUtil.addTestConfigurationSettings(conf);
 
     // Create job context.


### PR DESCRIPTION
Adding support to specify the dataset location for the temporary dataset, when bulk loading. The current behaviour defaults to the US location, this causes the following issue for datasets located in EU:
```
java.io.IOException: Cannot read and write in different locations: source: US, destination: EU
```
The configuration key to change the location is: `mapred.bq.output.location`