### PR TITLE
Fix rename and delete behavior to throw in certain cases

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -883,8 +883,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
    *
    * @param src Source path.
    * @param dst Destination path.
-   * @return true if successful, or false if the old name does not exist
-   * or if the new name already belongs to the namespace.
+   * @return true if successful, or false if the old name does not exist or if the new name already
+   *     belongs to the namespace.
    * @throws FileNotFoundException if src does not exist.
    * @throws IOException if an error occurs.
    */
@@ -915,13 +915,13 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
         throw e;
       } else {
         // Occasionally log exceptions that have a cause at info level,
-      // because they could surface real issues and help with troubleshooting
-      (logger.atFine().isEnabled() || e.getCause() == null
-              ? logger.atFine()
-              : logger.atInfo().atMostEvery(5, TimeUnit.MINUTES))
-          .withCause(e)
-          .log("rename(src: %s, dst: %s): false [failed]", src, dst);
-      return false;
+        // because they could surface real issues and help with troubleshooting
+        (logger.atFine().isEnabled() || e.getCause() == null
+                ? logger.atFine()
+                : logger.atInfo().atMostEvery(5, TimeUnit.MINUTES))
+            .withCause(e)
+            .log("rename(src: %s, dst: %s): false [failed]", src, dst);
+        return false;
       }
     }
 
@@ -940,8 +940,7 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     if (error == null) {
       return false;
     }
-    return ERROR_EXTRACTOR.accessDenied(error) ||
-          ERROR_EXTRACTOR.isInternalServerError(error);
+    return ERROR_EXTRACTOR.accessDenied(error) || ERROR_EXTRACTOR.isInternalServerError(error);
   }
 
   /**

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -673,14 +673,6 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     return result;
   }
 
-  // TODO(user): Improve conversion of exceptions to 'false'.
-  // Hadoop is inconsistent about when methods are expected to throw
-  // and when they should return false. The FileSystem documentation
-  // is unclear on this and many other aspects. For now, we convert
-  // all IOExceptions to false which is not the right thing to do.
-  // We need to find a way to only convert known cases to 'false'
-  // and let the other exceptions bubble up.
-
   /**
    * Opens the given file for reading.
    *

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchHelper.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchHelper.java
@@ -176,11 +176,11 @@ public class BatchHelper {
       T result = req.execute();
       callback.onSuccess(result, req.getLastResponseHeaders());
     } catch (IOException e) {
-      GoogleJsonResponseException je = ApiErrorExtractor.getJsonResponseExceptionOrNull(e);
-      if (je == null) {
+      GoogleJsonResponseException jsonException = ApiErrorExtractor.getJsonResponseException(e);
+      if (jsonException == null) {
         throw e;
       }
-      callback.onFailure(je.getDetails(), je.getHeaders());
+      callback.onFailure(jsonException.getDetails(), jsonException.getHeaders());
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.createItemInfoForStorageObject;
 import static com.google.cloud.hadoop.gcsio.StorageResourceId.createReadableString;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -307,7 +308,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
               sleeper);
     } catch (IOException e) {
       throw errorExtractor.itemNotFound(e)
-          ? GoogleCloudStorageExceptions.getFileNotFoundException(bucketName, objectName)
+          ? createFileNotFoundException(bucketName, objectName, e)
           : new IOException("Error reading " + resourceIdString, e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -1152,7 +1153,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           return handleExecuteMediaException(e1, getObject, /* retryWithLiveVersion= */ false);
         }
       }
-      throw GoogleCloudStorageExceptions.getFileNotFoundException(bucketName, objectName);
+      throw createFileNotFoundException(bucketName, objectName, e);
     }
     String msg =
         String.format("Error reading '%s' at position %d", resourceIdString, currentPosition);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.hadoop.gcsio.testing;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.client.util.Clock;
