### PR TITLE
Service Account Credentials via Configuration WIP

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,4 +1,12 @@
 1.9.7 - 2018-XX-XX
+  
+  1. Add an option to provide credentials directly in Hadoop Configuration,
+     without having to place a file on every node, or associating service accounts
+     with GCE VMs.
+
+       fs.gs.auth.service.account.client.email
+       fs.gs.auth.service.account.private.key.id
+       fs.gs.auth.service.account.private.key
 
 
 1.9.6 - 2018-08-30

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -70,7 +70,7 @@
   </property>
 
   <property>
-    <name>google.cloud.auth.service.account.enable</name>
+    <name>fs.gs.auth.service.account.enable</name>
     <value>true</value>
     <description>
       Whether to use a service account for GCS authorization. If an email and
@@ -83,10 +83,60 @@
   </property>
 
   <!-- The following properties are required when not on a GCE VM and
-    google.cloud.auth.service.account.enable is true.
+    google.cloud.auth.service.account.enable is true. There's 3 ways to configure
+    these credentials, which are mutually exclusive.
+  -->
+  <!-- Method1
+    Configure service account details directly in the Configuration file
+    or via Hadoop Credentials.
+    https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html
+   -->
+  <property>
+    <name>fs.gs.auth..service.account.client.email</name>
+    <value></value>
+    <description>
+      The email address associated with the service account used for GCS access.
+      This can be extracted from the json keyfile generated via the Google Cloud
+      Console.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.auth.service.account.private.key.id</name>
+    <value></value>
+    <description>
+      The private key id associated with the service account used for GCS access.
+      This can be extracted from the json keyfile generated via the Google Cloud
+      Console.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.auth.service.account.private.key</name>
+    <value></value>
+    <description>
+      The private key associated with the service account used for GCS access.
+      This can be extracted from the json keyfile generated via the Google Cloud
+      Console.
+    </description>
+  </property>
+
+  <!-- Method2
+    Configure service account credentials using a json keyfile. The file must exist at the same
+    path on all nodes
   -->
   <property>
-    <name>google.cloud.auth.service.account.email</name>
+    <name>fs.gs.auth.service.account.json.keyfile</name>
+    <value></value>
+    <description>
+      The path to the json keyfile for the service account.
+    </description>
+  </property>
+
+  <!-- Method3
+    Configure service account credentials using a P12 certificate. The file must exist at the same
+    path on all nodes
+  -->
+  <property>
+    <name>fs.gs.auth.service.account.email</name>
     <value></value>
     <description>
       The email address is associated with the service account used for GCS
@@ -95,7 +145,7 @@
     </description>
   </property>
   <property>
-    <name>google.cloud.auth.service.account.keyfile</name>
+    <name>fs.gs.auth.service.account.keyfile</name>
     <value></value>
     <description>
       The PKCS12 (p12) certificate file of the service account used for GCS
@@ -107,7 +157,7 @@
     google.cloud.auth.service.account.enable is false.
   -->
   <property>
-    <name>google.cloud.auth.client.id</name>
+    <name>fs.gs.auth.client.id</name>
     <value></value>
     <description>
       The client ID for GCS access in the OAuth 2.0 installed application flow
@@ -115,7 +165,7 @@
     </description>
   </property>
   <property>
-    <name>google.cloud.auth.client.secret</name>
+    <name>fs.gs.auth.client.secret</name>
     <value></value>
     <description>
       The client secret for GCS access in the OAuth 2.0 installed application
@@ -123,7 +173,7 @@
     </description>
   </property>
   <property>
-    <name>google.cloud.auth.client.file</name>
+    <name>fs.gs.auth.client.file</name>
     <value></value>
     <description>
       The client credential file for GCS access in the OAuth 2.0 installed

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -92,7 +92,7 @@
     https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html
    -->
   <property>
-    <name>fs.gs.auth..service.account.client.email</name>
+    <name>fs.gs.auth.service.account.client.email</name>
     <value></value>
     <description>
       The email address associated with the service account used for GCS access.

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -156,7 +156,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
     VERSION =
         PropertyUtil.getPropertyOrDefault(
             GoogleHadoopFileSystemBase.class, PROPERTIES_FILE, VERSION_PROPERTY, UNKNOWN_VERSION);
-    logger.atInfo().log("GHFS version: %s", VERSION);
+    logger.atFine().log("GHFS version: %s", VERSION);
     GHFS_ID = String.format("GHFS/%s", VERSION);
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -156,7 +156,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
     VERSION =
         PropertyUtil.getPropertyOrDefault(
             GoogleHadoopFileSystemBase.class, PROPERTIES_FILE, VERSION_PROPERTY, UNKNOWN_VERSION);
