### PR TITLE
Fix Spark Pub/Sub connector shading to leave PubsubMessage unshaded

### DIFF
--- a/pubsub/build.sbt
+++ b/pubsub/build.sbt
@@ -67,7 +67,7 @@ val notRenamed = Seq(
   "io.grpc",
   myPackage,
   // Exposed to the user in the API.
-  "com.google.cloud.pubsub")
+  "com.google.pubsub")
 
 assemblyShadeRules in assembly := (
   // Rename preserved prefixes to themselves first to keep them unchanged

--- a/pubsub/pom.xml
+++ b/pubsub/pom.xml
@@ -234,7 +234,7 @@
                   </includes>
                   <excludes>
                     <exclude>com.google.cloud.spark.**</exclude>
-                    <exclude>com.google.cloud.pubsub.**</exclude>
+                    <exclude>com.google.pubsub.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>


### PR DESCRIPTION
This shades google-cloud-pubsub and unshades the generated Java from protos.

That is because we expose PubsubMessage in the generated Java package [com.google.pubsub.v1](https://github.com/googleapis/googleapis/blob/master/google/pubsub/v1/pubsub.proto#L30).