@@ -207,9 +208,9 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
   public SeekableByteChannel open(
       StorageResourceId resourceId, GoogleCloudStorageReadOptions readOptions) throws IOException {
     if (!getItemInfo(resourceId).exists()) {
-      final IOException notFoundException =
-          GoogleCloudStorageExceptions.getFileNotFoundException(
-              resourceId.getBucketName(), resourceId.getObjectName());
+      IOException notFoundException =
+          createFileNotFoundException(
+              resourceId.getBucketName(), resourceId.getObjectName(), /* cause= */ null);
       if (readOptions.getFastFailOnNotFound()) {
         throw notFoundException;
       } else {
@@ -333,8 +334,8 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       // contents; the write-once constraint means this behavior is indistinguishable from a deep
       // copy, but the behavior might have to become complicated if GCS ever supports appends.
       if (!getItemInfo(new StorageResourceId(srcBucketName, srcObjectNames.get(i))).exists()) {
-        innerExceptions.add(GoogleCloudStorageExceptions.getFileNotFoundException(
-            srcBucketName, srcObjectNames.get(i)));
+        innerExceptions.add(
+            createFileNotFoundException(srcBucketName, srcObjectNames.get(i), /* cause= */ null));
         continue;
       }
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
@@ -16,14 +16,11 @@
 
 package com.google.cloud.hadoop.util;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
-
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.common.collect.ImmutableList;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.SocketException;
@@ -33,28 +30,27 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
 /**
- * Translates exceptions from API calls into higher-level meaning, while allowing injectability
- * for testing how API errors are handled.
+ * Translates exceptions from API calls into higher-level meaning, while allowing injectability for
+ * testing how API errors are handled.
  */
 public class ApiErrorExtractor {
 
   /** Singleton instance of the ApiErrorExtractor. */
   public static final ApiErrorExtractor INSTANCE = new ApiErrorExtractor();
 
-  // TODO(user): Move this into HttpStatusCodes.java.
-  public static final int STATUS_CODE_CONFLICT = 409;
-  public static final int STATUS_CODE_PRECONDITION_FAILED = 412;
   public static final int STATUS_CODE_RANGE_NOT_SATISFIABLE = 416;
+
   public static final String GLOBAL_DOMAIN = "global";
   public static final String USAGE_LIMITS_DOMAIN = "usageLimits";
-  public static final String RATE_LIMITED_REASON_CODE = "rateLimitExceeded";
-  public static final String USER_RATE_LIMITED_REASON_CODE = "userRateLimitExceeded";
+
+  public static final String RATE_LIMITED_REASON = "rateLimitExceeded";
+  public static final String USER_RATE_LIMITED_REASON = "userRateLimitExceeded";
 
   // These come with "The account for ... has been disabled" message.
-  public static final String ACCOUNT_DISABLED_REASON_CODE = "accountDisabled";
+  public static final String ACCOUNT_DISABLED_REASON = "accountDisabled";
 
   // These come with "Project marked for deletion" message.
-  public static final String ACCESS_NOT_CONFIGURED_REASON_CODE = "accessNotConfigured";
+  public static final String ACCESS_NOT_CONFIGURED_REASON = "accessNotConfigured";
 
   // These are 400 error codes with "resource 'xyz' is not ready" message.
   // These sometimes happens when create operation is still in-flight but resource
@@ -62,257 +58,154 @@ public class ApiErrorExtractor {
   // Only explanation I could find for this is described here:
   //    java/com/google/cloud/cluster/data/cognac/cognac.proto
   // with an example "because resource is being created in reconciler."
-  public static final String RESOURCE_NOT_READY_REASON_CODE = "resourceNotReady";
+  public static final String RESOURCE_NOT_READY_REASON = "resourceNotReady";
 
   // HTTP 413 with message "Value for field 'foo' is too large".
-  public static final String FIELD_SIZE_TOO_LARGE = "fieldSizeTooLarge";
+  public static final String FIELD_SIZE_TOO_LARGE_REASON = "fieldSizeTooLarge";
 
   // HTTP 400 message for 'USER_PROJECT_MISSING' error.
-  public static final String USER_PROJECT_MISSING =
+  public static final String USER_PROJECT_MISSING_MESSAGE =
       "Bucket is requester pays bucket but no user project provided.";
 
   // The debugInfo field present on Errors collection in GoogleJsonException
   // as an unknown key.
   private static final String DEBUG_INFO_FIELD = "debugInfo";
 
-  public static final JsonFactory JSON_FACTORY = new JacksonFactory();
-
   /** @deprecated use {@link #INSTANCE} instead */
   @Deprecated
   public ApiErrorExtractor() {}
 
-  // Public methods here are in alphabetical order.
-
+  /**
+   * Determines if the given exception indicates intermittent request failure or failure caused by
+   * user error.
+   */
+  public boolean requestFailure(IOException e) {
+    GoogleJsonResponseException jsonException = getJsonResponseException(e);
+    return jsonException != null
+        && (accessDenied(jsonException)
+            || badRequest(jsonException)
+            || internalServerError(jsonException)
+            || rateLimited(jsonException)
+            || socketError(jsonException)
+            || unauthorized(jsonException));
+  }
 
   /**
-   * Determines if the given exception indicates 'access denied'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'access denied'. Recursively checks getCause() if
+   * outer exception isn't an instance of the correct class.
    *
-   * <p> Warning: this method only checks for access denied status code,
-   * however this may include potentially recoverable reason codes such as
-   * rate limiting. For alternative, see
-   * {@link #accessDeniedNonRecoverable(IOException)}.
+   * <p>Warning: this method only checks for access denied status code, however this may include
+   * potentially recoverable reason codes such as rate limiting. For alternative, see {@link
+   * #accessDeniedNonRecoverable(IOException)}.
    */
   public boolean accessDenied(IOException e) {
     return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_FORBIDDEN);
   }
 
+  /** Determines if the given exception indicates bad request. */
+  public boolean badRequest(IOException e) {
+    return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+  }
 
   /**
-   * Determine if the given exception indicates the request was unauthenticated.
-   * This can be caused by attaching invalid credentials to a request.
+   * Determines if the given exception indicates the request was unauthenticated. This can be caused
+   * by attaching invalid credentials to a request.
    */
   public boolean unauthorized(IOException e) {
     return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
   }
 
   /**
-   * Determines if the given error indicates 'access denied'.
-   *
-   * <p>Warning: this method only checks for access denied status code, however this may include
-   * potentially recoverable reason codes such as rate limiting. For alternative, see {@link
-   * #accessDeniedNonRecoverable(GoogleJsonError)}.
-   */
-  public boolean accessDenied(GoogleJsonError e) {
-    return e.getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN;
-  }
-
-  /**
-   * Determine if the exception is a non-recoverable access denied code
-   * (such as account closed or marked for deletion).
+   * Determines if the exception is a non-recoverable access denied code (such as account closed or
+   * marked for deletion).
    */
   public boolean accessDeniedNonRecoverable(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return accessDeniedNonRecoverable(getDetails(jsonException));
-    }
-    return false;
-  }
-
-  /**
-   * Determine if a given GoogleJsonError is caused by, and only by,
-   * account disabled error.
-   */
-  public boolean accessDeniedNonRecoverable(GoogleJsonError e) {
     ErrorInfo errorInfo = getErrorInfo(e);
-    if (errorInfo != null) {
-      String reason = errorInfo.getReason();
-      return ACCOUNT_DISABLED_REASON_CODE.equals(reason)
-          || ACCESS_NOT_CONFIGURED_REASON_CODE.equals(reason);
-    }
-    return false;
+    String reason = errorInfo != null ? errorInfo.getReason() : null;
+    return ACCOUNT_DISABLED_REASON.equals(reason) || ACCESS_NOT_CONFIGURED_REASON.equals(reason);
+  }
+
+  /** Determines if the exception is a client error. */
+  public boolean clientError(IOException e) {
+    GoogleJsonResponseException jsonException = getJsonResponseException(e);
+    return jsonException != null && getHttpStatusCode(jsonException) / 100 == 4;
+  }
+
+  /** Determines if the exception is an internal server error. */
+  public boolean internalServerError(IOException e) {
+    GoogleJsonResponseException jsonException = getJsonResponseException(e);
+    return jsonException != null && getHttpStatusCode(jsonException) / 100 == 5;
   }
 
   /**
-   * Determines if the exception is a client error.
-   */
-  public boolean isClientError(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return getHttpStatusCode(jsonException) / 100 == 4;
-    }
-    return false;
-  }
-
-  /**
-   * Determines if the exception is an internal server error.
-   */
-  public boolean isInternalServerError(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return getHttpStatusCode(jsonException) / 100 == 5;
-    }
-    return false;
-  }
-
-  /** Determines if the error is an internal server error. */
-  public boolean isInternalServerError(GoogleJsonError e) {
-    return e.getCode() / 100 == 5;
-  }
-
-  /**
-   * Determines if the given exception indicates 'item already exists'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'item already exists'. Recursively checks
+   * getCause() if outer exception isn't an instance of the correct class.
    */
   public boolean itemAlreadyExists(IOException e) {
-      return recursiveCheckForCode(e, STATUS_CODE_CONFLICT);
+    return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_CONFLICT);
   }
 
   /**
-   * Determines if the given GoogleJsonError indicates 'item not found'.
-   */
-  public boolean itemNotFound(GoogleJsonError e) {
-    return e.getCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND;
-  }
-
-  /**
-   * Determines if the given exception indicates 'item not found'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'item not found'. Recursively checks getCause() if
+   * outer exception isn't an instance of the correct class.
    */
   public boolean itemNotFound(IOException e) {
     return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 
   /**
-   * Determines if the given GoogleJsonError indicates 'field size too large'.
-   */
-  public boolean fieldSizeTooLarge(GoogleJsonError e) {
-    ErrorInfo errorInfo = getErrorInfo(e);
-    if (errorInfo != null) {
-      String reason = errorInfo.getReason();
-      return FIELD_SIZE_TOO_LARGE.equals(reason);
-    }
-    return false;
-  }
-
-  /**
-   * Determines if the given exception indicates 'field size too large'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'field size too large'. Recursively checks
+   * getCause() if outer exception isn't an instance of the correct class.
    */
   public boolean fieldSizeTooLarge(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return fieldSizeTooLarge(getDetails(jsonException));
-    }
-    return false;
-  }
-
-  /**
-   * Determines if the given GoogleJsonError indicates 'resource not ready'.
-   */
-  public boolean resourceNotReady(GoogleJsonError e) {
     ErrorInfo errorInfo = getErrorInfo(e);
-    if (errorInfo != null) {
-      String reason = errorInfo.getReason();
-      return RESOURCE_NOT_READY_REASON_CODE.equals(reason);
-    }
-    return false;
+    return errorInfo != null && FIELD_SIZE_TOO_LARGE_REASON.equals(errorInfo.getReason());
   }
 
   /**
-   * Determines if the given exception indicates 'resource not ready'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'resource not ready'. Recursively checks getCause()
+   * if outer exception isn't an instance of the correct class.
    */
   public boolean resourceNotReady(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return resourceNotReady(getDetails(jsonException));
-    }
-    return false;
+    ErrorInfo errorInfo = getErrorInfo(e);
+    return errorInfo != null && RESOURCE_NOT_READY_REASON.equals(errorInfo.getReason());
   }
 
   /**
-   * Determines if the given GoogleJsonError indicates 'precondition not met'
-   */
-  public boolean preconditionNotMet(GoogleJsonError e) {
-    return e.getCode() == STATUS_CODE_PRECONDITION_FAILED;
-  }
-
-  /**
-   * Determine if the given IOException indicates 'precondition not met'
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given IOException indicates 'precondition not met' Recursively checks
+   * getCause() if outer exception isn't an instance of the correct class.
    */
   public boolean preconditionNotMet(IOException e) {
-    return recursiveCheckForCode(e, STATUS_CODE_PRECONDITION_FAILED);
+    return recursiveCheckForCode(e, HttpStatusCodes.STATUS_CODE_PRECONDITION_FAILED);
   }
 
   /**
-   * Determines if the given exception indicates 'range not satisfiable'.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if the given exception indicates 'range not satisfiable'. Recursively checks
+   * getCause() if outer exception isn't an instance of the correct class.
    */
   public boolean rangeNotSatisfiable(IOException e) {
     return recursiveCheckForCode(e, STATUS_CODE_RANGE_NOT_SATISFIABLE);
   }
 
   /**
-   * Determine if a given GoogleJsonError is caused by, and only by,
-   * a rate limit being applied.
-   * @param e The GoogleJsonError returned by the request
-   * @return True if the error is caused by a rate limit being applied.
+   * Determines if a given Throwable is caused by a rate limit being applied. Recursively checks
+   * getCause() if outer exception isn't an instance of the correct class.
+   *
+   * @param e The Throwable to check.
+   * @return True if the Throwable is a result of rate limiting being applied.
    */
