### PR TITLE
Wire HTTP transport settings into Credentials.

### DIFF
--- a/bigquery/bigquery-hadoop1.pom.xml
+++ b/bigquery/bigquery-hadoop1.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigquery-connector-parent</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.2-hadoop1</version>
+  <version>0.10.3-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/bigquery/bigquery-hadoop2.pom.xml
+++ b/bigquery/bigquery-hadoop2.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigquery-connector-parent</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.2-hadoop2</version>
+  <version>0.10.3-SNAPSHOT-hadoop2</version>
 
   <dependencies>
     <dependency>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.10.2</version>
+  <version>0.10.3-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,3 +1,5 @@
+1.6.2 - 2017-XX-XX
+
 1.6.1 - 2017-04-14
 
   1. Added a polling loop when determining if a createEmptyObjects error can

--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,4 +1,5 @@
 1.6.2 - 2017-XX-XX
+  1. Wire HTTP transport settings into Credential logic.
 
 1.6.1 - 2017-04-14
 
@@ -120,9 +121,9 @@
   2. Changed RetryHttpInitializer to treat HTTP code 429 as a retriable
      error with exponential backoff instead of erroring out.
   3. Added a new output stream type which can be used by setting:
-     
+
          fs.gs.outputstream.type=SYNCABLE_COMPOSITE
-     
+
      With the SYNCABLE_COMPOSITE type, output streams obtained with a call
      to FileSystem.create(Path) will have (limited) support for Hadoop's
      Syncable interface, where calling hsync() will commit the data written

--- a/gcs/gcs-hadoop1.pom.xml
+++ b/gcs/gcs-hadoop1.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>gcs-connector-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.1-hadoop1</version>
+  <version>1.6.2-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/gcs/gcs-hadoop2.pom.xml
+++ b/gcs/gcs-hadoop2.pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>gcs-connector-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.1-hadoop2</version>
+  <version>1.6.2-SNAPSHOT-hadoop2</version>
 
   <dependencies>
     <dependency>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -25,6 +25,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.PathCodec;
 import com.google.cloud.hadoop.util.ConfigurationUtil;
 import com.google.cloud.hadoop.util.CredentialFactory;
+import com.google.cloud.hadoop.util.EntriesCredentialConfiguration;
 import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
 import com.google.cloud.hadoop.util.HadoopVersionInfo;
 import com.google.cloud.hadoop.util.HttpTransportFactory;
@@ -444,19 +445,19 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
    * Configuration key for setting a proxy for the connector to use to connect to GCS. The proxy
    * must be an HTTP proxy of the form "host:port".
    */
-  public static final String GCS_PROXY_ADDRESS_KEY = "fs.gs.proxy.address";
+  public static final String GCS_PROXY_ADDRESS_KEY = EntriesCredentialConfiguration.PROXY_ADDRESS_KEY;
 
   /** Default to no proxy. */
-  public static final String GCS_PROXY_ADDRESS_DEFAULT = null;
+  public static final String GCS_PROXY_ADDRESS_DEFAULT = EntriesCredentialConfiguration.PROXY_ADDRESS_DEFAULT;
 
   /**
    * Configuration key for the name of HttpTransport class to use for connecting to GCS. Must be the
    * name of an HttpTransportFactory.HttpTransportType (APACHE or JAVA_NET).
    */
-  public static final String GCS_HTTP_TRANSPORT_KEY = "fs.gs.http.transport.type";
+  public static final String GCS_HTTP_TRANSPORT_KEY = EntriesCredentialConfiguration.HTTP_TRANSPORT_KEY;
 
   /** Default to the default specified in HttpTransportFactory. */
