### PR TITLE
Support to add credentials via hadoop credential provider path

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -29,6 +29,52 @@
   <artifactId>util</artifactId>
   <version>1.9.8-SNAPSHOT</version>
 
+  <properties>
+    <hadoop.one.version>0.23.11</hadoop.one.version>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>hadoop1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.one.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>hadoop2</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.two.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>hadoop3</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.three.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+
   <dependencies>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/EntriesCredentialConfiguration.java
@@ -78,6 +78,11 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
    */
   public static final String JSON_KEYFILE_SUFFIX = ".auth.service.account.json.keyfile";
   /**
+   * Hadoop credential provider path. Typically clients will configure the secret keys in the provider
+   */
+  public static final String CREDENTIAL_PROVIDER_PATH = ".auth.hadoop.credential.provider.path";
+
+  /**
    * For OAuth-based Installed App authentication, the key suffix specifying the client ID for
    * the credentials.
    */
@@ -243,6 +248,9 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
       if (getOAuthCredentialFile() != null) {
         configuration.set(prefix + OAUTH_CLIENT_FILE_SUFFIX, getOAuthCredentialFile());
       }
+      if (getCredentialProviderPath() != null) {
+        configuration.set(prefix + CREDENTIAL_PROVIDER_PATH, getCredentialProviderPath());
+      }
       configuration.setBoolean(prefix + ENABLE_NULL_CREDENTIAL_SUFFIX, isNullCredentialEnabled());
     }
     // Transport configuration does not use prefixes
@@ -291,6 +299,11 @@ public class EntriesCredentialConfiguration extends CredentialConfiguration {
       String serviceAccountJsonKeyFile = entries.get(prefix + JSON_KEYFILE_SUFFIX);
       if (serviceAccountJsonKeyFile != null) {
         setServiceAccountJsonKeyFile(serviceAccountJsonKeyFile);
+      }
+
+      String hadoopCredentialProviderPath = entries.get(prefix + CREDENTIAL_PROVIDER_PATH);
+      if (hadoopCredentialProviderPath != null) {
+        setCredentialProviderPath(hadoopCredentialProviderPath);
       }
 
       String clientId = entries.get(prefix + CLIENT_ID_SUFFIX);

--- a/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/CredentialConfigurationTest.java
@@ -25,6 +25,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import org.apache.hadoop.security.alias.CredentialProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,6 +113,16 @@ public class CredentialConfigurationTest {
 
     verify(mockCredentialFactory, times(1))
         .getCredentialFromJsonKeyFile("jsonExampleKeyFile", TEST_SCOPES, mockTransport);
+  }
+
+  @Test
+  public void hadoopCredentialProviderPathWhenConfigured() throws IOException, GeneralSecurityException {
+    configuration.setCredentialProviderPath("localjceks://file/home/random_user/aws.jceks");
+    configuration.getCredential(TEST_SCOPES);
+
+    verify(mockCredentialFactory, times(1))
+            .getCredentialFromCredentialProvider("localjceks://file/home/random_user/aws.jceks",
+                    TEST_SCOPES, mockTransport);
   }
 
   @Test


### PR DESCRIPTION
Pull request to support reading credential secrets from Hadoop credential provider. Currently, this is one of the ways how S3 credentials are read (integrated into Hadoop main trunk).

For details on Hadoop credential provider, please refer: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html.

The client will configure the credential in core-site like this:
<property>
     <name>google.cloud.auth.hadoop.credential.provider.path</name>
     <value>jceks://hdfs@random_namenode/user/random_user/test.jceks</value>
   </property>