-  public boolean rateLimited(GoogleJsonError e) {
+  public boolean rateLimited(IOException e) {
     ErrorInfo errorInfo = getErrorInfo(e);
     if (errorInfo != null) {
       String domain = errorInfo.getDomain();
-      String reason = errorInfo.getReason();
       boolean isRateLimitedOrGlobalDomain =
           USAGE_LIMITS_DOMAIN.equals(domain) || GLOBAL_DOMAIN.equals(domain);
+      String reason = errorInfo.getReason();
       boolean isRateLimitedReason =
-          RATE_LIMITED_REASON_CODE.equals(reason) || USER_RATE_LIMITED_REASON_CODE.equals(reason);
+          RATE_LIMITED_REASON.equals(reason) || USER_RATE_LIMITED_REASON.equals(reason);
       return isRateLimitedOrGlobalDomain && isRateLimitedReason;
     }
     return false;
-  }
-
-  /**
-   * Determine if a given Throwable is caused by a rate limit being applied.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
-   * @param throwable The Throwable to check.
-   * @return True if the Throwable is a result of rate limiting being applied.
-   */
-  // TODO(user): change to accept IOException, in line with other methods.
-  public boolean rateLimited(Throwable throwable) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(throwable);
-    if (jsonException != null) {
-      return rateLimited(getDetails(jsonException));
-    }
-    return false;
-  }
-
-  /** Determines if the given GoogleJsonError indicates that 'userProject' is missing in request */
-  public boolean userProjectMissing(GoogleJsonError e) {
-    ErrorInfo errorInfo = getErrorInfo(e);
-    return errorInfo != null
-        && e.getCode() == STATUS_CODE_BAD_REQUEST
-        && USER_PROJECT_MISSING.equals(errorInfo.getMessage());
   }
 
   /**
@@ -320,30 +213,31 @@ public class ApiErrorExtractor {
    * Recursively checks getCause() if outer exception isn't an instance of the correct class.
    */
   public boolean userProjectMissing(IOException e) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    return jsonException != null && userProjectMissing(jsonException.getDetails());
