### PR TITLE
GCS connector delegation token support

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractDelegationTokenBinding.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractDelegationTokenBinding.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import com.google.common.base.Preconditions;
+import com.google.common.flogger.GoogleLogger;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.SecretManager;
+import org.apache.hadoop.security.token.Token;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+
+public abstract class AbstractDelegationTokenBinding {
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private final Text kind;
+
+  protected SecretManager<AbstractGCPTokenIdentifier> secretManager =
+      new TokenSecretManager();
+
+  /**
+   * URI of the filesystem.
+   * Valid after {@link #bindToFileSystem(URI, GoogleHadoopFileSystemBase)}.
+   */
+  private URI canonicalUri;
+
+  private Text service;
+
+  /**
+   * The owning filesystem.
+   * Valid after {@link #bindToFileSystem(URI, GoogleHadoopFileSystemBase)}.
+   */
+  private GoogleHadoopFileSystemBase fileSystem;
+
+  /**
+   * Owner of the filesystem.
+   * Valid after {@link #bindToFileSystem(URI, GoogleHadoopFileSystemBase)}.
+   */
+  private UserGroupInformation owner;
+
+
+  protected AbstractDelegationTokenBinding(Text kind) {
+    this.kind = kind;
+  }
+
+  public Text getKind() {
+    return kind;
+  }
+
+  /**
+   * Get the canonical URI of the filesystem, which is what is used to identify the tokens.
+   * @return the URI.
+   */
+  public URI getCanonicalUri() {
+    return canonicalUri;
+  }
+
+  /**
+   * @return The bound file system
+   */
+  public GoogleHadoopFileSystemBase getFileSystem() {
+    return fileSystem;
+  }
+
+  public Text getService() {
+    return service;
+  }
+
+  /**
+   * Return the name of the owner to be used in tokens.
+   * This may be that of the UGI owner, or it could be related to
+   * the GCS login.
+   *
+   * @return a text name of the owner.
+   */
+  public Text getOwnerText() {
+    UserGroupInformation owner = getFileSystem().getOwner();
+    return new Text(owner != null ? owner.getUserName() : "");
+  }
+
+
+  /**
+   * Perform any actions when deploying unbonded, and return a list
+   * of credential providers.
+   * @throws IOException any failure.
+   */
+  public abstract AccessTokenProvider deployUnbonded() throws IOException;
+
+
+  /**
+   * Bind to the token identifier, returning the credential providers to use
+   * for the owner to talk to S3, DDB and related GCP Services.
+   * @param retrievedIdentifier the unmarshalled data
+   * @return non-empty list of GCP credential providers to use for
+   * authenticating this client with GCP services.
+   * @throws IOException any failure.
+   */
+  public abstract AccessTokenProvider bindToTokenIdentifier(AbstractGCPTokenIdentifier retrievedIdentifier)
+      throws IOException;
+
+  /**
+   * Bind to the filesystem.
+   * Subclasses can use this to perform their own binding operations -
+   * but they must always call their superclass implementation.
+   * This <i>Must</i> be called before calling {@code init()}.
+   *
+   * <b>Important:</b>
+   * This binding will happen during FileSystem.initialize(); the FS
+   * is not live for actual use and will not yet have interacted with
+   * GCS services.
+   *
+   * @param uri the canonical URI of the FS.
+   * @param fs owning FS.
+   *
+   * @throws IOException failure.
+   */
+  public void bindToFileSystem(final URI uri,
+                               final GoogleHadoopFileSystemBase fs)
+      throws IOException {
+    Preconditions.checkState((canonicalUri == null),
+                             "bindToFileSystem called twice");
+    this.canonicalUri = requireNonNull(uri);
+    this.fileSystem = requireNonNull(fs);
+    this.service = new Text(uri.toString());
+    this.owner = fs.getOwner();
+  }
+
+
+  /**
+   * Create a delegation token for the user.
+   * This will only be called if a new DT is needed, that is: the
+   * filesystem has been deployed unbound.
+   *
+   * @return the token
+   *
+   * @throws IOException if one cannot be created
+   */
+  public Token<AbstractGCPTokenIdentifier> createDelegationToken(String renewer)
+      throws IOException {
+    Text renewerText = new Text();
+    if (renewer != null) {
+      renewerText.set(renewer);
+    }
+
+    AbstractGCPTokenIdentifier tokenIdentifier =
+        requireNonNull(createTokenIdentifier(renewerText),
+                       "Token identifier");
+
+    Token<AbstractGCPTokenIdentifier> token =
+        new Token<>(tokenIdentifier, secretManager);
+    token.setKind(getKind());
+    token.setService(service);
+    logger.atFine().log("Created token %s with token identifier %s",
+        token, tokenIdentifier);
+    return token;
+  }
+
+  /**
+   * Create a token identifier with all the information needed
+   * to be included in a delegation token.
+   * This is where session credentials need to be extracted, etc.
+   * This will only be called if a new DT is needed, that is: the
+   * filesystem has been deployed unbound.
+   *
+   * If {@link #createDelegationToken}
+   * is overridden, this method can be replaced with a stub.
+   *
+   * @return the token data to include in the token identifier.
+   *
+   * @throws IOException failure creating the token data.
+   */
+  public abstract AbstractGCPTokenIdentifier createTokenIdentifier(Text renewer)
+      throws IOException;
+
+
+  /**
+   * Create a token identifier with all the information needed
+   * to be included in a delegation token.
+   * This is where session credentials need to be extracted, etc.
+   * This will only be called if a new DT is needed, that is: the
+   * filesystem has been deployed unbound.
+   *
+   * If {@link #createDelegationToken}
+   * is overridden, this method can be replaced with a stub.
+   *
+   * @return the token data to include in the token identifier.
+   *
+   * @throws IOException failure creating the token data.
+   */
+  public abstract AbstractGCPTokenIdentifier createTokenIdentifier()
+      throws IOException;
+
+
+  /**
+   * Create a new subclass of {@link AbstractGCPTokenIdentifier}.
+   * This is used in the secret manager.
+   * @return an empty identifier.
+   */
+  public abstract AbstractGCPTokenIdentifier createEmptyIdentifier();
+
+
+  /**
+   * Verify that a token identifier is of a specific class.
+   * This will reject subclasses (i.e. it is stricter than
+   * {@code instanceof}, then cast it to that type.
+   * @param identifier identifier to validate
+   * @param expectedClass class of the expected token identifier.
+   * @throws DelegationTokenIOException If the wrong class was found.
+   */
+  protected <T extends AbstractGCPTokenIdentifier> T convertTokenIdentifier(
+      final AbstractGCPTokenIdentifier identifier,
+      final Class<T> expectedClass) throws DelegationTokenIOException {
+    if (!identifier.getClass().equals(expectedClass)) {
+      throw DelegationTokenIOException.wrongTokenType(expectedClass, identifier);
+    }
+    return (T) identifier;
+  }
+
+  /**
+   * The secret manager always uses the same secret; the
+   * factory for new identifiers is that of the token manager.
+   */
+  protected class TokenSecretManager extends SecretManager<AbstractGCPTokenIdentifier> {
+
+    private final byte[] pwd = "not-a-pass".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    protected byte[] createPassword(AbstractGCPTokenIdentifier identifier) {
+      return pwd;
+    }
+
+    @Override
+    public byte[] retrievePassword(AbstractGCPTokenIdentifier identifier) throws InvalidToken {
+      return pwd;
+    }
+
+    @Override
+    public AbstractGCPTokenIdentifier createIdentifier() {
+      return AbstractDelegationTokenBinding.this.createEmptyIdentifier();
+    }
+  }
+
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractGCPTokenIdentifier.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractGCPTokenIdentifier.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.UUID;
+
+public abstract class AbstractGCPTokenIdentifier extends DelegationTokenIdentifier {
+
+  /**
+   * How long can any of the secrets, role policy be.
+   * Knox DTs can be long, so set this to a big value: {@value}
+   */
+  protected static final int MAX_TEXT_LENGTH = 32768;
+
+  /** Canonical URI of the bucket. */
+  private URI uri;
+
+  /**
+   * Timestamp of creation.
+   * This is set to the current time; it will be overridden when
+   * deserializing data.
+   */
+  private long created = System.currentTimeMillis();
+
+  /**
+   * An origin string for diagnostics.
+   */
+  private String origin = "";
+
+  /**
+   * This marshalled UUID can be used in testing to verify transmission,
+   * and reuse; as it is printed you can see what is happending too.
+   */
+  private String uuid = UUID.randomUUID().toString();
+
+
+  protected AbstractGCPTokenIdentifier(Text kind) {
+    super(kind);
+  }
+
+  protected AbstractGCPTokenIdentifier(Text kind, String renewer, String realUser) {
+    this(kind, new Text(), new Text(renewer), new Text(realUser));
+  }
+
+  protected AbstractGCPTokenIdentifier(Text kind, Text owner, Text renewer, Text realUser) {
+    super(kind, owner, renewer, realUser);
+  }
+
+  protected AbstractGCPTokenIdentifier(Text kind, URI uri, Text owner, String origin) {
+    super(kind);
+    this.setOwner(owner);
+    this.uri = uri;
+    this.origin = origin;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  public String getOrigin() {
+    return origin.toString();
+  }
+
+  public void setOrigin(final String origin) {
+    this.origin = origin;
+  }
+
+  public long getCreated() {
+    return created;
+  }
+
+  /**
+   * Write state.
+   * {@link org.apache.hadoop.io.Writable#write(DataOutput)}.
+   * @param out destination
+   * @throws IOException failure
+   */
+  @Override
+  public void write(final DataOutput out) throws IOException {
+    super.write(out);
+    Text.writeString(out, uri.toString());
+    Text.writeString(out, origin);
+    Text.writeString(out, uuid);
+    out.writeLong(created);
+  }
+
+  /**
+   * Read state.
+   * {@link org.apache.hadoop.io.Writable#readFields(DataInput)}.
+   *
+   * Note: this operation gets called in toString() operations on tokens, so
+   * must either always succeed, or throw an IOException to trigger the
+   * catch & downgrade. RuntimeExceptions (e.g. Preconditions checks) are
+   * not to be used here for this reason.)
+   *
+   * @param in input stream
+   * @throws DelegationTokenIOException if the token binding is wrong.
+   * @throws IOException IO problems.
+   */
+  @Override
+  public void readFields(final DataInput in)
+      throws DelegationTokenIOException, IOException {
+    super.readFields(in);
+    uri = URI.create(Text.readString(in, MAX_TEXT_LENGTH));
+    origin = Text.readString(in, MAX_TEXT_LENGTH);
+    uuid = Text.readString(in, MAX_TEXT_LENGTH);
+    created = in.readLong();
+  }
+
+
+  /**
+   * Validate the token by looking at its fields.
+   * @throws IOException on failure.
+   */
+  public void validate() throws IOException {
+    if (uri == null) {
+      throw new DelegationTokenIOException("No URI in " + this);
+    }
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("GCPTokenIdentifier{");
+    sb.append(getKind());
+    sb.append("; uri=").append(uri);
+    sb.append("; timestamp=").append(created);
+    sb.append("; uuid=").append(uuid);
+    sb.append("; ").append(origin);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /**
+   * Equality check is on superclass and URI only.
+   * @param o other.
+   * @return true if the base class considers them equal and the URIs match.
+   */
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AbstractGCPTokenIdentifier that = (AbstractGCPTokenIdentifier) o;
+    return Objects.equals(uuid, that.uuid) && Objects.equals(uri, that.uri);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), uri);
+  }
+
+  /**
+   * Return the expiry time in seconds since 1970-01-01.
+   * @return the time when the session credential expire.
+   */
+  public long getExpiryTime() {
+    return 0;
+  }
+
+  /**
+   * Get the UUID of this token identifier.
+   * @return a UUID.
+   */
+  public String getUuid() {
+    return uuid;
+  }
+
+  /**
+   * Create the default origin text message with hostname and
+   * timestamp.
+   * @return a string for token diagnostics.
+   */
+  public static String createDefaultOriginMessage() {
+    return String.format("Created on %s at time %s.",
+                         NetUtils.getHostname(),
+                         java.time.Instant.now());
+  }
+
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/DelegationTokenIOException.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/DelegationTokenIOException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+
+/**
+ * General IOException for Delegation Token issues.
+ * Includes recommended error strings, which can be used in tests when
+ * looking for specific errors.
+ */
+public class DelegationTokenIOException extends IOException {
+
+  private static final long serialVersionUID = 5431764092856006083L;
+
+  /** Error: delegation token/token identifier class isn't the right one. */
+  static final String TOKEN_WRONG_TYPE = "Delegation token type is incorrect";
+
+  /**
+   * The far end is expecting a different token kind than that which the client created.
+   */
+  static final String TOKEN_MISMATCH = "Token mismatch";
+
+
+  public static DelegationTokenIOException wrongTokenType(Class expectedClass,
+                                                          AbstractGCPTokenIdentifier identifier) {
+    return new DelegationTokenIOException(TOKEN_WRONG_TYPE +
+                                          "; expected a token identifier of type " +
+                                          expectedClass +
+                                          " but got " +
+                                          identifier.getClass() +
+                                          " and kind " + identifier.getKind());
+  }
+
+  public static DelegationTokenIOException tokenMismatch(Text service,
+                                                         Text expectedKind,
+                                                         Text actualKind) {
+    return new DelegationTokenIOException(
+        DelegationTokenIOException.TOKEN_MISMATCH + ": expected token"
+            + " for " + service
+            + " of type " + expectedKind
+            + " but got a token of type " + actualKind);
+  }
+
+  public DelegationTokenIOException(final String message) {
+    super(message);
+  }
+
+  public DelegationTokenIOException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GCSDelegationTokens.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GCSDelegationTokens.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import com.google.common.base.Preconditions;
+import com.google.common.flogger.GoogleLogger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+
+import java.io.IOException;
+import java.net.URI;
+
+
+import static java.util.Objects.requireNonNull;
+
+public class GCSDelegationTokens {
+
+  public static final String CONFIG_DELEGATION_TOKEN_BINDING_CLASS =
+      "fs.gs.delegation.token.binding";
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private static final String E_ALREADY_DEPLOYED =
+      "GCP Delegation tokens has already been bound/deployed";
+
+  private URI uri;
+
+  private GoogleHadoopFileSystemBase fileSystem;
+
+  /**
+   * User who owns this FS; fixed at instantiation time, so that
+   * in calls to getDelegationToken() and similar, this user is the one whose
+   * credentials are involved.
+   */
+  private final UserGroupInformation user;
+
+  private Text service;
+
+  /**
+   * Dynamically loaded token binding; lifecycle matches this object.
+   */
+  private AbstractDelegationTokenBinding tokenBinding;
+
+  private AccessTokenProvider accessTokenProvider = null;
+
+  /**
+   * Active Delegation token.
+   */
+  private Token<AbstractGCPTokenIdentifier> boundDT = null;
+
+  /**
+   * The DT decoded when this instance is created by bonding
+   * to an existing DT.
+   */
+  private AbstractGCPTokenIdentifier decodedIdentifier = null;
+
+
+  public GCSDelegationTokens() throws IOException {
+    user = UserGroupInformation.getCurrentUser();
+  }
+
+  public void init(final Configuration conf) {
+    String tokenBindingImpl =
+        conf.get(CONFIG_DELEGATION_TOKEN_BINDING_CLASS);
+
+    Preconditions.checkState((tokenBindingImpl != null),
+        "Delegation Tokens not configured");
+
+    try {
+      Class bindingClass = Class.forName(tokenBindingImpl);
+      AbstractDelegationTokenBinding binding =
+          (AbstractDelegationTokenBinding) bindingClass.newInstance();
+      binding.bindToFileSystem(getUri(), fileSystem);
+      tokenBinding = binding;
+      logger.atInfo().log("Filesystem %s is using delegation tokens of kind %s",
+          getUri(), tokenBinding.getKind().toString());
+
+      service = binding.getService();
+
+      bindToAnyDelegationToken();
+    } catch (Exception e) {
+      logger.atSevere().log("Failed to load configured delegation token binding %s",
+                tokenBindingImpl,
+                e);
+    }
+  }
+
+  public Text getService() {
+    return service;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  public AccessTokenProvider getAccessTokenProvider() {
+    return accessTokenProvider;
+  }
+
+  /**
+   * Perform the unbonded deployment operations.
+   * Create the GCP credential provider chain to use
+   * when talking to GCP when there is no delegation token to work with.
+   * authenticating this client with GCP services, and saves it
+   * to {@link #accessTokenProvider}
+   *
+   * @throws IOException any failure.
+   */
+  public AccessTokenProvider deployUnbonded()
+      throws IOException {
+    Preconditions.checkState(!isBoundToDT(),
+        "Already Bound to a delegation token");
+    logger.atInfo().log("No delegation tokens present: using direct authentication");
+    accessTokenProvider = tokenBinding.deployUnbonded();
+    return accessTokenProvider;
+  }
+
+  /**
+   * Attempt to bind to any existing DT, including unmarshalling its contents
+   * and creating the GCP credential provider used to authenticate
+   * the client.
+   *
+   * If successful:
+   * <ol>
+   *   <li>{@link #boundDT} is set to the retrieved token.</li>
+   *   <li>{@link #decodedIdentifier} is set to the extracted identifier.</li>
+   *   <li>{@link #accessTokenProvider} is set to the credential
+   *   provider(s) returned by the token binding.</li>
+   * </ol>
+   * If unsuccessful, {@link #deployUnbonded()} is called for the
+   * unbonded codepath instead, which will set
+   * {@link #accessTokenProvider} to its value.
+   *
+   * This means after this call (and only after) the token operations
+   * can be invoked.
+   *
+   * @throws IOException selection/extraction/validation failure.
+   */
+  public void bindToAnyDelegationToken() throws IOException {
+    Preconditions.checkState(accessTokenProvider == null, E_ALREADY_DEPLOYED);
+    Token<AbstractGCPTokenIdentifier> token = selectTokenFromFSOwner();
+    if (token != null) {
+      bindToDelegationToken(token);
+    } else {
+      deployUnbonded();
+    }
+    if (accessTokenProvider == null) {
+      throw new DelegationTokenIOException("No AccessTokenProvider"
+          + " created by Delegation Token Binding "
+          + tokenBinding.getKind());
+    }
+  }
+
+  /**
+   * This is a test-only back door which resets the state and binds to
+   * a token again.
+   * This allows an instance of this class to be bonded to a DT after being
+   * started, so avoids the need to have the token in the current user
+   * credentials. It is package scoped so as to only be usable in tests
+   * in the same package.
+   *
+   * Yes, this is ugly, but there is no obvious/easy way to test token
+   * binding without Kerberos getting involved.
+   * @param token token to decode and bind to.
+   * @throws IOException selection/extraction/validation failure.
+   */
+  void resetTokenBindingToDT(final Token<AbstractGCPTokenIdentifier> token)
+      throws IOException{
+    accessTokenProvider = null;
+    bindToDelegationToken(token);
+  }
+
+  /**
+   * Find a token for the FS user and canonical filesystem URI.
+   * @return the token, or null if one cannot be found.
+   * @throws IOException on a failure to unmarshall the token.
+   */
+  public Token<AbstractGCPTokenIdentifier> selectTokenFromFSOwner()
+      throws IOException {
+    return lookupToken(user.getCredentials(),
+        service,
+        tokenBinding.getKind());
+  }
+
+  /**
+   * Bind to the filesystem.
+   * Subclasses can use this to perform their own binding operations -
+   * but they must always call their superclass implementation.
+   * This <i>Must</i> be called before calling {@code init()}.
+   *
+   * <b>Important:</b>
+   * This binding will happen during FileSystem.initialize(); the FS
+   * is not live for actual use and will not yet have interacted with
+   * GCS services.
+   * @param fs owning FS.
+   * @throws IOException failure.
+   */
+  public void bindToFileSystem(
+      final URI uri,
+      final GoogleHadoopFileSystemBase fs) throws IOException {
+    this.uri = requireNonNull(uri);
+    this.fileSystem = requireNonNull(fs);
+  }
+
+
+  /**
+   * Bind to a delegation token retrieved for this filesystem.
+   * Extract the secrets from the token and set internal fields
+   * to the values.
+   * <ol>
+   *   <li>{@link #boundDT} is set to {@code token}.</li>
+   *   <li>{@link #decodedIdentifier} is set to the extracted identifier.</li>
+   *   <li>{@link #accessTokenProvider} is set to the credential
+   *   provider(s) returned by the token binding.</li>
+   * </ol>
+   * @param token token to decode and bind to.
+   * @throws IOException selection/extraction/validation failure.
+   */
+  public void bindToDelegationToken(
+      final Token<AbstractGCPTokenIdentifier> token)
+      throws IOException {
+    Preconditions.checkState((accessTokenProvider == null),
+                             E_ALREADY_DEPLOYED);
+    boundDT = token;
+    AbstractGCPTokenIdentifier dti = extractIdentifier(token);
+    logger.atInfo().log("Using delegation token %s", dti);
+    decodedIdentifier = dti;
+    // extract the credential providers.
+    accessTokenProvider = tokenBinding.bindToTokenIdentifier(dti);
+  }
+
+  /**
+   * Predicate: is there a bound DT?
+   * @return true if there's a value in {@link #boundDT}.
+   */
+  public boolean isBoundToDT() {
+    return (boundDT != null);
+  }
+
+  /**
+   * Get any bound DT.
+   * @return a delegation token if this instance was bound to it.
+   */
+  public Token<AbstractGCPTokenIdentifier> getBoundDT() {
+    return boundDT;
+  }
+
+  /**
+   * Get any bound DT or create a new one.
+   * @return a delegation token.
+   * @throws IOException if one cannot be created
+   */
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  public Token<AbstractGCPTokenIdentifier> getBoundOrNewDT(String renewer)
+      throws IOException {
+    logger.atFine().log("Delegation token requested");
+    if (isBoundToDT()) {
+      // the FS was created on startup with a token, so return it.
+      logger.atFine().log("Returning current token");
+      return getBoundDT();
+    } else {
+      // not bound to a token, so create a new one.
+      // issued DTs are not cached so that long-lived filesystems can
+      // reliably issue session/role tokens.
+      return tokenBinding.createDelegationToken(renewer);
+    }
+  }
+
+  /**
+   * From a token, get the session token identifier.
+   * @param token token to process
+   * @return the session token identifier
+   * @throws IOException failure to validate/read data encoded in identifier.
+   * @throws IllegalArgumentException if the token isn't an GCP session token
+   */
+  public AbstractGCPTokenIdentifier extractIdentifier(
+      final Token<? extends AbstractGCPTokenIdentifier> token)
+      throws IOException {
+    Preconditions.checkArgument(token != null, "null token");
+    AbstractGCPTokenIdentifier identifier;
+    // harden up decode beyond what Token does itself
+    try {
+      identifier = token.decodeIdentifier();
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause != null) {
+        // its a wrapping around class instantiation.
+        throw new DelegationTokenIOException("Decoding GCS token " + cause,
+                                             cause);
+      } else {
+        throw e;
+      }
+    }
+    if (identifier == null) {
+      throw new DelegationTokenIOException("Failed to unmarshall token for "
+          + getUri());
+    }
+    identifier.validate();
+    return identifier;
+  }
+
+  /**
+   * Look up a token from the credentials, verify it is of the correct
+   * kind.
+   * @param credentials credentials to look up.
+   * @param service service name
+   * @param kind token kind to look for
+   * @return the token or null if no suitable token was found
+   * @throws DelegationTokenIOException wrong token kind found
+   */
+  public static Token<AbstractGCPTokenIdentifier> lookupToken(
+      final Credentials credentials,
+      final Text service,
+      final Text kind)
+      throws DelegationTokenIOException {
+    logger.atFine().log("Looking for token for service %s in credentials", service);
+    Token<?> token = credentials.getToken(service);
+    if (token != null) {
+      Text tokenKind = token.getKind();
+      logger.atFine().log("Found token of kind %s", tokenKind);
+      if (kind.equals(tokenKind)) {
+        // the Oauth implementation catches and logs here; this one
+        // throws the failure up.
+        return (Token<AbstractGCPTokenIdentifier>) token;
+      } else {
+        // there's a token for this URI, but its not the right DT kind
+        throw DelegationTokenIOException.tokenMismatch(service, kind, tokenKind);
+      }
+    }
+    // A token for the service was not found
+    logger.atFine().log("No token for %s found", service);
+    return null;
+  }
+
+  /**
+   * Look up any token from the service; cast it to one of ours.
+   * @param credentials credentials
+   * @param service service to look up
+   * @return any token found or null if none was
+   * @throws ClassCastException if the token is of a wrong type.
+   */
+  public static Token<AbstractGCPTokenIdentifier> lookupToken(
+      final Credentials credentials,
+      final Text service) {
+    Token<AbstractGCPTokenIdentifier> result = null;
+    Token<?> token = credentials.getToken(service);
+    if (token != null) {
+      result = (Token<AbstractGCPTokenIdentifier>) token;
+    }
+    return result;
+  }
+
+  /**
+   * Look for any GCP token for the given FS service.
+   * @param credentials credentials to scan.
+   * @param uri the URI of the FS to look for
+   * @return the token or null if none was found
+   */
+  public static Token<AbstractGCPTokenIdentifier> lookupGCPDelegationToken(
+      final Credentials credentials,
+      final URI uri) throws DelegationTokenIOException {
+    return lookupToken(credentials, new Text(uri.toString()));
+  }
+
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GCSDtFetcher.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GCSDtFetcher.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.DtFetcher;
+import org.apache.hadoop.security.token.Token;
+
+import java.net.URI;
+
+/**
+ * A DT fetcher for GCS.
+ * This is a copy-and-paste of
+ * {@code org.apache.hadoop.hdfs.HdfsDtFetcher}.
+ */
+public class GCSDtFetcher implements DtFetcher {
+
+  private static final String SERVICE_NAME = "gs";
+
+  private static final String FETCH_FAILED =
+      "Filesystem not generating Delegation Tokens";
+
+  /**
+   * Returns the service name for GCS, which is also a valid URL prefix.
+   */
+  public Text getServiceName() {
+    return new Text(SERVICE_NAME);
+  }
+
+  public boolean isTokenRequired() {
+    return UserGroupInformation.isSecurityEnabled();
+  }
+
+  /**
+   *  Returns Token object via FileSystem, null if bad argument.
+   *  @param conf - a Configuration object used with FileSystem.get()
+   *  @param creds - a Credentials object to which token(s) will be added
+   *  @param renewer  - the renewer to send with the token request
+   *  @param url  - the URL to which the request is sent
+   *  @return a Token, or null if fetch fails.
+   */
+  public Token<?> addDelegationTokens(Configuration conf,
+                                      Credentials creds,
+                                      String renewer,
+                                      String url) throws Exception {
+    if (!url.startsWith(SERVICE_NAME)) {
+      url = SERVICE_NAME + "://" + url;
+    }
+    FileSystem fs = FileSystem.get(URI.create(url), conf);
+    Token<?> token = fs.getDelegationToken(renewer);
+    if (token == null) {
+      throw new DelegationTokenIOException(FETCH_FAILED + ": " + url);
+    }
+    creds.addToken(token.getService(), token);
+    return token;
+  }
+}
+

--- a/gcs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
+++ b/gcs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.google.cloud.hadoop.fs.gcs.auth.GCSDtFetcher

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemDelegationTokensTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemDelegationTokensTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs;
+
+import com.google.cloud.hadoop.fs.gcs.auth.AbstractGCPTokenIdentifier;
+import com.google.cloud.hadoop.fs.gcs.auth.GCSDelegationTokens;
+import com.google.cloud.hadoop.fs.gcs.auth.TestDelegationTokenBindingImpl;
+import com.google.cloud.hadoop.fs.gcs.auth.TestTokenIdentifierImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class GoogleHadoopFileSystemDelegationTokensTest {
+
+  /**
+   * Verifies that a configured delegation token binding is correctly loaded and employed
+   */
+  @Test
+  public void testDelegationTokenBinding() {
+    final URI initUri = (new Path("gs://" + "test/")).toUri();
+    final Text expectedKind = TestTokenIdentifierImpl.KIND;
+
+    GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem();
+    try {
+      fs.initialize(initUri, loadConfig());
+
+      // Request a delegation token
+      Token<?> dt = fs.getDelegationToken(null);
+      assertNotNull("Expected a delegation token", dt);
+      assertEquals("Unexpected delegation token service", initUri.toString(), dt.getService().toString());
+      assertEquals("Unexpected delegation token kind", expectedKind, dt.getKind());
+
+      // Validate the associated identifier
+      TokenIdentifier decoded = dt.decodeIdentifier();
+      assertNotNull("Failed to decode token identifier", decoded);
+      assertTrue("Unexpected delegation token identifier type", (decoded instanceof TestTokenIdentifierImpl));
+
+      AbstractGCPTokenIdentifier identifier = (AbstractGCPTokenIdentifier) decoded;
+      assertEquals("Unexpected delegation token identifier kind", expectedKind, identifier.getKind());
+      assertEquals("Unexpected delegation token URI", initUri, identifier.getUri());
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  private Configuration loadConfig() {
+    Configuration config = new Configuration();
+
+    config.set(GoogleHadoopFileSystemBase.GCS_PROJECT_ID_KEY, "test_project");
+    config.setInt(GoogleHadoopFileSystemBase.BUFFERSIZE_KEY, 512);
+    config.setLong(GoogleHadoopFileSystemBase.BLOCK_SIZE_KEY, 1024);
+
+    // Token binding config
+    config.set(GCSDelegationTokens.CONFIG_DELEGATION_TOKEN_BINDING_CLASS,
+               TestDelegationTokenBindingImpl.class.getName());
+    config.set(TestDelegationTokenBindingImpl.TestAccessTokenProviderImpl.TOKEN_CONFIG_PROPERTY_NAME,
+               "qWDAWFA3WWFAWFAWFAW3FAWF3AWF3WFAF33GR5G5"); // Bogus auth token
+
+    return config;
+  }
+
+
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/auth/TestDelegationTokenBindingImpl.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/auth/TestDelegationTokenBindingImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+
+/**
+ * A test delegation token binding implementation
+ */
+public class TestDelegationTokenBindingImpl extends AbstractDelegationTokenBinding {
+
+  public TestDelegationTokenBindingImpl() {
+    super(TestTokenIdentifierImpl.KIND);
+  }
+
+  @Override
+  public AccessTokenProvider deployUnbonded() throws IOException {
+    return new TestAccessTokenProviderImpl();
+  }
+
+  @Override
+  public AccessTokenProvider bindToTokenIdentifier(AbstractGCPTokenIdentifier retrievedIdentifier) throws IOException {
+    return deployUnbonded();
+  }
+
+  @Override
+  public AbstractGCPTokenIdentifier createTokenIdentifier(Text renewer) throws IOException {
+    return new TestTokenIdentifierImpl(getFileSystem().getUri(), new Text("owner_name"), "Test");
+  }
+
+  @Override
+  public AbstractGCPTokenIdentifier createTokenIdentifier() throws IOException {
+    return createEmptyIdentifier();
+  }
+
+  @Override
+  public AbstractGCPTokenIdentifier createEmptyIdentifier() {
+    return new TestTokenIdentifierImpl();
+  }
+
+  public static class TestAccessTokenProviderImpl implements AccessTokenProvider {
+
+    public static final String TOKEN_CONFIG_PROPERTY_NAME = "test.token.value";
+
+    private Configuration config = null;
+
+    @Override
+    public AccessToken getAccessToken() {
+      return new AccessToken(config.get(TOKEN_CONFIG_PROPERTY_NAME),
+          System.currentTimeMillis() + 60000);
+    }
+
+    @Override
+    public void refresh() throws IOException {
+      //
+    }
+
+    @Override
+    public void setConf(Configuration configuration) {
+      this.config = configuration;
+    }
+
+    @Override
+    public Configuration getConf() {
+      return config;
+    }
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/auth/TestTokenIdentifierImpl.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/auth/TestTokenIdentifierImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.hadoop.fs.gcs.auth;
+
+import org.apache.hadoop.io.Text;
+
+import java.net.URI;
+
+/**
+ * A test delegation token identifier implementation
+ */
+public class TestTokenIdentifierImpl extends AbstractGCPTokenIdentifier {
+
+  public static final Text KIND = new Text("GCPDelegationToken/Test");
+
+  public TestTokenIdentifierImpl() {
+    super(KIND);
+  }
+
+  public TestTokenIdentifierImpl(URI uri, Text owner, String origin) {
+    super(KIND, uri, owner, origin);
+  }
+}
+

--- a/gcs/src/test/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/gcs/src/test/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.google.cloud.hadoop.fs.gcs.auth.TestTokenIdentifierImpl

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/CredentialFromAccessTokenProviderClassFactory.java
@@ -89,6 +89,19 @@ public final class CredentialFromAccessTokenProviderClassFactory {
    * provider, return null.
    */
   public static Credential credential(
+    AccessTokenProvider accessTokenProvider,
+    Collection<String> scopes)
+    throws IOException, GeneralSecurityException {
+    return getCredentialFromAccessTokenProvider(accessTokenProvider, scopes);
+  }
+
+  /**
+   * Generate the credential.
+   *
+   * <p>If the {@link AccessTokenProviderClassFromConfigFactory} generates no Class for the
+   * provider, return null.
+   */
+  public static Credential credential(
       AccessTokenProviderClassFromConfigFactory providerClassFactory,
       Configuration config,
       Collection<String> scopes)


### PR DESCRIPTION
These changes provide an extension point for supporting delegation tokens, similar to what has been done for the s3a file system ([HADOOP-14556](https://issues.apache.org/jira/browse/HADOOP-14556)).