### PR TITLE
Support specifying partition in table name

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputFormat.java
@@ -193,6 +193,6 @@ public class BigQueryOutputFormat<K, V extends JsonObject>
    */
   static String getUniqueTable(String taskAttemptId, String tableId) {
     return String.format(
-        "%s_%s", tableId, taskAttemptId.toString());
+        "%s_%s", tableId.replace("$", "__"), taskAttemptId.toString());
   }
 }

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryStrings.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryStrings.java
@@ -10,7 +10,7 @@ import com.google.common.base.Strings;
  */
 public class BigQueryStrings {
   // Regular expression for validating a datasetId.tableId pair.
-  public static final String DATASET_AND_TABLE_REGEX = "[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+";
+  public static final String DATASET_AND_TABLE_REGEX = "[a-zA-Z0-9_]+\\.[a-zA-Z0-9_$]+";
 
   /**
    * Returns a String representation of the TableReference suitable for interop with other bigquery

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryOutputFormatTest.java
@@ -239,6 +239,14 @@ public class BigQueryOutputFormatTest {
         String.format("test_tableId_attempt_%s_%04d_r_%06d_%d",
             jobIdString, jobNumber, taskNumber, taskAttempt),
         uniqueTable);
+
+    tableId = "test_tableId$20160808";
+    uniqueTable = BigQueryOutputFormat.getUniqueTable(taskAttemptId.toString(), tableId);
+    Assert.assertEquals(
+            String.format("test_tableId__20160808_attempt_%s_%04d_r_%06d_%d",
+                    jobIdString, jobNumber, taskNumber, taskAttempt),
+            uniqueTable);
+
   }
 
 


### PR DESCRIPTION
Currently connector doesn't allow table names containing $ sign (that specifies partition for time-partitioned tables). So this PR fixes it.