### PR TITLE
Perform lazy seek before in GoogleCloudStorageReadChannel.position

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -527,6 +527,8 @@ public class GoogleCloudStorageReadChannel
       if (skipBuffer == null) {
         skipBuffer = new byte[SKIP_BUFFER_SIZE];
       }
+      // perform lazy seek before reading
+      performLazySeek();
       while (seekDistance > 0) {
         int bytesRead = readChannel.read(
             ByteBuffer.wrap(skipBuffer, 0, (int) Math.min(skipBuffer.length, seekDistance)));


### PR DESCRIPTION
Main issue: When reading ORC data (hive columnar format which extensively uses positional reads), it ended up throwing the following exception with gcs-connector. 

`Caused by: java.io.IOException: Somehow read -1 bytes trying to skip 617 more bytes to seek to position 2634, size: 6950
        at com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel.position(GoogleCloudStorageReadChannel.java:535)
        at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream.seek(GoogleHadoopFSInputStream.java:301)
        at org.apache.hadoop.fs.FSInputStream.read(FSInputStream.java:74)
        at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream.read(GoogleHadoopFSInputStream.java:266)
        at org.apache.hadoop.fs.FSInputStream.readFully(FSInputStream.java:121)
        at org.apache.hadoop.fs.FSDataInputStream.readFully(FSDataInputStream.java:111)`



Simple demo is available in https://github.com/rajeshbalamohan/gcs-connector-issue-demo.

It would be good to use FS contract tests of Hadoop (https://issues.apache.org/jira/browse/HADOOP-9361, https://github.com/apache/hadoop/tree/trunk/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract)