### PR TITLE
Support as many parts of Application Default Credentials as safely possible

### DIFF
--- a/bigquery/bigquery-hadoop1.pom.xml
+++ b/bigquery/bigquery-hadoop1.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigquery-connector-parent</artifactId>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.3-SNAPSHOT-hadoop1</version>
+  <version>0.11.3-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/bigquery/bigquery-hadoop1.pom.xml
+++ b/bigquery/bigquery-hadoop1.pom.xml
@@ -30,7 +30,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.11.3-SNAPSHOT-hadoop1</version>
+  <version>0.11.0-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/bigquery/bigquery-hadoop2.pom.xml
+++ b/bigquery/bigquery-hadoop2.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigquery-connector-parent</artifactId>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.3-SNAPSHOT-hadoop2</version>
+  <version>0.11.0-SNAPSHOT-hadoop2</version>
 
   <dependencies>
     <dependency>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.3-SNAPSHOT</version>
+  <version>0.11.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,4 +1,5 @@
 1.7.0 - 2017-XX-XX
+
   1. Wire HTTP transport settings into Credential logic.
 
   2. Fixed an issue where JSON auth files containing user auth e.g.
@@ -7,6 +8,9 @@
 
   3. Honor GOOGLE_APPLICATION_DEFAULT_CREDENTIALS environment variable. For
      Google Application Default Credentials (but not other defaults).
+
+  4. Make fs.gs.project.id optional. It is still required for listing buckets,
+     creating buckets, and entire BigQuery connector.
 
 1.6.1 - 2017-04-14
 

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,4 +1,4 @@
-1.6.2 - 2017-XX-XX
+1.7.0 - 2017-XX-XX
   1. Wire HTTP transport settings into Credential logic.
 
 1.6.1 - 2017-04-14

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,6 +1,10 @@
 1.7.0 - 2017-XX-XX
   1. Wire HTTP transport settings into Credential logic.
 
+  2. Fixed an issue where JSON auth files containing user auth e.g.
+     Application default credentials does not work with
+     google.cloud.auth.service.account.json.keyfile
+
 1.6.1 - 2017-04-14
 
   1. Added a polling loop when determining if a createEmptyObjects error can

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -2,8 +2,11 @@
   1. Wire HTTP transport settings into Credential logic.
 
   2. Fixed an issue where JSON auth files containing user auth e.g.
-     Application default credentials does not work with
+     application_default_credentials.json does not work with
      google.cloud.auth.service.account.json.keyfile
+
+  3. Honor GOOGLE_APPLICATION_DEFAULT_CREDENTIALS environment variable. For
+     Google Application Default Credentials (but not other defaults).
 
 1.6.1 - 2017-04-14
 