-    logger.atFine().log("GHFS version: %s", VERSION);
+    logger.atInfo().log("GHFS version: %s", VERSION);
     GHFS_ID = String.format("GHFS/%s", VERSION);
   }
 

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
@@ -117,9 +117,10 @@ public final class CredentialFromAccessTokenProviderClassFactory {
     GoogleCredential credential =
         GoogleCredentialWithAccessTokenProvider.fromAccessTokenProvider(
             Clock.SYSTEM, accessTokenProvider);
-    // TODO: credential.createScoped does nothing at the moment, since GoogleCredentialWithAccessTokenProvider
-    // never sets the serviceAccountPrivateKey. The AccessTokenProvider interface does not provide
-    // a mechanism to return a private key, and scopes cannot be sent down to the AccessTokenProvider
+    // TODO: credential.createScoped does nothing at the moment, since
+    // GoogleCredentialWithAccessTokenProvider never sets the serviceAccountPrivateKey.
+    // The AccessTokenProvider interface does not provide a mechanism to return a private key,
+    // and scopes cannot be sent down to the AccessTokenProvider
     // so they're essentially ignored at the moment.
     return credential.createScoped(scopes);
   }

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
@@ -57,6 +57,7 @@ public final class CredentialFromAccessTokenProviderClassFactory {
       withProvider
           .setAccessToken(accessToken.getToken())
           .setExpirationTimeMilliseconds(accessToken.getExpirationTimeMilliSeconds());
+      // TODO This should be setting the refresh token as well.
       return withProvider;
     }
 
@@ -116,6 +117,10 @@ public final class CredentialFromAccessTokenProviderClassFactory {
     GoogleCredential credential =
         GoogleCredentialWithAccessTokenProvider.fromAccessTokenProvider(
             Clock.SYSTEM, accessTokenProvider);
+    // TODO: credential.createScoped does nothing at the moment, since GoogleCredentialWithAccessTokenProvider
+    // never sets the serviceAccountPrivateKey. The AccessTokenProvider interface does not provide
+    // a mechanism to return a private key, and scopes cannot be sent down to the AccessTokenProvider
+    // so they're essentially ignored at the moment.
     return credential.createScoped(scopes);
   }
 }

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationUtil.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationUtil.java
@@ -17,6 +17,7 @@ package com.google.cloud.hadoop.testing;
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration;
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration.Entries;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,6 +58,11 @@ public class EntriesCredentialConfigurationUtil {
     public void setBoolean(String key, boolean value) {
       Boolean b = Boolean.valueOf(value);
       map.put(key, b);
+    }
+
+    @Override
+    public String getPassword(String key) throws IOException {
+      return get(key);
     }
   }
 }

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationUtil.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationUtil.java
@@ -16,7 +16,6 @@ package com.google.cloud.hadoop.testing;
 
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration;
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration.Entries;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
@@ -16,6 +16,7 @@ package com.google.cloud.hadoop.util;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.hadoop.conf.Configuration;
  * credentials.
  */
 public class HadoopCredentialConfiguration
