### PR TITLE
Change GCS batch endpoint from /batch to /batch/storage/v1.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchHelper.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchHelper.java
@@ -18,6 +18,7 @@ package com.google.cloud.hadoop.gcsio;
 
 import com.google.api.client.googleapis.batch.BatchRequest;
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback;
+import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageRequest;
@@ -115,6 +116,7 @@ public class BatchHelper {
           head.enqueue();
         }
 
+        batch.setBatchUrl(new GenericUrl("https://www.googleapis.com/batch/storage/v1"));
         batch.execute();
       } finally {
         flushing = false;


### PR DESCRIPTION
This is in line with documentation at
https://cloud.google.com/storage/docs/json_api/v1/how-tos/batch.