-  public static final String GCS_HTTP_TRANSPORT_DEFAULT = null;
+  public static final String GCS_HTTP_TRANSPORT_DEFAULT = EntriesCredentialConfiguration.PROXY_ADDRESS_DEFAULT;
 
   /** Configuration key for adding a suffix to the GHFS application name sent to GCS. */
   public static final String GCS_APPLICATION_NAME_SUFFIX_KEY = "fs.gs.application.name.suffix";

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
@@ -417,6 +417,7 @@ public abstract class GoogleCloudStorageIntegrationHelper {
   /**
    * Gets the credential tests should use for accessing GCS.
    */
+  @Deprecated
   Credential getCredential()
       throws IOException {
     String clientId = System.getenv(GCS_TEST_CLIENT_ID);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpTransport;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
@@ -25,6 +26,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.Builder;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.cloud.hadoop.util.CredentialFactory;
+import com.google.cloud.hadoop.util.HttpTransportFactory;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -57,11 +59,13 @@ public class GoogleCloudStorageTestHelper {
     Credential credential;
     try {
       CredentialFactory credentialFactory = new CredentialFactory();
+      HttpTransport transport = HttpTransportFactory.newTrustedTransport();
       credential =
           credentialFactory.getCredentialFromPrivateKeyServiceAccount(
               serviceAccount,
               privateKeyfile,
-              CredentialFactory.GCS_SCOPES);
+              CredentialFactory.GCS_SCOPES,
+              transport);
     } catch (GeneralSecurityException gse) {
       throw new IOException(gse);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.cloud.bigdataoss</groupId>
   <artifactId>bigdataoss-parent</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
   <name>BigDataOSS Parent</name>
   <description>
     Parent project for Google Cloud Platform Big-Data connectors.
@@ -70,12 +70,12 @@
   </prerequisites>
 
   <properties>
-    <bigdataoss.util.version>1.6.1</bigdataoss.util.version>
-    <bigdataoss.gcsio.version>1.6.1</bigdataoss.gcsio.version>
-    <bigdataoss.util-hadoop.one.version>1.6.1-hadoop1</bigdataoss.util-hadoop.one.version>
-    <bigdataoss.util-hadoop.two.version>1.6.1-hadoop2</bigdataoss.util-hadoop.two.version>
-    <bigdataoss.gcs.hadoop.one.version>1.6.1-hadoop1</bigdataoss.gcs.hadoop.one.version>
-    <bigdataoss.gcs.hadoop.two.version>1.6.1-hadoop2</bigdataoss.gcs.hadoop.two.version>
+    <bigdataoss.util.version>1.6.2-SNAPSHOT</bigdataoss.util.version>
+    <bigdataoss.gcsio.version>1.6.2-SNAPSHOT</bigdataoss.gcsio.version>
+    <bigdataoss.util-hadoop.one.version>1.6.2-SNAPSHOT-hadoop1</bigdataoss.util-hadoop.one.version>
+    <bigdataoss.util-hadoop.two.version>1.6.2-SNAPSHOT-hadoop2</bigdataoss.util-hadoop.two.version>
+    <bigdataoss.gcs.hadoop.one.version>1.6.2-SNAPSHOT-hadoop1</bigdataoss.gcs.hadoop.one.version>
+    <bigdataoss.gcs.hadoop.two.version>1.6.2-SNAPSHOT-hadoop2</bigdataoss.gcs.hadoop.two.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <google.api.version>1.20.0</google.api.version>
     <google.guava.version>18.0</google.guava.version>

--- a/util-hadoop/pom.xml
+++ b/util-hadoop/pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <packaging>pom</packaging>
   <artifactId>util-hadoop-parent</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.hadoop.testing.EntriesCredentialConfigurationUtil;
 import com.google.cloud.hadoop.testing.EntriesCredentialConfigurationUtil.TestEntries;
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration.Entries;
+import com.google.cloud.hadoop.util.HttpTransportFactory.HttpTransportType;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Test;
@@ -105,6 +106,12 @@ public class EntriesCredentialConfigurationTest {
         conf,
         EntriesCredentialConfiguration.ENABLE_NULL_CREDENTIAL_SUFFIX,
         "true");
+    conf.set(
+        EntriesCredentialConfiguration.PROXY_ADDRESS_KEY,
+        "foo.bar:1234");
+    conf.set(
+        EntriesCredentialConfiguration.HTTP_TRANSPORT_KEY,
+        "APACHE");
 
     CredentialConfiguration credentialConfiguration =
         EntriesCredentialConfiguration
@@ -121,6 +128,8 @@ public class EntriesCredentialConfigurationTest {
         credentialConfiguration.getOAuthCredentialFile());
     assertFalse(credentialConfiguration.isServiceAccountEnabled());
     assertTrue(credentialConfiguration.isNullCredentialEnabled());
+    assertEquals("foo.bar:1234", credentialConfiguration.getProxyAddress());
+    assertEquals(HttpTransportType.APACHE, credentialConfiguration.getTransportType());
   }
 
   @Test
@@ -140,6 +149,8 @@ public class EntriesCredentialConfigurationTest {
     assertEquals("anEmail", writtenValue);
 
     credentialConfiguration.setServiceAccountKeyFile("aKeyFile");
+    credentialConfiguration.setProxyAddress("foo.bar:1234");
+    credentialConfiguration.setTransportType(HttpTransportType.APACHE);
     credentialConfiguration.getConfigurationInto(conf);
     writtenValue = getConfigurationKey(
         conf,
@@ -173,5 +184,7 @@ public class EntriesCredentialConfigurationTest {
         conf,
         EntriesCredentialConfiguration.ENABLE_NULL_CREDENTIAL_SUFFIX);
     assertEquals("true", writtenValue);
+    assertEquals("foo.bar:1234", conf.get(EntriesCredentialConfiguration.PROXY_ADDRESS_KEY));
+    assertEquals("APACHE", conf.get(EntriesCredentialConfiguration.HTTP_TRANSPORT_KEY));
   }
 }

--- a/util-hadoop/util-hadoop-hadoop1.pom.xml
+++ b/util-hadoop/util-hadoop-hadoop1.pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>util-hadoop-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
   <packaging>jar</packaging>
   <artifactId>util-hadoop</artifactId>
-  <version>1.6.1-hadoop1</version>
+  <version>1.6.2-SNAPSHOT-hadoop1</version>
 
   <dependencies>
     <dependency>

--- a/util-hadoop/util-hadoop-hadoop2.pom.xml
+++ b/util-hadoop/util-hadoop-hadoop2.pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>util-hadoop-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>pom.xml</relativePath>
   </parent>
 
   <packaging>jar</packaging>
   <artifactId>util-hadoop</artifactId>
-  <version>1.6.1-hadoop2</version>
+  <version>1.6.2-SNAPSHOT-hadoop2</version>
 
   <dependencies>
     <dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <groupId>com.google.cloud.bigdataoss</groupId>
     <artifactId>bigdataoss-parent</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <packaging>jar</packaging>
   <artifactId>util</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013 Google Inc. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.compute.ComputeCredential;
 import com.google.api.client.googleapis.extensions.java6.auth.oauth2.GooglePromptReceiver;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
@@ -61,6 +60,7 @@ public class CredentialFactory {
    * IO Exceptions with an exponential backoff.
    */
   public static class CredentialHttpRetryInitializer implements HttpRequestInitializer {
+
     @Override
     public void initialize(HttpRequest httpRequest) throws IOException {
       httpRequest.setIOExceptionHandler(
@@ -96,7 +96,7 @@ public class CredentialFactory {
           .setTransport(credential.getTransport())
           .setJsonFactory(credential.getJsonFactory())
           .setClock(credential.getClock());
-        return new GoogleCredentialWithRetry(builder);
+      return new GoogleCredentialWithRetry(builder);
     }
 
     public GoogleCredentialWithRetry(Builder builder) {
@@ -142,6 +142,7 @@ public class CredentialFactory {
    * A subclass of ComputeCredential that properly sets request initializers.
    */
   public static class ComputeCredentialWithRetry extends ComputeCredential {
+
     public ComputeCredentialWithRetry(Builder builder) {
       super(builder);
     }
@@ -177,18 +178,19 @@ public class CredentialFactory {
   // HTTP transport used for created credentials to perform token-refresh handshakes with remote
   // credential servers. Initialized lazily to move the possibility of throwing
   // GeneralSecurityException to the time a caller actually tries to get a credential.
-  private static HttpTransport httpTransport = null;
+  // Should only be used for Metadata Auth.
+  private static HttpTransport staticHttpTransport = null;
 
   /**
-   * Returns shared httpTransport instance; initializes httpTransport if it hasn't already been
-   * initialized.
+   * Returns shared staticHttpTransport instance; initializes staticHttpTransport if it hasn't
+   * already been initialized.
    */
-  private static synchronized HttpTransport getHttpTransport()
+  private static synchronized HttpTransport getStaticHttpTransport()
       throws IOException, GeneralSecurityException {
-    if (httpTransport == null) {
-      httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    if (staticHttpTransport == null) {
+      staticHttpTransport = HttpTransportFactory.newTrustedTransport();
     }
-    return httpTransport;
+    return staticHttpTransport;
   }
 
   /**
@@ -200,7 +202,7 @@ public class CredentialFactory {
       throws IOException, GeneralSecurityException {
     LOG.debug("getCredentialFromMetadataServiceAccount()");
     Credential cred = new ComputeCredentialWithRetry(
-        new ComputeCredential.Builder(getHttpTransport(), JSON_FACTORY)
+        new ComputeCredential.Builder(getStaticHttpTransport(), JSON_FACTORY)
             .setRequestInitializer(new CredentialHttpRetryInitializer()));
     try {
       cred.refreshToken();
@@ -215,41 +217,45 @@ public class CredentialFactory {
    * Initializes OAuth2 credential from a private keyfile, as described in
    * <a href="https://code.google.com/p/google-api-java-client/wiki/OAuth2#Service_Accounts"
    * > OAuth2 Service Accounts</a>.
-   *
    * @param serviceAccountEmail Email address of the service account associated with the keyfile.
    * @param privateKeyFile Full local path to private keyfile.
    * @param scopes List of well-formed desired scopes to use with the credential.
+   * @param transport The HttpTransport used for authorization
    */
   public Credential getCredentialFromPrivateKeyServiceAccount(
-      String serviceAccountEmail, String privateKeyFile, List<String> scopes)
+      String serviceAccountEmail,
+      String privateKeyFile,
+      List<String> scopes,
+      HttpTransport transport)
       throws IOException, GeneralSecurityException {
     LOG.debug("getCredentialFromPrivateKeyServiceAccount({}, {}, {})",
         serviceAccountEmail, privateKeyFile, scopes);
 
     return new GoogleCredentialWithRetry(
         new GoogleCredential.Builder()
-          .setTransport(getHttpTransport())
-          .setJsonFactory(JSON_FACTORY)
-          .setServiceAccountId(serviceAccountEmail)
-          .setServiceAccountScopes(scopes)
-          .setServiceAccountPrivateKeyFromP12File(new File(privateKeyFile))
-          .setRequestInitializer(new CredentialHttpRetryInitializer()));
+            .setTransport(transport)
+            .setJsonFactory(JSON_FACTORY)
+            .setServiceAccountId(serviceAccountEmail)
+            .setServiceAccountScopes(scopes)
+            .setServiceAccountPrivateKeyFromP12File(new File(privateKeyFile))
+            .setRequestInitializer(new CredentialHttpRetryInitializer()));
   }
 
   /***
    * Get credentials listed in a JSON file.
    * @param serviceAccountJsonKeyFile A file path pointing to a JSON file containing credentials.
    * @param scopes The OAuth scopes that the credential should be valid for.
+   * @param transport The HttpTransport used for authorization
    */
   public Credential getCredentialFromJsonKeyFile(
-      String serviceAccountJsonKeyFile, List<String> scopes)
+      String serviceAccountJsonKeyFile, List<String> scopes, HttpTransport transport)
       throws IOException, GeneralSecurityException {
     LOG.debug("getCredentialFromJsonKeyFile({}, {})",
         serviceAccountJsonKeyFile, scopes);
 
     try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
       return GoogleCredentialWithRetry.fromGoogleCredential(
-          GoogleCredential.fromStream(fis, getHttpTransport(), JSON_FACTORY)
+          GoogleCredential.fromStream(fis, transport, JSON_FACTORY)
               .createScoped(scopes));
     }
   }
@@ -262,11 +268,16 @@ public class CredentialFactory {
    * @param clientSecret OAuth2 client secret
    * @param filePath full path to a ".json" file for storing the credential
    * @param scopes list of well-formed scopes desired in the credential
+   * @param transport The HttpTransport used for authorization
    * @return credential with desired scopes, possibly obtained from loading {@code filePath}.
    * @throws IOException on IO error
    */
   public Credential getCredentialFromFileCredentialStoreForInstalledApp(
-      String clientId, String clientSecret, String filePath, List<String> scopes)
+      String clientId,
+      String clientSecret,
+      String filePath,
+      List<String> scopes,
+      HttpTransport transport)
       throws IOException, GeneralSecurityException {
     LOG.debug("getCredentialFromFileCredentialStoreForInstalledApp({}, {}, {}, {})",
         clientId, clientSecret, filePath, scopes);
@@ -293,13 +304,13 @@ public class CredentialFactory {
     // Set up authorization code flow.
     GoogleAuthorizationCodeFlow flow =
         new GoogleAuthorizationCodeFlow.Builder(
-            getHttpTransport(),
+            transport,
             JSON_FACTORY,
             clientSecrets,
             scopes)
-        .setCredentialStore(credentialStore)
-        .setRequestInitializer(new CredentialHttpRetryInitializer())
-        .build();
+            .setCredentialStore(credentialStore)
+            .setRequestInitializer(new CredentialHttpRetryInitializer())
+            .build();
 
     // Authorize access.
     return new AuthorizationCodeInstalledApp(flow, new GooglePromptReceiver()).authorize("user");
@@ -313,13 +324,15 @@ public class CredentialFactory {
    * @return credential that allows access to GCS
    * @throws IOException on IO error
    */
+  @Deprecated
   public Credential getStorageCredential(String clientId, String clientSecret)
       throws IOException, GeneralSecurityException {
     LOG.debug("getStorageCredential({}, {})", clientId, clientSecret);
     String filePath = System.getProperty("user.home") + "/.credentials/storage.json";
     return getCredentialFromFileCredentialStoreForInstalledApp(
-        clientId, clientSecret, filePath, GCS_SCOPES);
+        clientId, clientSecret, filePath, GCS_SCOPES, getStaticHttpTransport());
   }
+
   /**
    * Initializes OAuth2 credential and obtains authorization to access Datastore.
    *
@@ -328,11 +341,46 @@ public class CredentialFactory {
    * @return credential that allows access to Datastore
    * @throws IOException on IO error
    */
+  @Deprecated
   public Credential getDatastoreCredential(String clientId, String clientSecret)
       throws IOException, GeneralSecurityException {
     LOG.debug("getStorageCredential({}, {})", clientId, clientSecret);
     String filePath = System.getProperty("user.home") + "/.credentials/datastore.json";
     return getCredentialFromFileCredentialStoreForInstalledApp(
         clientId, clientSecret, filePath, DATASTORE_SCOPES);
+  }
+
+  /**
+   * @deprecated
+   * Caller should provide HttpTransport
+   */
+  @Deprecated
+  public Credential getCredentialFromPrivateKeyServiceAccount(
+      String serviceAccountEmail, String privateKeyFile, List<String> scopes)
+      throws IOException, GeneralSecurityException {
+    return getCredentialFromPrivateKeyServiceAccount(
+        serviceAccountEmail, privateKeyFile, scopes, getStaticHttpTransport());
+  }
+
+  /**
+   * @deprecated
+   * Caller should provide HttpTransport
+   */
+  @Deprecated
+  public Credential getCredentialFromJsonKeyFile(String file, List<String> scopes)
+      throws IOException, GeneralSecurityException {
+    return getCredentialFromJsonKeyFile(file, scopes, getStaticHttpTransport());
+  }
+
+  /**
+   * @deprecated
+   * Caller should provide HttpTransport
+   */
+  @Deprecated
+  public Credential getCredentialFromFileCredentialStoreForInstalledApp(
+      String clientId, String clientSecret, String filePath, List<String> scopes)
+      throws IOException, GeneralSecurityException {
+    return getCredentialFromFileCredentialStoreForInstalledApp(
+        clientId, clientSecret, filePath, scopes);
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -381,6 +381,6 @@ public class CredentialFactory {
       String clientId, String clientSecret, String filePath, List<String> scopes)
       throws IOException, GeneralSecurityException {
     return getCredentialFromFileCredentialStoreForInstalledApp(
-        clientId, clientSecret, filePath, scopes);
+        clientId, clientSecret, filePath, scopes, getStaticHttpTransport());
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -15,6 +15,7 @@
 package com.google.cloud.hadoop.util;
 
 import com.google.api.client.googleapis.GoogleUtils;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -136,6 +137,14 @@ public class HttpTransportFactory {
     builder.trustCertificates(GoogleUtils.getCertificateTrustStore());
     builder.setProxy(proxy);
     return builder.build();
+  }
+
+  /**
+   * Convenience method equivalent to {@link GoogleNetHttpTransport#newTrustedTransport()}.
+   */
+  public static HttpTransport newTrustedTransport()
+      throws GeneralSecurityException, IOException {
+    return createNetHttpTransport(null);
   }
 
   /**


### PR DESCRIPTION
This fixes #49 where proxy settings are not honored for authentication requests.