+    GoogleJsonError jsonError = getJsonError(e);
+    return jsonError != null
+        && jsonError.getCode() == HttpStatusCodes.STATUS_CODE_BAD_REQUEST
+        && USER_PROJECT_MISSING_MESSAGE.equals(jsonError.getMessage());
   }
 
   /**
-   * Determine if a given Throwable is caused by an IO error.
-   * Recursively checks getCause() if outer exception isn't an instance of the
-   * correct class.
+   * Determines if a given Throwable is caused by an IO error. Recursively checks getCause() if
+   * outer exception isn't an instance of the correct class.
    *
    * @param throwable The Throwable to check.
    * @return True if the Throwable is a result of an IO error.
    */
-
   public boolean ioError(Throwable throwable) {
     if (throwable instanceof IOException || throwable instanceof IOError) {
       return true;
     }
-    return throwable.getCause() != null && ioError(throwable.getCause());
+    Throwable cause = throwable.getCause();
+    return cause != null && ioError(cause);
   }
 
   /**
-   * Determine if a given Throwable is caused by a socket error.
-   * Recursively checks getCause() if outer exception isn't
-   * an instance of the correct class.
+   * Determines if a given Throwable is caused by a socket error. Recursively checks getCause() if
+   * outer exception isn't an instance of the correct class.
+   *
    * @param throwable The Throwable to check.
    * @return True if the Throwable is a result of a socket error.
    */
@@ -360,82 +254,60 @@ public class ApiErrorExtractor {
     return cause != null && socketError(cause);
   }
 