-    extends EntriesCredentialConfiguration {
+    extends EntriesCredentialConfiguration implements Configurable {
 
   /**
    * An adapter to use our Configuration object as the config object
@@ -104,5 +105,20 @@ public class HadoopCredentialConfiguration
     Configuration configuration = new Configuration();
     getConfigurationInto(new ConfigurationEntriesAdapter(configuration));
     return configuration;
+  }
+
+  /**
+   * Load configuration values from the provided Configuration source. For any key that does not
+   * have a corresponding value in the Configuration, no changes will be made to the state of this
+   * object.
+   */
+  @Override
+  @Deprecated
+  public void setConf(Configuration entries) {
+    try {
+      setConfiguration(new ConfigurationEntriesAdapter(entries));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
@@ -14,8 +14,8 @@
 
 package com.google.cloud.hadoop.util;
 
+import java.io.IOException;
 import java.util.List;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration;
  * credentials.
  */
 public class HadoopCredentialConfiguration
-    extends EntriesCredentialConfiguration implements Configurable {
+    extends EntriesCredentialConfiguration {
 
   /**
    * An adapter to use our Configuration object as the config object
@@ -55,6 +55,12 @@ public class HadoopCredentialConfiguration
 
     public void setBoolean(String key, boolean value) {
       config.setBoolean(key, value);
+    }
+
+    @Override
+    public String getPassword(String key) throws IOException {
+      char[] val = config.getPassword(key);
+      return val == null ? null : String.valueOf(config.getPassword(key));
     }
   }
 
@@ -98,14 +104,5 @@ public class HadoopCredentialConfiguration
     Configuration configuration = new Configuration();
     getConfigurationInto(new ConfigurationEntriesAdapter(configuration));
     return configuration;
-  }
-
-  /**
-   * Load configuration values from the provided Configuration source. For any key that does not
-   * have a corresponding value in the Configuration, no changes will be made to the state of this
-   * object.
-   */
-  public void setConf(Configuration entries) {
-    setConfiguration(new ConfigurationEntriesAdapter(entries));
   }
 }

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
@@ -60,7 +60,7 @@ public class HadoopCredentialConfiguration
     @Override
     public String getPassword(String key) throws IOException {
       char[] val = config.getPassword(key);
-      return val == null ? null : String.valueOf(config.getPassword(key));
+      return val == null ? null : String.valueOf(val);
     }
   }
 

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/EntriesCredentialConfigurationTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.hadoop.testing.EntriesCredentialConfigurationUtil.TestEn
 import com.google.cloud.hadoop.util.EntriesCredentialConfiguration.Entries;
 import com.google.cloud.hadoop.util.HttpTransportFactory.HttpTransportType;
 import com.google.common.collect.ImmutableList;
+import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +40,7 @@ public class EntriesCredentialConfigurationTest {
   }
 
   @Test
-  public void componentsCanOverrideBaseConfiguration() {
+  public void componentsCanOverrideBaseConfiguration() throws IOException {
     Entries configuration =
         EntriesCredentialConfigurationUtil.getTestConfiguration();
     // Overall, use service accounts
@@ -72,7 +73,7 @@ public class EntriesCredentialConfigurationTest {
   }
 
   @Test
-  public void setConfigurationSetsValuesAsExpected() {
+  public void setConfiugrationSetsValuesAsExpected() throws IOException {
     Entries conf = new TestEntries();
 
     setConfigurationKey(

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.hadoop.util;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.io.IOException;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class HadoopCredentialConfigurationTest {
   }
 
   @Test
-  public void componentsCanOverrideBaseConfiguration() {
+  public void componentsCanOverrideBaseConfiguration() throws IOException {
     Configuration configuration = new Configuration();
     // Overall, use service accounts
     configuration.set(HadoopCredentialConfiguration.BASE_KEY_PREFIX +
@@ -63,9 +64,21 @@ public class HadoopCredentialConfigurationTest {
   }
 
   @Test
-  public void setConfiugrationSetsValuesAsExpected() {
+  public void setConfiugrationSetsValuesAsExpected() throws IOException {
     Configuration conf = new Configuration();
 
+    setConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_CLIENT_EMAIL_SUFFIX,
+        "anEmail");
+    setConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_PRIVATE_KEY_ID_SUFFIX,
+        "aPrivateKeyId");
+    setConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_PRIVATE_KEY_SUFFIX,
+        "aPrivateKey");
     setConfigurationKey(
         conf,
         HadoopCredentialConfiguration.SERVICE_ACCOUNT_EMAIL_SUFFIX,
@@ -104,6 +117,9 @@ public class HadoopCredentialConfigurationTest {
         .withConfiguration(conf)
         .build();
 
+    assertThat(credentialConfiguration.getSaClientEmail()).isEqualTo("anEmail");
+    assertThat(credentialConfiguration.getSaPrivateKeyId()).isEqualTo("aPrivateKeyId");
+    assertThat(credentialConfiguration.getSaPrivateKey()).isEqualTo("aPrivateKey");
     assertThat(credentialConfiguration.getServiceAccountEmail()).isEqualTo("anEmail");
     assertThat(credentialConfiguration.getServiceAccountKeyFile()).isEqualTo("aKeyFile");
     assertThat(credentialConfiguration.getServiceAccountJsonKeyFile()).isEqualTo("aJsonFile");
@@ -141,6 +157,27 @@ public class HadoopCredentialConfigurationTest {
         conf,
         HadoopCredentialConfiguration.JSON_KEYFILE_SUFFIX);
     assertThat(writtenValue).isEqualTo("aJsonFile");
+
+    credentialConfiguration.setSaClientEmail("anEmail");
+    conf = credentialConfiguration.getConf();
+    writtenValue = getConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_CLIENT_EMAIL_SUFFIX);
+    assertThat(writtenValue).isEqualTo("anEmail");
+
+    credentialConfiguration.setSaPrivateKeyId("aPrivateKeyId");
+    conf = credentialConfiguration.getConf();
+    writtenValue = getConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_PRIVATE_KEY_ID_SUFFIX);
+    assertThat(writtenValue).isEqualTo("aPrivateKeyId");
+
+    credentialConfiguration.setSaPrivateKey("aPrivateKey");
+    conf = credentialConfiguration.getConf();
+    writtenValue = getConfigurationKey(
+        conf,
+        HadoopCredentialConfiguration.SA_PRIVATE_KEY_SUFFIX);
+    assertThat(writtenValue).isEqualTo("aPrivateKey");
 
     credentialConfiguration.setClientSecret("clientSecret");
     conf = credentialConfiguration.getConf();

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -68,17 +68,11 @@ public class HadoopCredentialConfigurationTest {
     Configuration conf = new Configuration();
 
     setConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SA_CLIENT_EMAIL_SUFFIX,
-        "anEmail");
+        conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX, "anEmail");
     setConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SA_PRIVATE_KEY_ID_SUFFIX,
-        "aPrivateKeyId");
+        conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX, "aPrivateKeyId");
     setConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SA_PRIVATE_KEY_SUFFIX,
-        "aPrivateKey");
+        conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX, "aPrivateKey");
     setConfigurationKey(
         conf,
         HadoopCredentialConfiguration.SERVICE_ACCOUNT_EMAIL_SUFFIX,
@@ -117,9 +111,9 @@ public class HadoopCredentialConfigurationTest {
         .withConfiguration(conf)
         .build();
 
-    assertThat(credentialConfiguration.getSaClientEmail()).isEqualTo("anEmail");
-    assertThat(credentialConfiguration.getSaPrivateKeyId()).isEqualTo("aPrivateKeyId");
-    assertThat(credentialConfiguration.getSaPrivateKey()).isEqualTo("aPrivateKey");
+    assertThat(credentialConfiguration.getServiceAccountClientEmail()).isEqualTo("anEmail");
+    assertThat(credentialConfiguration.getServiceAccountPrivateKeyId()).isEqualTo("aPrivateKeyId");
+    assertThat(credentialConfiguration.getServiceAccountPrivateKey()).isEqualTo("aPrivateKey");
     assertThat(credentialConfiguration.getServiceAccountEmail()).isEqualTo("anEmail");
     assertThat(credentialConfiguration.getServiceAccountKeyFile()).isEqualTo("aKeyFile");
     assertThat(credentialConfiguration.getServiceAccountJsonKeyFile()).isEqualTo("aJsonFile");
@@ -158,25 +152,25 @@ public class HadoopCredentialConfigurationTest {
         HadoopCredentialConfiguration.JSON_KEYFILE_SUFFIX);
     assertThat(writtenValue).isEqualTo("aJsonFile");
 
-    credentialConfiguration.setSaClientEmail("anEmail");
+    credentialConfiguration.setServiceAccountClientEmail("anEmail");
     conf = credentialConfiguration.getConf();
     writtenValue = getConfigurationKey(
         conf,
-        HadoopCredentialConfiguration.SA_CLIENT_EMAIL_SUFFIX);
+        HadoopCredentialConfiguration.SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX);
     assertThat(writtenValue).isEqualTo("anEmail");
 
-    credentialConfiguration.setSaPrivateKeyId("aPrivateKeyId");
+    credentialConfiguration.setServiceAccountPrivateKeyId("aPrivateKeyId");
     conf = credentialConfiguration.getConf();
     writtenValue = getConfigurationKey(
         conf,
-        HadoopCredentialConfiguration.SA_PRIVATE_KEY_ID_SUFFIX);
+        HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX);
     assertThat(writtenValue).isEqualTo("aPrivateKeyId");
 
-    credentialConfiguration.setSaPrivateKey("aPrivateKey");
+    credentialConfiguration.setServiceAccountPrivateKey("aPrivateKey");
     conf = credentialConfiguration.getConf();
     writtenValue = getConfigurationKey(
         conf,
-        HadoopCredentialConfiguration.SA_PRIVATE_KEY_SUFFIX);
+        HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX);
     assertThat(writtenValue).isEqualTo("aPrivateKey");
 
     credentialConfiguration.setClientSecret("clientSecret");

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -154,23 +154,22 @@ public class HadoopCredentialConfigurationTest {
 
     credentialConfiguration.setServiceAccountClientEmail("anEmail");
     conf = credentialConfiguration.getConf();
-    writtenValue = getConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX);
+    writtenValue =
+        getConfigurationKey(
+            conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX);
     assertThat(writtenValue).isEqualTo("anEmail");
 
     credentialConfiguration.setServiceAccountPrivateKeyId("aPrivateKeyId");
     conf = credentialConfiguration.getConf();
-    writtenValue = getConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX);
+    writtenValue =
+        getConfigurationKey(
+            conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX);
     assertThat(writtenValue).isEqualTo("aPrivateKeyId");
 
     credentialConfiguration.setServiceAccountPrivateKey("aPrivateKey");
     conf = credentialConfiguration.getConf();
-    writtenValue = getConfigurationKey(
-        conf,
-        HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX);
+    writtenValue =
+        getConfigurationKey(conf, HadoopCredentialConfiguration.SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX);
     assertThat(writtenValue).isEqualTo("aPrivateKey");
 
     credentialConfiguration.setClientSecret("clientSecret");

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
@@ -31,12 +31,18 @@ public class CredentialConfiguration {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private boolean serviceAccountEnabled = true;
-  private String saPrivateKeyId = null;
-  private String saPrivateKey = null;
-  private String saClientEmail = null;
+  // The following 3 parameters are used for credentials set directly via Hadoop Configuration
+  private String serviceAccountPrivateKeyId = null;
+  private String serviceAccountPrivateKey = null;
+  private String serviceAccountClientEmail = null;
+
+  // The following 2 parameters are used for ServiceAccount P12 KeyFiles
   private String serviceAccountEmail = null;
   private String serviceAccountKeyFile = null;
+
+  // The following parameter is used for ServiceAccount Json KeyFiles
   private String serviceAccountJsonKeyFile = null;
+
   private String clientId = null;
   private String clientSecret = null;
   private String oAuthCredentialFile = null;
@@ -76,14 +82,14 @@ public class CredentialConfiguration {
         return credentialFactory.getCredentialFromMetadataServiceAccount();
       }
 
-      if (!isNullOrEmpty(saPrivateKeyId)) {
+      if (!isNullOrEmpty(serviceAccountPrivateKeyId)) {
         // TODO: Test with a hadoop credentials (jceks) file. getPassword is being used.
         logger.atFine().log("Attempting to get credentials from Configuration");
         Preconditions.checkState(
-            !isNullOrEmpty(saPrivateKey),
+            !isNullOrEmpty(serviceAccountPrivateKey),
             "privateKeyId must be set if using credentials configured directly in configuration");
         Preconditions.checkState(
-            !isNullOrEmpty(saClientEmail),
+            !isNullOrEmpty(serviceAccountClientEmail),
             "clientEmail must be set if using credentials configured directly in configuration");
         Preconditions.checkArgument(
             isNullOrEmpty(serviceAccountKeyFile),
@@ -92,7 +98,11 @@ public class CredentialConfiguration {
             isNullOrEmpty(serviceAccountJsonKeyFile),
             "A JSON key file may not be specified at the same time as credentials via configuration.");
         return credentialFactory.getCredentialsFromSAParameters(
-            saPrivateKeyId, saPrivateKey, saClientEmail, scopes, getTransport());
+            serviceAccountPrivateKeyId,
+            serviceAccountPrivateKey,
+            serviceAccountClientEmail,
+            scopes,
+            getTransport());
       }
 
       if (isNullOrEmpty(serviceAccountJsonKeyFile)) {
@@ -147,7 +157,7 @@ public class CredentialConfiguration {
   public boolean shouldUseMetadataService() {
     return isNullOrEmpty(serviceAccountKeyFile)
         && isNullOrEmpty(serviceAccountJsonKeyFile)
-        && isNullOrEmpty(saPrivateKey)
+        && isNullOrEmpty(serviceAccountPrivateKey)
         && !shouldUseApplicationDefaultCredentials();
   }
 
@@ -171,28 +181,28 @@ public class CredentialConfiguration {
     return serviceAccountEnabled;
   }
 
-  public String getSaPrivateKeyId() {
-    return saPrivateKeyId;
+  public String getServiceAccountPrivateKeyId() {
+    return serviceAccountPrivateKeyId;
   }
 
-  public void setSaPrivateKeyId(String saPrivateKeyId) {
-    this.saPrivateKeyId = saPrivateKeyId;
+  public void setServiceAccountPrivateKeyId(String serviceAccountPrivateKeyId) {
+    this.serviceAccountPrivateKeyId = serviceAccountPrivateKeyId;
   }
 
-  public String getSaPrivateKey() {
-    return saPrivateKey;
+  public String getServiceAccountPrivateKey() {
+    return serviceAccountPrivateKey;
   }
 
-  public void setSaPrivateKey(String saPrivateKey) {
-    this.saPrivateKey = saPrivateKey;
+  public void setServiceAccountPrivateKey(String serviceAccountPrivateKey) {
+    this.serviceAccountPrivateKey = serviceAccountPrivateKey.replace("\\n", System.lineSeparator());
   }
 
-  public String getSaClientEmail() {
-    return saClientEmail;
+  public String getServiceAccountClientEmail() {
+    return serviceAccountClientEmail;
   }
 
-  public void setSaClientEmail(String saClientEmail) {
-    this.saClientEmail = saClientEmail;
+  public void setServiceAccountClientEmail(String serviceAccountClientEmail) {
+    this.serviceAccountClientEmail = serviceAccountClientEmail;
   }
 
   public void setEnableServiceAccounts(boolean enableServiceAccounts) {
@@ -264,13 +274,17 @@ public class CredentialConfiguration {
   public String toString() {
     return "CredentialConfiguration{"
         + ("serviceAccountEnabled: " + isServiceAccountEnabled() + '\n')
-        + ("saPrivateKeyId: "
-            + (isNullOrEmpty(getSaPrivateKeyId()) ? "Not Provided" : "Provided, but not displayed")
+        + ("serviceAccountPrivateKeyId: "
+            + (isNullOrEmpty(getServiceAccountPrivateKeyId())
+                ? "Not Provided"
+                : "Provided, but not displayed")
             + '\n')
-        + ("saPrivateKey: "
-            + (isNullOrEmpty(getSaPrivateKey()) ? "Not Provided" : "Provided, but not displayed")
+        + ("serviceAccountPrivateKey: "
+            + (isNullOrEmpty(getServiceAccountPrivateKey())
+                ? "Not Provided"
+                : "Provided, but not displayed")
             + '\n')
-        + ("saClientEmail: " + getSaClientEmail() + '\n')
+        + ("serviceAccountClientEmail: " + getServiceAccountClientEmail() + '\n')
         + ("serviceAccountEmail: " + getServiceAccountEmail() + '\n')
         + ("serviceAccountKeyfile: " + getServiceAccountKeyFile() + '\n')
         + ("clientId: " + getClientId() + '\n')

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
@@ -34,7 +34,6 @@ public class CredentialConfiguration {
   private String saPrivateKeyId = null;
   private String saPrivateKey = null;
   private String saClientEmail = null;
-  private String saClientId = null;
   private String serviceAccountEmail = null;
   private String serviceAccountKeyFile = null;
   private String serviceAccountJsonKeyFile = null;

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialConfiguration.java
@@ -105,7 +105,7 @@ public class CredentialConfiguration {
             getTransport());
       }
 
-      if (isNullOrEmpty(serviceAccountJsonKeyFile)) {
+      if (!isNullOrEmpty(serviceAccountJsonKeyFile)) {
         logger.atFine().log("Using JSON keyfile %s", serviceAccountJsonKeyFile);
         Preconditions.checkArgument(
             isNullOrEmpty(serviceAccountKeyFile),
@@ -287,6 +287,7 @@ public class CredentialConfiguration {
         + ("serviceAccountClientEmail: " + getServiceAccountClientEmail() + '\n')
         + ("serviceAccountEmail: " + getServiceAccountEmail() + '\n')
         + ("serviceAccountKeyfile: " + getServiceAccountKeyFile() + '\n')
+        + ("serviceAccountJsonKeyFile: " + getServiceAccountJsonKeyFile() + '\n')
         + ("clientId: " + getClientId() + '\n')
         + ("clientSecret: "
             + (isNullOrEmpty(getClientSecret()) ? "Not provided" : "Provided, but not displayed")

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -296,8 +296,9 @@ public class CredentialFactory {
       throws IOException {
     logger.atFine().log("getServiceAccountCredentialFromHadoopConfiguration(%s)", clientEmail);
     if (clientEmail == null || privateKeyPem == null || privateKeyId == null) {
-      throw new IOException("Error reading service account credential from stream, "
-          + "expecting, 'client_email', 'private_key' and 'private_key_id'.");
+      throw new IOException(
+          "Error reading service account credential from stream, "
+              + "expecting, 'client_email', 'private_key' and 'private_key_id'.");
     }
     PrivateKey privateKey = privateKeyFromPkcs8(privateKeyPem);
     GoogleCredential.Builder builder =
@@ -458,6 +459,5 @@ public class CredentialFactory {
     } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
       throw new IOException("Unexpected expcetion reading PKCS data", exception);
     }
-
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -41,6 +41,9 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.PemReader;
+import com.google.api.client.util.PemReader.Section;
+import com.google.api.client.util.SecurityUtils;
 import com.google.api.services.storage.StorageScopes;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -49,7 +52,14 @@ import com.google.common.flogger.GoogleLogger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.List;
 
 /** Miscellaneous helper methods for getting a {@code Credential} from various sources. */
@@ -277,6 +287,31 @@ public class CredentialFactory {
     }
   }
 
+  public Credential getCredentialsFromSAParameters(
+      String privateKeyId,
+      String privateKeyPem,
+      String clientEmail,
+      List<String> scopes,
+      HttpTransport transport)
+      throws IOException {
+    logger.atFine().log("getServiceAccountCredentialFromHadoopConfiguration({})", clientEmail);
+    if (clientEmail == null || privateKeyPem == null
+        || privateKeyId == null) {
+      throw new IOException("Error reading service account credential from stream, "
+          + "expecting, 'client_email', 'private_key' and 'private_key_id'.");
+    }
+    PrivateKey privateKey = privateKeyFromPkcs8(privateKeyPem);
+    GoogleCredential.Builder builder =
+        new GoogleCredential.Builder()
+            .setTransport(transport)
+            .setJsonFactory(JSON_FACTORY)
+            .setServiceAccountId(clientEmail)
+            .setServiceAccountScopes(scopes)
+            .setServiceAccountPrivateKey(privateKey)
+            .setServiceAccountPrivateKeyId(privateKeyId);
+    return new GoogleCredentialWithRetry(builder);
+  }
+
   /**
    * Initialized OAuth2 credential for the "installed application" flow; where the credential
    * typically represents an actual end user (instead of a service account), and is stored as a
@@ -406,5 +441,27 @@ public class CredentialFactory {
     logger.atFine().log("getApplicationDefaultCredential(%s)", scopes);
     return GoogleCredentialWithRetry.fromGoogleCredential(
         GoogleCredential.getApplicationDefault(transport, JSON_FACTORY).createScoped(scopes));
+  }
+
+  // TODO (Copied (mostly) over from Google Credential since it has private scope)
+  private static PrivateKey privateKeyFromPkcs8(String privateKeyPem) throws IOException {
+    Reader reader = new StringReader(privateKeyPem);
+    Section section = PemReader.readFirstSectionAndClose(reader, "PRIVATE KEY");
+    if (section == null) {
+      throw new IOException("Invalid PKCS8 data.");
+    }
+    byte[] bytes = section.getBase64DecodedBytes();
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(bytes);
+    Exception unexpectedException = null;
+    try {
+      KeyFactory keyFactory = SecurityUtils.getRsaKeyFactory();
+      PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
+      return privateKey;
+    } catch (NoSuchAlgorithmException exception) {
+      unexpectedException = exception;
+    } catch (InvalidKeySpecException exception) {
+      unexpectedException = exception;
+    }
+    throw new IOException("Unexpected expcetion reading PKCS data", unexpectedException);
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -294,9 +294,8 @@ public class CredentialFactory {
       List<String> scopes,
       HttpTransport transport)
       throws IOException {
-    logger.atFine().log("getServiceAccountCredentialFromHadoopConfiguration({})", clientEmail);
-    if (clientEmail == null || privateKeyPem == null
-        || privateKeyId == null) {
+    logger.atFine().log("getServiceAccountCredentialFromHadoopConfiguration(%s)", clientEmail);
+    if (clientEmail == null || privateKeyPem == null || privateKeyId == null) {
       throw new IOException("Error reading service account credential from stream, "
           + "expecting, 'client_email', 'private_key' and 'private_key_id'.");
     }

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -452,16 +452,13 @@ public class CredentialFactory {
     }
     byte[] bytes = section.getBase64DecodedBytes();
     PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(bytes);
-    Exception unexpectedException = null;
     try {
       KeyFactory keyFactory = SecurityUtils.getRsaKeyFactory();
       PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
       return privateKey;
-    } catch (NoSuchAlgorithmException exception) {
-      unexpectedException = exception;
-    } catch (InvalidKeySpecException exception) {
-      unexpectedException = exception;
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+      throw new IOException("Unexpected expcetion reading PKCS data", exception);
     }
-    throw new IOException("Unexpected expcetion reading PKCS data", unexpectedException);
+
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
@@ -62,11 +62,14 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
    */
   public static final String ENABLE_SERVICE_ACCOUNTS_SUFFIX = ".auth.service.account.enable";
 
-  // TODO Document the parameters. Additional documentation in gs-defaults.xml, toString
-  public static final String SA_PRIVATE_KEY_ID_SUFFIX = ".auth.service.account.private.key.id";
-  public static final String SA_PRIVATE_KEY_SUFFIX = ".auth.service.account.private.key";
-  // Not ideal to duplicate email, but keeps the parameter names for this set of configuration consistent
-  public static final String SA_CLIENT_EMAIL_SUFFIX = ".auth.service.account.client.email";
+  public static final String SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX =
+      ".auth.service.account.private.key.id";
+  public static final String SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX =
+      ".auth.service.account.private.key";
+  // Not ideal to duplicate email, but keeps the parameter names for this set of configuration
+  // consistent
+  public static final String SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX =
+      ".auth.service.account.client.email";
 
   /**
    * Key suffix used to control which email address is associated with the service account.
@@ -226,14 +229,14 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
   public void getConfigurationInto(Entries configuration) {
     for (String prefix : prefixes) {
       configuration.setBoolean(prefix + ENABLE_SERVICE_ACCOUNTS_SUFFIX, isServiceAccountEnabled());
-      if (getSaClientEmail() != null) {
-        configuration.set(prefix + SA_CLIENT_EMAIL_SUFFIX, getSaClientEmail());
+      if (getServiceAccountClientEmail() != null) {
+        configuration.set(prefix + SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX, getServiceAccountClientEmail());
       }
-      if (getSaPrivateKeyId() != null) {
-        configuration.set(prefix + SA_PRIVATE_KEY_ID_SUFFIX, getSaPrivateKeyId());
+      if (getServiceAccountPrivateKeyId() != null) {
+        configuration.set(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX, getServiceAccountPrivateKeyId());
       }
-      if (getSaPrivateKey() != null) {
-        configuration.set(prefix + SA_PRIVATE_KEY_SUFFIX, getSaPrivateKey());
+      if (getServiceAccountPrivateKey() != null) {
+        configuration.set(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX, getServiceAccountPrivateKey());
       }
       if (getServiceAccountEmail() != null) {
         configuration.set(prefix + SERVICE_ACCOUNT_EMAIL_SUFFIX, getServiceAccountEmail());
@@ -276,21 +279,23 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
         setEnableServiceAccounts(enableServiceAccounts.get());
       }
 
-      // Parameters for SA directly in Configuration
-      String saPrivateKeyId = entries.getPassword(prefix + SA_PRIVATE_KEY_ID_SUFFIX);
-      if (saPrivateKeyId != null) {
-        setSaPrivateKeyId(saPrivateKeyId);
+      // Parameters for ServiceAccount directly in Configuration
+      String serviceAccountPrivateKeyId =
+          entries.getPassword(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX);
+      if (serviceAccountPrivateKeyId != null) {
+        setServiceAccountPrivateKeyId(serviceAccountPrivateKeyId);
       }
 
-      String saPrivateKey = entries.getPassword(prefix + SA_PRIVATE_KEY_SUFFIX);
-      if (saPrivateKey != null) {
-        saPrivateKey = saPrivateKey.replace("\\n", System.lineSeparator());
-        setSaPrivateKey(saPrivateKey);
+      String serviceAccountPrivateKey =
+          entries.getPassword(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX);
+      if (serviceAccountPrivateKey != null) {
+        setServiceAccountPrivateKey(serviceAccountPrivateKey);
       }
 
-      String saClientEmail = entries.getPassword(prefix + SA_CLIENT_EMAIL_SUFFIX);
-      if (saClientEmail != null) {
-        setSaClientEmail(saClientEmail);
+      String serviceAccountClientEmail =
+          entries.getPassword(prefix + SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX);
+      if (serviceAccountClientEmail != null) {
+        setServiceAccountClientEmail(serviceAccountClientEmail);
       }
 
       // Parameters for file based credentials

--- a/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
@@ -155,9 +155,7 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
      */
     protected abstract T beginBuild();
 
-    /**
-     * Return the fully-assembled concrete object for which this is a builder.
-     */
+    /** Return the fully-assembled concrete object for which this is a builder. */
     public T build() throws IOException {
       T concreteCredentialConfiguration = beginBuild();
       if (configuration != null) {
@@ -230,13 +228,16 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
     for (String prefix : prefixes) {
       configuration.setBoolean(prefix + ENABLE_SERVICE_ACCOUNTS_SUFFIX, isServiceAccountEnabled());
       if (getServiceAccountClientEmail() != null) {
-        configuration.set(prefix + SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX, getServiceAccountClientEmail());
+        configuration.set(
+            prefix + SERVICE_ACCOUNT_CLIENT_EMAIL_SUFFIX, getServiceAccountClientEmail());
       }
       if (getServiceAccountPrivateKeyId() != null) {
-        configuration.set(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX, getServiceAccountPrivateKeyId());
+        configuration.set(
+            prefix + SERVICE_ACCOUNT_PRIVATE_KEY_ID_SUFFIX, getServiceAccountPrivateKeyId());
       }
       if (getServiceAccountPrivateKey() != null) {
-        configuration.set(prefix + SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX, getServiceAccountPrivateKey());
+        configuration.set(
+            prefix + SERVICE_ACCOUNT_PRIVATE_KEY_SUFFIX, getServiceAccountPrivateKey());
       }
       if (getServiceAccountEmail() != null) {
         configuration.set(prefix + SERVICE_ACCOUNT_EMAIL_SUFFIX, getServiceAccountEmail());

--- a/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
@@ -115,6 +115,18 @@ public class CredentialConfigurationTest {
   }
 
   @Test
+  public void configurationSAUsedWhenConfigured() throws IOException, GeneralSecurityException {
+    configuration.setSaClientEmail("foo@example.com");
+    configuration.setSaPrivateKeyId("privateKeyId");
+    configuration.setSaPrivateKey("privateKey");
+
+    configuration.getCredential(TEST_SCOPES);
+    verify(mockCredentialFactory, times(1))
+        .getCredentialsFromSAParameters(
+            "privateKeyId", "privateKey", "foo@example.com", TEST_SCOPES, mockTransport);
+  }
+
+  @Test
   public void installedAppWorkflowUsedWhenConfigurred()
       throws IOException, GeneralSecurityException  {
     configuration.setEnableServiceAccounts(false);

--- a/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
@@ -116,9 +116,9 @@ public class CredentialConfigurationTest {
 
   @Test
   public void configurationSAUsedWhenConfigured() throws IOException, GeneralSecurityException {
-    configuration.setSaClientEmail("foo@example.com");
-    configuration.setSaPrivateKeyId("privateKeyId");
-    configuration.setSaPrivateKey("privateKey");
+    configuration.setServiceAccountClientEmail("foo@example.com");
+    configuration.setServiceAccountPrivateKeyId("privateKeyId");
+    configuration.setServiceAccountPrivateKey("privateKey");
 
     configuration.getCredential(TEST_SCOPES);
     verify(mockCredentialFactory, times(1))


### PR DESCRIPTION

Takes approach 1 mentioned in the #119, i.e. 3 parameters to be configured - all of which are pulled from a json keyfile:
```
fs.gs.auth.service.account.client.email
fs.gs.auth.service.account.private.key.id
fs.gs.auth.service.account.private.key
```

Resolves https://github.com/GoogleCloudPlatform/bigdata-interop/issues/62
Resolves https://github.com/GoogleCloudPlatform/bigdata-interop/issues/75
Resolves https://github.com/GoogleCloudPlatform/bigdata-interop/issues/119 