--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -17,39 +17,8 @@ Placing the connector jar in the appropriate subdirectory of the Hadoop installa
 
 To begin, you will need a JSON keyfile so the connector can authenticate to Google Cloud Storage. You can follow [these directions](https://cloud.google.com/storage/docs/authentication#service_accounts) to obtain a JSON keyfile.
 
-Once you have the JSON key file, you must add the following properties to `core-site.xml` on your server.
+Once you have the JSON key file, you must add the following property to `core-site.xml` on your server.
 
-    <property>
-      <name>fs.gs.impl</name>
-      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem</value>
-      <description>The FileSystem for gs: (GCS) uris.</description>
-    </property>
-    <property>
-      <name>fs.AbstractFileSystem.gs.impl</name>
-      <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS</value>
-      <description>
-        The AbstractFileSystem for gs: (GCS) uris. Only necessary for use with Hadoop 2.
-      </description>
-    </property>
-    <property>
-      <name>fs.gs.project.id</name>
-      <value></value>
-      <description>
-        Required. Google Cloud Project ID with access to configured GCS buckets.
-      </description>
-    </property>
-    <property>
-      <name>google.cloud.auth.service.account.enable</name>
-      <value>true</value>
-      <description>
-        Whether to use a service account for GCS authorizaiton. If an email and
-        keyfile are provided (see google.cloud.auth.service.account.email and
-        google.cloud.auth.service.account.keyfile), then that service account
-        willl be used. Otherwise the connector will look to see if it running on
-        a GCE VM with some level of GCS access in it's service account scope, and
-        use that service account.
-      </description>
-    </property>
     <property>
       <name>google.cloud.auth.service.account.json.keyfile</name>
       <value></value>
@@ -58,6 +27,8 @@ Once you have the JSON key file, you must add the following properties to `core-
         access when google.cloud.auth.service.account.enable is true.
       </description>
     </property>
+
+You can alternatively set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to your keyfile.
 
 Additional properties can be specified for the Cloud Storage connector, including alternative authentication options. For more information, see the values documented in the [gcs-core-default.xml](/gcs/conf/gcs-core-default.xml) file inside the `conf` directory.
 

--- a/gcs/gcs-hadoop1.pom.xml
+++ b/gcs/gcs-hadoop1.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>gcs-connector-parent</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.2-SNAPSHOT-hadoop1</version>
+  <version>1.7.0-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/gcs/gcs-hadoop2.pom.xml
+++ b/gcs/gcs-hadoop2.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>gcs-connector-parent</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.2-SNAPSHOT-hadoop2</version>
+  <version>1.7.0-SNAPSHOT-hadoop2</version>
 
   <dependencies>
     <dependency>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.2-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -2181,8 +2181,7 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
         .setTransportType(transportType)
         .setProxyAddress(proxyAddress);
 
-    String projectId =
-        ConfigurationUtil.getMandatoryConfig(config, GCS_PROJECT_ID_KEY);
+    String projectId = config.get(GCS_PROJECT_ID_KEY);
 
     optionsBuilder.getCloudStorageOptionsBuilder().setProjectId(projectId);
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -309,24 +309,13 @@ public class GoogleHadoopFileSystemIntegrationTest
   }
 
   @Test
-  public void testInitializeThrowsWhenNoProjectIdConfigured()
+  public void testInitializeSucceedsWhenNoProjectIdConfigured()
       throws URISyntaxException, IOException {
-    // Verify that incomplete config raises exception.
-    String existingBucket = bucketName;
+    Configuration config = loadConfig();
+    // Unset Project ID
+    config.set(GoogleHadoopFileSystemBase.GCS_PROJECT_ID_KEY, null);
 
-    Configuration config = new Configuration();
-    URI gsUri = new URI("gs://foobar/");
-    config.setBoolean(GoogleHadoopFileSystemBase.ENABLE_GCE_SERVICE_ACCOUNT_AUTH_KEY, false);
-    config.setBoolean(
-        HadoopCredentialConfiguration.BASE_KEY_PREFIX
-            + HadoopCredentialConfiguration.ENABLE_NULL_CREDENTIAL_SUFFIX,
-        true);
-    config.set(GoogleHadoopFileSystemBase.GCS_SYSTEM_BUCKET_KEY, existingBucket);
-    // project ID is not set.
-
-    expectedException.expect(IOException.class);
-    expectedException.expectMessage(GoogleHadoopFileSystemBase.GCS_PROJECT_ID_KEY);
-
+    URI gsUri = (new Path("gs://foo")).toUri();
     new GoogleHadoopFileSystem().initialize(gsUri, config);
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -91,6 +91,11 @@ public class GoogleHadoopFileSystemTest
   }
 
   @Test @Override
+  public void testInitializeSucceedsWhenNoProjectIdConfigured()
+      throws IOException, URISyntaxException {
+  }
+
+  @Test @Override
   public void testInitializeWithWorkingDirectory()
       throws IOException, URISyntaxException {
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopGlobalRootedFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopGlobalRootedFileSystemIntegrationTest.java
@@ -211,28 +211,6 @@ public class GoogleHadoopGlobalRootedFileSystemIntegrationTest
   }
 
   @Test
-  public void testInitializeThrowsWhenNoProjectIdConfigured()
-      throws URISyntaxException, IOException {
-    // Verify that incomplete config raises exception.
-    String existingBucket = bucketName;
-
-    Configuration config = new Configuration();
-    URI gsUri = new URI("gsg://foobar/");
-    config.setBoolean(GoogleHadoopFileSystemBase.ENABLE_GCE_SERVICE_ACCOUNT_AUTH_KEY, false);
-    config.setBoolean(
-        HadoopCredentialConfiguration.BASE_KEY_PREFIX
-            + HadoopCredentialConfiguration.ENABLE_NULL_CREDENTIAL_SUFFIX,
-        true);
-    config.set(GoogleHadoopFileSystemBase.GCS_SYSTEM_BUCKET_KEY, existingBucket);
-    // project ID is not set.
-
-    expectedException.expect(IOException.class);
-    expectedException.expectMessage(GoogleHadoopFileSystemBase.GCS_PROJECT_ID_KEY);
-
-    new GoogleHadoopGlobalRootedFileSystem().initialize(gsUri, config);
-  }
-
-  @Test
   public void testInitializeThrowsWhenWrongSchemeConfigured()
       throws URISyntaxException, IOException {
     // Verify that we cannot initialize using URI with a wrong scheme.

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -93,14 +93,6 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -583,6 +583,7 @@ public class GoogleCloudStorageImpl
     Preconditions.checkArgument(!Strings.isNullOrEmpty(bucketName),
         "bucketName must not be null or empty");
     Preconditions.checkNotNull(options, "options must not be null");
+    Preconditions.checkNotNull(storageOptions.getProjectId(), "projectId must not be null");
 
     Bucket bucket = new Bucket();
     bucket.setName(bucketName);
@@ -909,9 +910,9 @@ public class GoogleCloudStorageImpl
    * results; these can then be used to either extract just their names, or to parse into full
    * GoogleCloudStorageItemInfos.
    */
-  private List<Bucket> listBucketsInternal()
-      throws IOException {
+  private List<Bucket> listBucketsInternal() throws IOException {
     LOG.debug("listBucketsInternal()");
+    Preconditions.checkNotNull(storageOptions.getProjectId(), "projectId must not be null");
     List<Bucket> allBuckets = new ArrayList<>();
     Storage.Buckets.List listBucket = gcs.buckets().list(storageOptions.getProjectId());
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -18,6 +18,7 @@ import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.HttpTransportFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import javax.annotation.Nullable;
 
 /**
  * Configuration options for the GoogleCloudStorage class.
@@ -212,6 +213,7 @@ public class GoogleCloudStorageOptions {
     return inferImplicitDirectoriesEnabled;
   }
 
+  @Nullable
   public String getProjectId() {
     return projectId;
   }
@@ -249,8 +251,6 @@ public class GoogleCloudStorageOptions {
   }
 
   public void throwIfNotValid() {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId),
-        "projectId must not be null or empty");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(appName),
         "appName must not be null or empty");
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -96,22 +96,12 @@ public class GoogleCloudStorageFileSystemTest
 
     setDefaultValidOptions(optionsBuilder);
 
-    // Verify that projectId == null or empty throws IllegalArgumentException.
+    // Verify that projectId == null or empty does not throw.
     optionsBuilder.getCloudStorageOptionsBuilder().setProjectId(null);
-    try {
-      new GoogleCloudStorageFileSystem(cred, optionsBuilder.build());
-      Assert.fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException iae) {
-      // Expected.
-    }
+    new GoogleCloudStorageFileSystem(cred, optionsBuilder.build());
 
     optionsBuilder.getCloudStorageOptionsBuilder().setProjectId("");
-    try {
-      new GoogleCloudStorageFileSystem(cred, optionsBuilder.build());
-      Assert.fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException iae) {
-      // Expected.
-    }
+    new GoogleCloudStorageFileSystem(cred, optionsBuilder.build());
 
     optionsBuilder.getCloudStorageOptionsBuilder().setProjectId("projectId");
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -4323,22 +4323,12 @@ public class GoogleCloudStorageTest {
     // Verify that fake projectId/appName and mock storage does not throw.
     new GoogleCloudStorageImpl(optionsBuilder.build(), mockStorage);
 
-    // Verify that projectId == null or empty throws IllegalArgumentException.
+    // Verify that projectId == null or empty does not throw.
     optionsBuilder.setProjectId(null);
-    try {
-      new GoogleCloudStorageImpl(optionsBuilder.build(), mockStorage);
-      Assert.fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException iae) {
-      // Expected.
-    }
+    new GoogleCloudStorageImpl(optionsBuilder.build(), mockStorage);
 
     optionsBuilder.setProjectId("");
-    try {
-      new GoogleCloudStorageImpl(optionsBuilder.build(), mockStorage);
-      Assert.fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException iae) {
-      // Expected.
-    }
+    new GoogleCloudStorageImpl(optionsBuilder.build(), mockStorage);
 
     optionsBuilder.setProjectId("projectId");
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -94,9 +94,15 @@ public class CredentialFactory {
           .setServiceAccountScopes(credential.getServiceAccountScopes())
           .setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl())
           .setTransport(credential.getTransport())
+          .setClientAuthentication(credential.getClientAuthentication())
           .setJsonFactory(credential.getJsonFactory())
           .setClock(credential.getClock());
-      return new GoogleCredentialWithRetry(builder);
+      GoogleCredentialWithRetry withRetry = new GoogleCredentialWithRetry(builder);
+      // Setting a refresh token requires validation even if it is null.
+      if(credential.getRefreshToken() != null) {
+        withRetry.setRefreshToken(credential.getRefreshToken());
+      }
+      return withRetry;
     }
 
     public GoogleCredentialWithRetry(Builder builder) {

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -55,6 +55,8 @@ import org.slf4j.LoggerFactory;
  */
 public class CredentialFactory {
 
+  static final String CREDENTIAL_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS";
+
   /**
    * Simple HttpRequestInitializer that retries requests that result in 5XX response codes and
    * IO Exceptions with an exponential backoff.
@@ -388,5 +390,32 @@ public class CredentialFactory {
       throws IOException, GeneralSecurityException {
     return getCredentialFromFileCredentialStoreForInstalledApp(
         clientId, clientSecret, filePath, scopes, getStaticHttpTransport());
+  }
+
+  /**
+   * Determines whether Application Default Credentials have been configured as an evironment
+   * variable.
+   *
+   * In this class for testability.
+   */
+  boolean hasApplicationDefaultCredentialsConfigured() {
+    return System.getenv(CREDENTIAL_ENV_VAR) != null;
+  }
+
+  /**
+   * Get Google Application Default Credentials as described in
+   * <a href="https://developers.google.com/identity/protocols/application-default-credentials#callingjava"
+   * >Google Application Default Credentials</a>
+   * @param scopes The OAuth scopes that the credential should be valid for.
+   */
+  public Credential getApplicationDefaultCredentials(
+      List<String> scopes, HttpTransport transport)
+      throws IOException, GeneralSecurityException {
+    LOG.debug("getApplicationDefaultCredential({})", scopes);
+    // GoogleCredentialWithRetry will not properly retry for all application default credentials e.g.
+    // AppEngine, or GCE metadata. But this should properly retry for known JSON key Credentials.
+    return GoogleCredentialWithRetry.fromGoogleCredential(
+        GoogleCredential.getApplicationDefault(transport, JSON_FACTORY)
+            .createScoped(scopes));
   }
 }

--- a/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.hadoop.util;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.common.collect.ImmutableList;
@@ -81,8 +82,20 @@ public class CredentialConfigurationTest {
   @Test
   public void metadataServiceIsUsedByDefault() throws IOException, GeneralSecurityException {
     configuration.getCredential(TEST_SCOPES);
+    when(mockCredentialFactory.hasApplicationDefaultCredentialsConfigured()).thenReturn(false);
 
     verify(mockCredentialFactory, times(1)).getCredentialFromMetadataServiceAccount();
+  }
+
+  @Test
+  public void applicationDefaultServiceAccountWhenConfigured()
+      throws IOException, GeneralSecurityException {
+    when(mockCredentialFactory.hasApplicationDefaultCredentialsConfigured()).thenReturn(true);
+
+    configuration.getCredential(TEST_SCOPES);
+
+    verify(mockCredentialFactory, times(1))
+        .getApplicationDefaultCredentials(TEST_SCOPES, mockTransport);
   }
 
   @Test


### PR DESCRIPTION
This allows using Cloud SDK credentials with  google.cloud.auth.service.account.json.keyfile (even though it's not a service account keyfile).