### PR TITLE
Retry on HTTP status code 410 Gone

### DIFF
--- a/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
@@ -38,6 +38,8 @@ import org.slf4j.LoggerFactory;
 
 public class RetryHttpInitializer implements HttpRequestInitializer {
 
+  /** HTTP status code occasionally returned by GCS backend error. */
+  public static final int STATUS_CODE_GONE = 410;
   /** HTTP status code indicating too many requests in a given amount of time. */
   public static final int STATUS_CODE_TOO_MANY_REQUESTS = 429;
 
@@ -131,6 +133,7 @@ public class RetryHttpInitializer implements HttpRequestInitializer {
             @Override
             public boolean isRequired(HttpResponse response) {
               return BASE_HTTP_BACKOFF_REQUIRED.isRequired(response)
+                  || response.getStatusCode() == STATUS_CODE_GONE
                   || response.getStatusCode() == STATUS_CODE_TOO_MANY_REQUESTS;
             }
           });

--- a/util/src/test/java/com/google/cloud/hadoop/util/RetryHttpInitializerTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/RetryHttpInitializerTest.java
@@ -181,6 +181,11 @@ public class RetryHttpInitializerTest {
   }
 
   @Test
+  public void testErrorCodeGone() throws IOException, InterruptedException {
+    testRetriesForErrorCode(410);
+  }
+
+  @Test
   public void testErrorCodeRateLimitExceeded() throws IOException, InterruptedException {
     testRetriesForErrorCode(429);
   }


### PR DESCRIPTION
GCS sometimes returns 'Backend Error' with status code 410, causing whole Spark job to fail