-  /**
-   * True if the exception is a "read timed out".
-   */
-  public boolean readTimedOut(IOException ex) {
-    if (!(ex instanceof SocketTimeoutException)) {
-      return false;
-    }
-    return (ex.getMessage().equals("Read timed out"));
+  /** True if the exception is a "read timed out". */
+  public boolean readTimedOut(IOException e) {
+    return e instanceof SocketTimeoutException && e.getMessage().equals("Read timed out");
   }
 
   /** Extracts the error message. */
   public String getErrorMessage(IOException e) {
     // Prefer to use message from GJRE.
-    GoogleJsonResponseException gjre = getJsonResponseExceptionOrNull(e);
-
-    if (gjre != null && gjre.getDetails() != null) {
-      return gjre.getDetails().getMessage();
-    }
-    return e.getMessage();
+    GoogleJsonError jsonError = getJsonError(e);
+    return jsonError == null ? e.getMessage() : jsonError.getMessage();
   }
 
   /**
-   * Converts the exception to a user-presentable error message. Specifically,
-   * extracts message field for HTTP 4xx codes, and creates a generic
-   * "Internal Server Error" for HTTP 5xx codes.
+   * Converts the exception to a user-presentable error message. Specifically, extracts message
+   * field for HTTP 4xx codes, and creates a generic "Internal Server Error" for HTTP 5xx codes.
    *
-   * @param ioe the exception
+   * @param e the exception
    * @param action the description of the action being performed at the time of error.
    * @see #toUserPresentableMessage(IOException, String)
    */
-  public IOException toUserPresentableException(IOException ioe, String action) throws IOException {
-    throw new IOException(toUserPresentableMessage(ioe, action), ioe);
+  public IOException toUserPresentableException(IOException e, String action) throws IOException {
+    throw new IOException(toUserPresentableMessage(e, action), e);
   }
 
   /**
-   * Converts the exception to a user-presentable error message. Specifically,
-   * extracts message field for HTTP 4xx codes, and creates a generic
-   * "Internal Server Error" for HTTP 5xx codes.
+   * Converts the exception to a user-presentable error message. Specifically, extracts message
+   * field for HTTP 4xx codes, and creates a generic "Internal Server Error" for HTTP 5xx codes.
    */
-  public String toUserPresentableMessage(IOException ioe, @Nullable String action) {
+  public String toUserPresentableMessage(IOException e, @Nullable String action) {
     String message = "Internal server error";
-    if (isClientError(ioe)) {
-      message = getErrorMessage(ioe);
+    if (clientError(e)) {
+      message = getErrorMessage(e);
     }
-
-    if (action == null) {
-      return message;
-    } else {
-      return String.format("Encountered an error while %s: %s", action, message);
-    }
+    return action == null
+        ? message
+        : String.format("Encountered an error while %s: %s", action, message);
   }
 
-  /**
-   * @see #toUserPresentableMessage(IOException, String)
-   */
-  public String toUserPresentableMessage(IOException ioe) {
-    return toUserPresentableMessage(ioe, null);
+  /** @see #toUserPresentableMessage(IOException, String) */
+  public String toUserPresentableMessage(IOException e) {
+    return toUserPresentableMessage(e, null);
   }
 
   @Nullable
-  public String getDebugInfo(IOException ioe) {
-    ErrorInfo info = getErrorInfo(ioe);
-    if (info != null) {
-      if (info.getUnknownKeys().containsKey(DEBUG_INFO_FIELD)) {
-        return (String) info.getUnknownKeys().get(DEBUG_INFO_FIELD);
-      }
-    }
-    return null;
+  public String getDebugInfo(IOException e) {
+    ErrorInfo errorInfo = getErrorInfo(e);
+    return errorInfo != null ? (String) errorInfo.getUnknownKeys().get(DEBUG_INFO_FIELD) : null;
   }
 
   /**
    * Returns HTTP status code from the given exception.
    *
-   * <p> Note: GoogleJsonResponseException.getStatusCode() method is marked final
-   * therefore it cannot be mocked using Mockito. We use this helper so that
-   * we can override it in tests.
+   * <p>Note: GoogleJsonResponseException.getStatusCode() method is marked final therefore it cannot
+   * be mocked using Mockito. We use this helper so that we can override it in tests.
    */
   protected int getHttpStatusCode(GoogleJsonResponseException e) {
     return e.getStatusCode();
@@ -445,90 +317,40 @@ public class ApiErrorExtractor {
    * Get the first ErrorInfo from an IOException if it is an instance of
    * GoogleJsonResponseException, otherwise return null.
    */
+  @Nullable
   protected ErrorInfo getErrorInfo(IOException e) {
-    GoogleJsonError gjre = getDetails(e);
-    if (gjre != null) {
-      return getErrorInfo(gjre);
-    }
-    return null;
-  }
-
-  /** Get the first ErrorInfo from a GoogleJsonError, or null if there is not one. */
-  protected ErrorInfo getErrorInfo(GoogleJsonError details) {
-    if (details == null) {
-      return null;
-    }
-    List<ErrorInfo> errors = details.getErrors();
-    return errors.isEmpty() ? null : errors.get(0);
+    GoogleJsonError jsonError = getJsonError(e);
+    List<ErrorInfo> errors = jsonError != null ? jsonError.getErrors() : ImmutableList.of();
+    return jsonError != null ? errors.isEmpty() ? null : errors.get(0) : null;
   }
 
   /** If the exception is a GoogleJsonResponseException, get the error details, else return null. */
-  protected GoogleJsonError getDetails(IOException e) {
-    if (e instanceof GoogleJsonResponseException) {
-      return ((GoogleJsonResponseException) e).getDetails();
-    }
-    return null;
+  @Nullable
+  protected GoogleJsonError getJsonError(IOException e) {
+    GoogleJsonResponseException jsonException = getJsonResponseException(e);
+    return jsonException == null ? null : jsonException.getDetails();
   }
 
   /** Recursively checks getCause() if outer exception isn't an instance of the correct class. */
-  protected boolean recursiveCheckForCode(Throwable e, int code) {
-    GoogleJsonResponseException jsonException = getJsonResponseExceptionOrNull(e);
-    if (jsonException != null) {
-      return getHttpStatusCode(jsonException) == code;
-    }
-    return false;
+  protected boolean recursiveCheckForCode(IOException e, int code) {
+    GoogleJsonResponseException jsonException = getJsonResponseException(e);
+    return jsonException != null && getHttpStatusCode(jsonException) == code;
   }
 
   @Nullable
-  public static GoogleJsonResponseException getJsonResponseExceptionOrNull(Throwable t) {
-    Throwable cause = t;
+  public static GoogleJsonResponseException getJsonResponseException(Throwable throwable) {
+    Throwable cause = throwable;
     while (cause != null) {
       if (cause instanceof GoogleJsonResponseException) {
         return (GoogleJsonResponseException) cause;
       }
-      cause = cause.getCause();
-    }
-    return null;
-  }
-
-  // sometimes GoogleJsonResponseException is rewrapped to plain IOException making it impossible to
-  // decode
-  @Nullable
-  public GoogleJsonError unwrapJsonError(Throwable t) {
-    // verify rewrapped exceptions
-    Throwable cause = t;
-    while (cause != null) {
-      if (cause instanceof GoogleJsonResponseException) {
-        return ((GoogleJsonResponseException) cause).getDetails();
-      } else if (cause instanceof IOException) {
-        GoogleJsonError decoded = tryParseJsonError(cause);
-        if (decoded != null) {
-          return decoded;
-        }
-        for (Throwable suppressed : cause.getSuppressed()) {
-          decoded = unwrapJsonError(suppressed);
-          if (decoded != null) {
-            return decoded;
-          }
+      for (Throwable suppressed : cause.getSuppressed()) {
+        GoogleJsonResponseException suppressedJsonException = getJsonResponseException(suppressed);
+        if (suppressedJsonException != null) {
+          return suppressedJsonException;
         }
       }
       cause = cause.getCause();
-    }
-    return null;
-  }
-
-  @Nullable
-  private GoogleJsonError tryParseJsonError(Throwable t) {
-    if (t.getMessage() == null) {
-      return null;
-    }
-    try {
-      GoogleJsonError decoded = JSON_FACTORY.fromString(t.getMessage(), GoogleJsonError.class);
-      if (decoded != null && decoded.getCode() != 0) {
-        return decoded;
-      }
-    } catch (IOException | IllegalArgumentException e) {
-      // ignore
     }
     return null;
   }

--- a/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
@@ -22,6 +22,8 @@ import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.SocketException;
@@ -108,10 +110,9 @@ public class ApiErrorExtractor {
   /**
    * Determines if the given error indicates 'access denied'.
    *
-   * <p> Warning: this method only checks for access denied status code,
-   * however this may include potentially recoverable reason codes such as
-   * rate limiting. For alternative, see
-   * {@link #accessDeniedNonRecoverable(GoogleJsonError)}.
+   * <p>Warning: this method only checks for access denied status code, however this may include
+   * potentially recoverable reason codes such as rate limiting. For alternative, see {@link
+   * #accessDeniedNonRecoverable(GoogleJsonError)}.
    */
   public boolean accessDenied(GoogleJsonError e) {
     return e.getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN;
@@ -165,9 +166,7 @@ public class ApiErrorExtractor {
     return false;
   }
 
-  /**
-   * Determines if the error is an internal server error.
-   */
+  /** Determines if the error is an internal server error. */
   public boolean isInternalServerError(GoogleJsonError e) {
     return e.getCode() / 100 == 5;
   }
@@ -492,7 +491,8 @@ public class ApiErrorExtractor {
     return null;
   }
 
-  // sometimes GoogleJsonResponseException is rewrapped to plain IOException making it impossible to decode
+  // sometimes GoogleJsonResponseException is rewrapped to plain IOException making it impossible to
+  // decode
   @Nullable
   public GoogleJsonError unwrapJsonError(Throwable t) {
     // verify rewrapped exceptions
@@ -527,10 +527,9 @@ public class ApiErrorExtractor {
       if (decoded != null && decoded.getCode() != 0) {
         return decoded;
       }
-    } catch (IOException|IllegalArgumentException e) {
+    } catch (IOException | IllegalArgumentException e) {
       // ignore
     }
     return null;
   }
-
 }

--- a/util/src/test/java/com/google/cloud/hadoop/util/ApiErrorExtractorTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/ApiErrorExtractorTest.java
@@ -76,11 +76,11 @@ public class ApiErrorExtractorTest {
     alreadyExists = googleJsonResponseException(409, "409", "409");
     resourceNotReady =
         googleJsonResponseException(
-            400, ApiErrorExtractor.RESOURCE_NOT_READY_REASON_CODE, "Resource not ready");
+            400, ApiErrorExtractor.RESOURCE_NOT_READY_REASON, "Resource not ready");
 
     // This works because googleJsonResponseException takes final ErrorInfo
     ErrorInfo errorInfo = new ErrorInfo();
-    errorInfo.setReason(ApiErrorExtractor.RATE_LIMITED_REASON_CODE);
+    errorInfo.setReason(ApiErrorExtractor.RATE_LIMITED_REASON);
     notRateLimited = googleJsonResponseException(POSSIBLE_RATE_LIMIT, errorInfo, "");
     errorInfo.setDomain(ApiErrorExtractor.USAGE_LIMITS_DOMAIN);
     rateLimited = googleJsonResponseException(POSSIBLE_RATE_LIMIT, errorInfo, "");
@@ -123,7 +123,6 @@ public class ApiErrorExtractorTest {
     assertThat(errorExtractor.itemNotFound(notFound)).isTrue();
     GoogleJsonError gje = new GoogleJsonError();
     gje.setCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
-    assertThat(errorExtractor.itemNotFound(gje)).isTrue();
     assertThat(errorExtractor.itemNotFound(new IOException(notFound))).isTrue();
     assertThat(errorExtractor.itemNotFound(new IOException(new IOException(notFound)))).isTrue();
 
@@ -160,7 +159,7 @@ public class ApiErrorExtractorTest {
     assertThat(errorExtractor.rateLimited(notRateLimited)).isFalse();
     assertThat(errorExtractor.rateLimited(new IOException(notRateLimited))).isFalse();
     assertThat(errorExtractor.rateLimited(new IOException(statusOk))).isFalse();
-    assertThat(errorExtractor.rateLimited((Throwable) null)).isFalse();
+    assertThat(errorExtractor.rateLimited(null)).isFalse();
   }
 
   /** Validates rateLimited() with BigQuery domain / reason codes */
@@ -258,7 +257,7 @@ public class ApiErrorExtractorTest {
     // Check failure case.
     assertThat(errorExtractor.resourceNotReady(statusOk)).isFalse();
     assertThat(errorExtractor.resourceNotReady(new IOException(statusOk))).isFalse();
-    assertThat(errorExtractor.resourceNotReady((IOException) null)).isFalse();
+    assertThat(errorExtractor.resourceNotReady(null)).isFalse();
   }
 
   @Test
@@ -276,46 +275,12 @@ public class ApiErrorExtractorTest {
   }
 
   @Test
-  public void testUnwrapJsonError() throws IOException {
-    GoogleJsonResponseException withJsonError =
-        googleJsonResponseException(
-            42, "Detail Reason", "Detail message", "Top Level HTTP Message");
-
-    GoogleJsonError originalError = errorExtractor.unwrapJsonError(withJsonError);
-    assertThat(originalError).isNotNull();
-    assertThat(originalError.getCode()).isEqualTo(42);
-    assertThat(originalError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException wrappedException = new IOException(withJsonError.getDetails().toString());
-    GoogleJsonError wrappedError = errorExtractor.unwrapJsonError(wrappedException);
-    assertThat(wrappedError).isNotNull();
-    assertThat(wrappedError.getCode()).isEqualTo(42);
-    assertThat(wrappedError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException nestedException =
-        new IOException(new IOException(withJsonError.getDetails().toString()));
-    GoogleJsonError nestedError = errorExtractor.unwrapJsonError(nestedException);
-    assertThat(nestedError).isNotNull();
-    assertThat(nestedError.getCode()).isEqualTo(42);
-    assertThat(nestedError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException multiException = new IOException();
-    multiException.addSuppressed(new IOException());
-    multiException.addSuppressed(
-        new IOException(new IOException(withJsonError.getDetails().toString())));
-    GoogleJsonError multiError = errorExtractor.unwrapJsonError(multiException);
-    assertThat(multiError).isNotNull();
-    assertThat(multiError.getCode()).isEqualTo(42);
-    assertThat(multiError.getMessage()).isEqualTo("Top Level HTTP Message");
-  }
-
-  @Test
   public void accessDeniedNonRecoverable_GoogleJsonErrorWithAccountDisabledReturnTrue()
       throws IOException {
     IOException withJsonError =
         googleJsonResponseException(
             HttpStatusCodes.STATUS_CODE_FORBIDDEN,
-            ApiErrorExtractor.ACCOUNT_DISABLED_REASON_CODE,
+            ApiErrorExtractor.ACCOUNT_DISABLED_REASON,
             "Forbidden",
             "Forbidden");
     assertThat(errorExtractor.accessDeniedNonRecoverable(withJsonError)).isTrue();
@@ -327,7 +292,7 @@ public class ApiErrorExtractorTest {
     IOException withJsonError =
         googleJsonResponseException(
             HttpStatusCodes.STATUS_CODE_FORBIDDEN,
-            ApiErrorExtractor.ACCESS_NOT_CONFIGURED_REASON_CODE,
+            ApiErrorExtractor.ACCESS_NOT_CONFIGURED_REASON,
             "Forbidden",
             "Forbidden");
     assertThat(errorExtractor.accessDeniedNonRecoverable(withJsonError)).isTrue();
@@ -340,12 +305,12 @@ public class ApiErrorExtractorTest {
 
   @Test
   public void accessDeniedNonRecoverable_GoogleJsonErrorAsNullReturnFalse() {
-    assertThat(errorExtractor.accessDeniedNonRecoverable((IOException) null)).isFalse();
+    assertThat(errorExtractor.accessDeniedNonRecoverable(null)).isFalse();
   }
 
   @Test
   public void isClientError_GoogleJsonErrorWithAccessDeniedReturnTrue() {
-    assertThat(errorExtractor.isClientError(accessDenied)).isTrue();
+    assertThat(errorExtractor.clientError(accessDenied)).isTrue();
   }
 
   @Test
@@ -353,17 +318,17 @@ public class ApiErrorExtractorTest {
     IOException withJsonError =
         googleJsonResponseException(
             HttpStatusCodes.STATUS_CODE_BAD_GATEWAY, "Bad gateway", "Bad gateway", "Bad gateway");
-    assertThat(errorExtractor.isClientError(withJsonError)).isFalse();
+    assertThat(errorExtractor.clientError(withJsonError)).isFalse();
   }
 
   @Test
   public void isClientError_GoogleJsonErrorAsNullReturnFalse() {
-    assertThat(errorExtractor.isClientError(null)).isFalse();
+    assertThat(errorExtractor.clientError(null)).isFalse();
   }
 
   @Test
   public void isInternalServerError_GoogleJsonErrorWithAccessDeniedReturnFalse() {
-    assertThat(errorExtractor.isInternalServerError(accessDenied)).isFalse();
+    assertThat(errorExtractor.internalServerError(accessDenied)).isFalse();
   }
 
   @Test
@@ -372,12 +337,12 @@ public class ApiErrorExtractorTest {
     IOException withJsonError =
         googleJsonResponseException(
             HttpStatusCodes.STATUS_CODE_BAD_GATEWAY, "Bad gateway", "Bad gateway", "Bad gateway");
-    assertThat(errorExtractor.isInternalServerError(withJsonError)).isTrue();
+    assertThat(errorExtractor.internalServerError(withJsonError)).isTrue();
   }
 
   @Test
   public void isInternalServerError_GoogleJsonErrorAsNullReturnFalse() {
-    assertThat(errorExtractor.isInternalServerError((IOException) null)).isFalse();
+    assertThat(errorExtractor.internalServerError(null)).isFalse();
   }
 
   @Test
@@ -391,7 +356,7 @@ public class ApiErrorExtractorTest {
     IOException withJsonError =
         googleJsonResponseException(
             /* httpStatus= */ 413,
-            ApiErrorExtractor.FIELD_SIZE_TOO_LARGE,
+            ApiErrorExtractor.FIELD_SIZE_TOO_LARGE_REASON,
             "Value for field 'foo' is too large",
             "Value for field 'foo' is too large");
     assertThat(errorExtractor.fieldSizeTooLarge(withJsonError)).isTrue();
@@ -399,7 +364,7 @@ public class ApiErrorExtractorTest {
 
   @Test
   public void fieldSizeTooLarge_GoogleJsonErrorAsNullReturnFalse() {
-    assertThat(errorExtractor.fieldSizeTooLarge((IOException) null)).isFalse();
+    assertThat(errorExtractor.fieldSizeTooLarge(null)).isFalse();
   }
 
   @Test
@@ -407,25 +372,11 @@ public class ApiErrorExtractorTest {
       throws IOException {
     IOException withJsonError =
         googleJsonResponseException(
-            ApiErrorExtractor.STATUS_CODE_PRECONDITION_FAILED,
+            HttpStatusCodes.STATUS_CODE_PRECONDITION_FAILED,
             "preconditionNotMet",
             "Precondition not met",
             "Precondition not met");
     assertThat(errorExtractor.preconditionNotMet(withJsonError)).isTrue();
-  }
-
-  @Test
-  public void preconditionNotMet_GoogleJsonErrorPredictionFailedReturnTrue() {
-    GoogleJsonError gje = new GoogleJsonError();
-    gje.setCode(HttpStatusCodes.STATUS_CODE_PRECONDITION_FAILED);
-    assertThat(errorExtractor.preconditionNotMet(gje)).isTrue();
-  }
-
-  @Test
-  public void preconditionNotMet_GoogleJsonErrorBadGatewayReturnFalse() {
-    GoogleJsonError gje = new GoogleJsonError();
-    gje.setCode(HttpStatusCodes.STATUS_CODE_BAD_GATEWAY);
-    assertThat(errorExtractor.preconditionNotMet(gje)).isFalse();
   }
 
   @Test
@@ -479,40 +430,6 @@ public class ApiErrorExtractorTest {
   @Test
   public void getDebugInfo_accessDeniedReturnNull() {
     assertThat(errorExtractor.getDebugInfo(new IOException(accessDenied))).isNull();
-  }
-
-  @Test
-  public void testUnwrapJsonError() throws IOException {
-    GoogleJsonResponseException withJsonError =
-        googleJsonResponseException(
-            42, "Detail Reason", "Detail message", "Top Level HTTP Message");
-
-    GoogleJsonError originalError = errorExtractor.unwrapJsonError(withJsonError);
-    assertThat(originalError).isNotNull();
-    assertThat(originalError.getCode()).isEqualTo(42);
-    assertThat(originalError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException wrappedException = new IOException(withJsonError.getDetails().toString());
-    GoogleJsonError wrappedError = errorExtractor.unwrapJsonError(wrappedException);
-    assertThat(wrappedError).isNotNull();
-    assertThat(wrappedError.getCode()).isEqualTo(42);
-    assertThat(wrappedError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException nestedException =
-        new IOException(new IOException(withJsonError.getDetails().toString()));
-    GoogleJsonError nestedError = errorExtractor.unwrapJsonError(nestedException);
-    assertThat(nestedError).isNotNull();
-    assertThat(nestedError.getCode()).isEqualTo(42);
-    assertThat(nestedError.getMessage()).isEqualTo("Top Level HTTP Message");
-
-    IOException multiException = new IOException();
-    multiException.addSuppressed(new IOException());
-    multiException.addSuppressed(
-        new IOException(new IOException(withJsonError.getDetails().toString())));
-    GoogleJsonError multiError = errorExtractor.unwrapJsonError(multiException);
-    assertThat(multiError).isNotNull();
-    assertThat(multiError.getCode()).isEqualTo(42);
-    assertThat(multiError.getMessage()).isEqualTo("Top Level HTTP Message");
   }
 
   /** Builds a fake GoogleJsonResponseException for testing API error handling. */

--- a/util/src/test/java/com/google/cloud/hadoop/util/ApiErrorExtractorTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/ApiErrorExtractorTest.java
@@ -45,8 +45,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import static org.junit.Assert.*;
-
 /** Unit-tests for ApiErrorExtractor class. */
 @RunWith(JUnit4.class)
 public class ApiErrorExtractorTest {
@@ -279,33 +277,36 @@ public class ApiErrorExtractorTest {
 
   @Test
   public void testUnwrapJsonError() throws IOException {
-    GoogleJsonResponseException withJsonError = googleJsonResponseException(
-          42, "Detail Reason", "Detail message", "Top Level HTTP Message");
+    GoogleJsonResponseException withJsonError =
+        googleJsonResponseException(
+            42, "Detail Reason", "Detail message", "Top Level HTTP Message");
 
     GoogleJsonError originalError = errorExtractor.unwrapJsonError(withJsonError);
-    assertNotNull(originalError);
-    assertEquals(originalError.getCode(), 42);
-    assertEquals(originalError.getMessage(), "Top Level HTTP Message");
+    assertThat(originalError).isNotNull();
+    assertThat(originalError.getCode()).isEqualTo(42);
+    assertThat(originalError.getMessage()).isEqualTo("Top Level HTTP Message");
 
     IOException wrappedException = new IOException(withJsonError.getDetails().toString());
     GoogleJsonError wrappedError = errorExtractor.unwrapJsonError(wrappedException);
-    assertNotNull(wrappedError);
-    assertEquals(wrappedError.getCode(), 42);
-    assertEquals(wrappedError.getMessage(), "Top Level HTTP Message");
+    assertThat(wrappedError).isNotNull();
+    assertThat(wrappedError.getCode()).isEqualTo(42);
+    assertThat(wrappedError.getMessage()).isEqualTo("Top Level HTTP Message");
 
-    IOException nestedException = new IOException(new IOException(withJsonError.getDetails().toString()));
+    IOException nestedException =
+        new IOException(new IOException(withJsonError.getDetails().toString()));
     GoogleJsonError nestedError = errorExtractor.unwrapJsonError(nestedException);
-    assertNotNull(nestedError);
-    assertEquals(nestedError.getCode(), 42);
-    assertEquals(nestedError.getMessage(), "Top Level HTTP Message");
+    assertThat(nestedError).isNotNull();
+    assertThat(nestedError.getCode()).isEqualTo(42);
+    assertThat(nestedError.getMessage()).isEqualTo("Top Level HTTP Message");
 
     IOException multiException = new IOException();
     multiException.addSuppressed(new IOException());
-    multiException.addSuppressed(new IOException(new IOException(withJsonError.getDetails().toString())));
+    multiException.addSuppressed(
+        new IOException(new IOException(withJsonError.getDetails().toString())));
     GoogleJsonError multiError = errorExtractor.unwrapJsonError(multiException);
-    assertNotNull(multiError);
-    assertEquals(multiError.getCode(), 42);
-    assertEquals(multiError.getMessage(), "Top Level HTTP Message");
+    assertThat(multiError).isNotNull();
+    assertThat(multiError.getCode()).isEqualTo(42);
+    assertThat(multiError.getMessage()).isEqualTo("Top Level HTTP Message");
   }
 
   @Test
@@ -376,7 +377,7 @@ public class ApiErrorExtractorTest {
 
   @Test
   public void isInternalServerError_GoogleJsonErrorAsNullReturnFalse() {
-    assertThat(errorExtractor.isInternalServerError(null)).isFalse();
+    assertThat(errorExtractor.isInternalServerError((IOException) null)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Original HDFS rename implementation [returns](https://github.com/apache/hadoop/blob/release-2.9.2-RC0/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java#L496:L508):

> true if successful, or false if the old name does not exists or or if the new name already belongs to the namespace.

In other cases exception is thrown.

This patch adds re-throwing in cases of access and server errors.

Some implementations, such as Apache Hive, expect rename to throw:
- https://github.com/apache/hive/blob/branch-2.1/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L2717
- https://github.com/apache/hive/blob/branch-2.1/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L2738