### PR TITLE
GCS Connector override file support

### DIFF
--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -278,4 +278,12 @@
     </description>
   </property>
 
+  <property>
+    <name>fs.gs.config.override.file</name>
+    <description>
+      Optional. Override configuration file path. Properties defined in this file overrides
+      the properties defined in core-site.xml and values passed from command line.
+    </description>
+  </property>
+
 </configuration>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -59,13 +59,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.flogger.GoogleLogger;
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
+
+import java.io.*;
 import java.net.URI;
 import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,6 +76,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -1529,6 +1528,16 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
 
       enableFlatGlob = GCS_FLAT_GLOB_ENABLE.get(config, config::getBoolean);
       checksumType = GCS_FILE_CHECKSUM_TYPE.get(config, config::getEnum);
+
+      // if overrides file configured, update properties from override file into Configuration object
+      if(config.get(GoogleHadoopFileSystemConfiguration.GCS_CONFIG_OVERRIDE_FILE.getKey()) != null) {
+        File overrideFileObject = Paths.get(config.get(GoogleHadoopFileSystemConfiguration.GCS_CONFIG_OVERRIDE_FILE.getKey())).toFile();
+        if(overrideFileObject.exists()) {
+          config.addResource(FileUtils.openInputStream(overrideFileObject));
+        } else {
+          logger.atWarning().log("Override configuration path specified not present, path "+overrideFileObject.getAbsolutePath());
+        }
+      }
 
       GoogleCloudStorageFileSystemOptions.Builder optionsBuilder =
           GoogleHadoopFileSystemConfiguration.getGcsFsOptionsBuilder(config);

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -511,6 +511,14 @@ public class GoogleHadoopFileSystemConfiguration {
               "fs.gs.inputstream.min.range.request.size",
               GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE);
 
+  /**
+   * Override configuration file path.
+   */
+  public static final GoogleHadoopFileSystemConfigurationProperty<Integer>
+          GCS_CONFIG_OVERRIDE_FILE =
+          new GoogleHadoopFileSystemConfigurationProperty<>(
+                  "fs.gs.config.override.file", null);
+
   @VisibleForTesting
   static GoogleCloudStorageFileSystemOptions.Builder getGcsFsOptionsBuilder(Configuration config) {
     GoogleCloudStorageFileSystemOptions.Builder gcsFsOptionsBuilder =


### PR DESCRIPTION
Added new property to pass override json file path. Added support to read key/value pairs from file and override them in Cionfigurtation object.