### PR TITLE
Moving GCS docs to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ bin/
 *.iml
 *.ipr
 *.iws
+
+# MacOS filder files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Libraries and tools for interoperability between Hadoop-related open-source soft
 
 ## Google Cloud Storage connector for Hadoop
 
-The Google Cloud Storage connector for Hadoop enables running MapReduce jobs directly on data in Google Cloud Storage by implementing the Hadoop FileSystem interface.
-
-For details, visit https://developers.google.com/hadoop/google-cloud-storage-connector
+The Google Cloud Storage connector for Hadoop enables running MapReduce jobs directly on data in Google Cloud Storage by implementing the Hadoop FileSystem interface. For details, see the README in the `/gcs/` folder.
 
 ### Building
 

--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -1,0 +1,43 @@
+# Installing the connector
+
+To install the connector manually, complete the following steps.
+
+## Ensure authenticated Cloud Storage access
+
+Depending on where the machines which comprise your cluster are located, you must do one of the following:
+
+* **Google Cloud Platform** - Each Google Compute Engine VM must be [configured to have access](https://cloud.google.com/compute/docs/authentication#using) to the [Cloud Storage scope](https://cloud.google.com/storage/docs/authentication#oauth) you intend to use the connector for.
+* **non-Google Cloud Platform** - Obtain an [OAuth 2.0 private key](https://cloud.google.com/storage/docs/authentication#generating-a-private-key). Installing the connector on a machine other than a GCE VM can lead to higher Cloud Storage access costs. For more information, see [Cloud Storage Pricing](https://cloud.google.com/storage/pricing).
+
+## Add the connector jar to Hadoop's classpath
+
+Placing the connector jar in the appropriate subdirectory of the Hadoop installation may be effective to have Hadoop load the jar. However, to be certain that the jar is loaded, add `HADOOP_CLASSPATH=$HADOOP_CLASSPATH:</path/to/gcs-connector-jar>` to `hadoop-env.sh` in the Hadoop configuration directory.
+
+## Configure Hadoop
+
+Based on the steps in configuring the connector, you must add the following two properties to `core-site.xml`.
+
+    <property>
+      <name>fs.gs.impl</name>
+      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem</value>
+      <description>The FileSystem for gs: (GCS) uris.</description>
+    </property>
+    <property>
+      <name>fs.AbstractFileSystem.gs.impl</name>
+      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS</value>
+      <description>
+        The AbstractFileSystem for gs: (GCS) uris. Only necessary for use with Hadoop 2.
+      </description>
+    </property>
+
+If you chose to use a private key for Cloud Storage Authorizaton, make sure to set the necessary `google.cloud.auth` values documented in [gcs-core-default.xml](/conf/gcs-core-default.xml) inside the `conf` directory.
+
+## Test the installation
+
+On the command line, type `hadoop fs -ls gs://<some-bucket>`, where `<some-bucket>` is the Google Cloud Storage bucket to which you gave the connector read access. The command should output the top-level directories and objects contained in `<some-bucket>`. If there is a problem, see Troubleshooting the installation.
+
+## Troubleshooting the installation
+
+* If the installation test reported `No FileSystem for scheme: gs`, make sure that you correctly set the two properties in the correct core-site.xml.
+* If the test reported `java.lang.ClassNotFoundException: com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem`, check that you added the connector to the [Hadoop classpath](https://cloud.google.com/hadoop/google-cloud-storage-connector#classpath).
+* If the test issued a message related to authorization, make sure that you have access to `<some-bucket>` with [`gsutil`](https://cloud.google.com/storage/docs/gsutil), and that the credentials in your configuration are correct.

--- a/gcs/README.MD
+++ b/gcs/README.MD
@@ -1,0 +1,39 @@
+# Google Cloud Storage Connector for Spark and Hadoop
+
+The Google Cloud Storage connector for Hadoop lets you run [Apache Hadoop](http://hadoop.apache.org) or [Apache Spark](http://spark.apache.org) jobs directly on data in [Google Cloud Storage](https://cloud.google.com/storage), and offers a number of benefits over choosing Hadoop Distributed File System (HDFS) as your default file system.
+
+## Benefits of using the connector
+
+Choosing Cloud Storage alongside the [Hadoop Distributed File System (HDFS)](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html) has several benefits:
+
+* **Direct data access** - Store your data in Cloud Storage and access it directly, with no need to transfer it into HDFS first.
+* **HDFS compatibility** - You can store data in HDFS in addition to Cloud Storage, and access it with the connector by using a different file path.
+* **Interoperability** - Storing data in Cloud Storage enables seamless interoperability between Spark, Hadoop, and other Google services.
+* **Data accessibility** - When you shut down a Hadoop cluster, you still have access to your data in Cloud Storage, unlike HDFS.
+* **High data availability** - Data stored in Cloud Storage is highly available and globally replicated without a performance hit.
+* **No storage management overhead** - Unlike HDFS, Cloud Storage requires no routine maintenance such as checking the file system, upgrading or rolling back to a previous version of the file system, etc.
+* **Quick startup** - In HDFS, a MapReduce job can't start until the NameNode is out of safe mode—a process that can take from a few seconds to many minutes depending on the size and state of your data. With Google Cloud Storage, you can start your job as soon as the task nodes start, leading to significant cost savings over time.
+
+## Getting the connector
+
+This repository contains the Hadoop 1.x compatible and the Hadoop 2.x compatible connector. You can clone this repository and follow the directions in `INSTALL.md` within this directory to install the connector. If you use [Google Cloud Dataproc](https://cloud.google.com/dataproc) the connector is installed automatically.
+
+## Configuring the connector
+
+When you set up a Hadoop cluster by following the directions in `INSTALL.md`, the cluster is automatically configured for optimal use with the connector. Typically, there is no need for further configuration.
+
+To customize the connector, specify configuration values in `core-site.xml`  based on how you set yoir cluster:
+* **[`bdutil`](https://github.com/GoogleCloudPlatform/bdutil)** - in `conf/hadoop<version>gcs-core-template.xml` in the bdutil package directory, before deploying a cluster with bdutil
+* **other existing clusters** - the Hadoop configuration directory on the machine on which the connector is installed
+
+For a complete list of configuration keys and their default values see `gcs-core-default.xml`.
+
+## Accessing Cloud Storage data
+
+There are multiple ways to access data stored in Google Cloud Storage:
+
+* The hadoop shell: `hadoop fs -ls gs://<CONFIGBUCKET>/dir/file` (recommended) or `fs -ls /dir/file`
+* the [Cloud Platform Console Cloud Storage browser](https://cloud.google.com/storage/docs/gettingstarted-console)
+* [`gsutil cp`](https://cloud.google.com/storage/docs/gsutil/commands/cp)
+* [`gsutil rsync`](https://cloud.google.com/storage/docs/gsutil/commands/rsync)
+* The [Cloud Storage JSON API](https://cloud.google.com/storage/docs/json_api/v1/)

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.gs.project.id</name>
+    <value></value>
+    <description>
+      Required. Google Cloud Project ID with access to configured GCS buckets.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.working.dir</name>
+    <value>/</value>
+    <description>
+      The directory relative gs: uris resolve in inside of the default bucket.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.metadata.cache.enable</name>
+    <value>true</value>
+    <description>
+      Whether or not to create an in memory cache of GCS objects created by
+      the connector. This allows for immediate visibility of objects to
+      subsequent list requests from the same client.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.implicit.directory.repair</name>
+    <value>true</value>
+    <description>
+      Whether or not to create objects for the parent directories of objects
+      with / in their path e.g. creating gs://bucket/foo/ upon finding
+      gs://bucket/foo/bar.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.glob.flatlist.enable</name>
+    <value>true</value>
+    <description>
+      Whether or not to prepopulate potenital glob matches in a single list
+      request to minimize calls to GCS in nested glob cases.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.system.bucket</name>
+    <value></value>
+    <description>
+      Deprecated. GCS bucket to use as a default bucket if fs.default.name
+      is not a gs: uri.
+    </description>
+  </property>
+
+  <!-- Authorization -->
+
+  <property>
+    <name>google.cloud.auth.service.account.enable</name>
+    <value>true</value>
+    <description>
+      Whether to use a service account for GCS authorizaiton. If an email and
+      keyfile are provided (see google.cloud.auth.service.account.email and
+      google.cloud.auth.service.account.keyfile), then that service account
+      willl be used. Otherwise the connector will look to see if it running on
+      a GCE VM with some level of GCS access in it's service account scope, and
+      use that service account.
+    </description>
+  </property>
+
+  <!-- The following properties are required when not on a GCE VM and
+    google.cloud.auth.service.account.enable is true.
+  -->
+  <property>
+    <name>google.cloud.auth.service.account.email</name>
+    <value></value>
+    <description>
+      The email address is associated with the service account used for GCS
+      access when google.cloud.auth.service.account.enable is true.
+    </description>
+  </property>
+  <property>
+    <name>google.cloud.auth.service.account.keyfile</name>
+    <value></value>
+    <description>
+      The PKCS12 (p12) certificate file of the service account used for GCS
+      access when google.cloud.auth.service.account.enable is true.
+    </description>
+  </property>
+
+  <!--  The following properties are required when
+    google.cloud.auth.service.account.enable is false.
+  -->
+  <property>
+    <name>google.cloud.auth.client.id</name>
+    <value></value>
+    <description>
+      The client ID for GCS access in the OAuth 2.0 installed application flow
+      (when google.cloud.auth.service.account.enable is false).
+    </description>
+  </property>
+  <property>
+    <name>google.cloud.auth.client.secret</name>
+    <value></value>
+    <description>
+      The client secret for GCS access in the OAuth 2.0 installed application
+      flow (when google.cloud.auth.service.account.enable is false).
+    </description>
+  </property>
+  <property>
+    <name>google.cloud.auth.client.file</name>
+    <value></value>
+    <description>
+      The client credential file for GCS access in the OAuth 2.0 installed
+      application flow (when google.cloud.auth.service.account.enable is
+      false).
+    </description>
+  </property>
+
+  <!-- Block, Buffer, and file sizes -->
+
+  <property>
+    <name>fs.gs.block.size</name>
+    <value>67108864</value>
+    <description>
+      The reported block size of the file system. This does not change any
+      behavior of the connector or the underlying GCS objectsr. However it
+      will affect the number of splits Hadoop MapReduce uses for a given
+      input.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.io.buffersize</name>
+    <value>8388608</value>
+    <description>
+      The number of bytes in read buffers.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.io.buffersize.write</name>
+    <value>67108864</value>
+    <description>
+      The number of bytes in write buffers.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.file.size.limit.250gb</name>
+    <value>true</value>
+    <description>
+      Whether to limit files to 250 GB. Setting to false may degrade connector
+      performance somewhat.
+    </description>
+  </property>
+</configuration>


### PR DESCRIPTION
Currently, the GCS connector docs live on the [Google Cloud site](https://cloud.google.com/hadoop/google-cloud-storage-connector). But those docs are far away from the connector, somewhat stale, and in a place that is hard to find. 

This PR takes the data on that documentation page and forks it into two new docs:

- A README for details about the GCS connector
- An INSTALL for installation directions