### PR TITLE
Set default for "fs.gs.working.dir" to "/"

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -148,7 +148,7 @@ public class GoogleHadoopFileSystemConfiguration {
 
   /** Configuration key for initial working directory of a GHFS instance. Default value: '/' */
   public static final GoogleHadoopFileSystemConfigurationProperty<String> GCS_WORKING_DIRECTORY =
-      new GoogleHadoopFileSystemConfigurationProperty<>("fs.gs.working.dir");
+      new GoogleHadoopFileSystemConfigurationProperty<>("fs.gs.working.dir", "/");
 
   /**
    * If true, recursive delete on a path that refers to a GCS bucket itself ('/' for any


### PR DESCRIPTION
The code comment on line 149 was already saying that "/" was the default value, but it was actually not effectively set. This avoids having to manually set the property.