### PR TITLE
Make it possible to set `fs.gs.system.bucket` to an empty string

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -16,6 +16,10 @@
 
       fs.gs.lazy.init.enable (default: false)
 
+  5. Add ability to unset `fs.gs.system.bucket` with an empty string value:
+
+      fs.gs.system.bucket=
+
 
 1.9.10 - 2018-11-01
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -78,7 +78,7 @@ public class GoogleHadoopFileSystem extends GoogleHadoopFileSystemBase {
     if (rootBucket != null) {
       // Validate root bucket name
       pathCodec.getPath(rootBucket, null, true);
-    } else if (systemBucket != null && !systemBucket.isEmpty()) {
+    } else if (systemBucket != null) {
       logger.atWarning().log(
           "GHFS.configureBuckets: Warning. No GCS bucket provided. "
               + "Falling back on deprecated fs.gs.system.bucket.");

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -78,7 +78,7 @@ public class GoogleHadoopFileSystem extends GoogleHadoopFileSystemBase {
     if (rootBucket != null) {
       // Validate root bucket name
       pathCodec.getPath(rootBucket, null, true);
-    } else if (systemBucket != null) {
+    } else if (systemBucket != null && !systemBucket.isEmpty()) {
       logger.atWarning().log(
           "GHFS.configureBuckets: Warning. No GCS bucket provided. "
               + "Falling back on deprecated fs.gs.system.bucket.");

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -1657,7 +1657,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
     logger.atFine().log("GHFS.configureBuckets: %s, %s", systemBucketName, createSystemBucket);
 
     systemBucket = systemBucketName;
-    if (systemBucket != null) {
+    if (systemBucket != null && !systemBucket.isEmpty()) {
       logger.atFine().log("GHFS.configureBuckets: Warning fs.gs.system.bucket is deprecated.");
       // Ensure that system bucket exists. It really must be a bucket, not a GCS path.
       URI systemBucketPath =

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -33,6 +33,7 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.PERMISSIONS_TO_REPORT;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.flogger.LazyArgs.lazy;
 
 import com.google.api.client.auth.oauth2.Credential;
@@ -1557,7 +1558,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
     // Set this configuration as the default config for this instance.
     setConf(config);
 
-    systemBucket = GCS_SYSTEM_BUCKET.get(config, config::get);
+    systemBucket = emptyToNull(GCS_SYSTEM_BUCKET.get(config, config::get));
     enableFlatGlob = GCS_FLAT_GLOB_ENABLE.get(config, config::getBoolean);
     enableConcurrentGlob = GCS_CONCURRENT_GLOB_ENABLE.get(config, config::getBoolean);
     checksumType = GCS_FILE_CHECKSUM_TYPE.get(config, config::getEnum);
@@ -1657,7 +1658,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
     logger.atFine().log("GHFS.configureBuckets: %s, %s", systemBucketName, createSystemBucket);
 
     systemBucket = systemBucketName;
-    if (systemBucket != null && !systemBucket.isEmpty()) {
+    if (systemBucket != null) {
       logger.atFine().log("GHFS.configureBuckets: Warning fs.gs.system.bucket is deprecated.");
       // Ensure that system bucket exists. It really must be a bucket, not a GCS path.
       URI systemBucketPath =

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -419,6 +419,48 @@ public class GoogleHadoopFileSystemIntegrationTest
     assertThat(fs.getRootBucketName()).isEqualTo(systemBucketName);
   }
 
+  /**
+   * Validates success path when there is a root bucket but no system bucket is specified.
+   * @throws IOException
+   */
+  @Test @Override
+  public void testConfigureBucketsWithRootBucketButNoSystemBucket() throws IOException {
+    String systemBucketName = "";
+    String rootBucketName = ghfsHelper.getUniqueBucketName("configure-root");
+    URI initUri = (new Path("gs://" + rootBucketName)).toUri();
+    GoogleCloudStorageFileSystem fakeGcsFs =
+            new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
+    GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem(fakeGcsFs);
+    fs.initUri = initUri;
+    fs.configureBuckets(fakeGcsFs, systemBucketName,true);
+
+    // Verify that config settings were set correctly.
+    assertThat(fs.getSystemBucketName()).isEqualTo("");
+    assertThat(fs.initUri).isEqualTo(initUri);
+  }
+
+  /**
+   * Validates that a system bucket is required if no root bucket is specified.
+   * @throws IOException
+   */
+  @Test @Override
+  public void testConfigureBucketsWithNeitherRootBucketNorSystemBucket() throws IOException {
+    String systemBucketName = "";
+    URI initUri = (new Path("gs://")).toUri();
+    final GoogleCloudStorageFileSystem fakeGcsFs =
+            new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
+    final GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem(fakeGcsFs);
+    fs.initUri = initUri;
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                fs.configureBuckets(fakeGcsFs, systemBucketName,true));
+
+    assertThat(thrown).hasMessageThat().isEqualTo("No bucket specified in GCS URI: gs:/");
+  }
+
   @Test
   public void testConfigureBucketsThrowsWhenBucketNotFound() throws IOException {
     GoogleCloudStorageFileSystem fakeGcsFs =

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -419,44 +419,39 @@ public class GoogleHadoopFileSystemIntegrationTest
     assertThat(fs.getRootBucketName()).isEqualTo(systemBucketName);
   }
 
-  /**
-   * Validates success path when there is a root bucket but no system bucket is specified.
-   * @throws IOException
-   */
-  @Test @Override
+  /** Validates success path when there is a root bucket but no system bucket is specified. */
+  @Test
+  @Override
   public void testConfigureBucketsWithRootBucketButNoSystemBucket() throws IOException {
-    String systemBucketName = "";
+    String systemBucketName = null;
     String rootBucketName = ghfsHelper.getUniqueBucketName("configure-root");
     URI initUri = (new Path("gs://" + rootBucketName)).toUri();
     GoogleCloudStorageFileSystem fakeGcsFs =
-            new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
+        new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
     GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem(fakeGcsFs);
     fs.initUri = initUri;
-    fs.configureBuckets(fakeGcsFs, systemBucketName,true);
+    fs.configureBuckets(fakeGcsFs, systemBucketName, true);
 
     // Verify that config settings were set correctly.
-    assertThat(fs.getSystemBucketName()).isEqualTo("");
+    assertThat(fs.getSystemBucketName()).isNull();
     assertThat(fs.initUri).isEqualTo(initUri);
   }
 
-  /**
-   * Validates that a system bucket is required if no root bucket is specified.
-   * @throws IOException
-   */
-  @Test @Override
+  /** Validates that a system bucket is required if no root bucket is specified. */
+  @Test
+  @Override
   public void testConfigureBucketsWithNeitherRootBucketNorSystemBucket() throws IOException {
-    String systemBucketName = "";
+    String systemBucketName = null;
     URI initUri = (new Path("gs://")).toUri();
     final GoogleCloudStorageFileSystem fakeGcsFs =
-            new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
+        new GoogleCloudStorageFileSystem(new InMemoryGoogleCloudStorage());
     final GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem(fakeGcsFs);
     fs.initUri = initUri;
 
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () ->
-                fs.configureBuckets(fakeGcsFs, systemBucketName,true));
+            () -> fs.configureBuckets(fakeGcsFs, systemBucketName, true));
 
     assertThat(thrown).hasMessageThat().isEqualTo("No bucket specified in GCS URI: gs:/");
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -139,6 +139,14 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
   public abstract void testConfigureBucketsSuccess()
       throws URISyntaxException, IOException;
 
+  @Test
+  public abstract void testConfigureBucketsWithRootBucketButNoSystemBucket()
+      throws IOException;
+
+  @Test
+  public abstract void testConfigureBucketsWithNeitherRootBucketNorSystemBucket()
+        throws IOException;
+
   // -----------------------------------------------------------------------------------------
   // Tests that aren't supported by all configurations of GHFS.
   // -----------------------------------------------------------------------------------------

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -140,12 +140,11 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
       throws URISyntaxException, IOException;
 
   @Test
-  public abstract void testConfigureBucketsWithRootBucketButNoSystemBucket()
-      throws IOException;
+  public abstract void testConfigureBucketsWithRootBucketButNoSystemBucket() throws IOException;
 
   @Test
   public abstract void testConfigureBucketsWithNeitherRootBucketNorSystemBucket()
-        throws IOException;
+      throws IOException;
 
   // -----------------------------------------------------------------------------------------
   // Tests that aren't supported by all configurations of GHFS.


### PR DESCRIPTION
Make it possible to set `fs.gs.system.bucket` to an empty string in the case where there is a root bucket.