### PR TITLE
Add kmsKeyName to GoogleCloudStorageWriteChannel

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageWriteChannel.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013 Google Inc. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *    
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-/**
- * Implements WritableByteChannel to provide write access to GCS.
- */
+/** Implements WritableByteChannel to provide write access to GCS. */
 public class GoogleCloudStorageWriteChannel
     extends AbstractGoogleAsyncWriteChannel<Insert, StorageObject>
     implements GoogleCloudStorageItemInfo.Provider {
@@ -40,16 +38,16 @@ public class GoogleCloudStorageWriteChannel
   private final Storage gcs;
   private final String bucketName;
   private final String objectName;
+  private final String kmsKeyName;
   private final ObjectWriteConditions writeConditions;
   private final Map<String, String> metadata;
-  private String kmsKeyName;
 
   private GoogleCloudStorageItemInfo completedItemInfo = null;
 
   /**
    * Constructs an instance of GoogleCloudStorageWriteChannel.
    *
-   * @param threadPool thread pool to use for running the upload operation
+   * @param uploadThreadPool thread pool to use for running the upload operation
    * @param gcs storage object instance
    * @param requestHelper a ClientRequestHelper to set extra headers
    * @param bucketName name of the bucket to create object in
@@ -57,8 +55,9 @@ public class GoogleCloudStorageWriteChannel
    * @param writeConditions conditions on which write should be allowed to continue
    * @param objectMetadata metadata to apply to the newly created object
    */
+  @Deprecated
   public GoogleCloudStorageWriteChannel(
-      ExecutorService threadPool,
+      ExecutorService uploadThreadPool,
       Storage gcs,
       ClientRequestHelper<StorageObject> requestHelper,
       String bucketName,
@@ -67,22 +66,22 @@ public class GoogleCloudStorageWriteChannel
       ObjectWriteConditions writeConditions,
       Map<String, String> objectMetadata) {
     this(
-        threadPool,
+        uploadThreadPool,
         gcs,
         requestHelper,
         bucketName,
         objectName,
+        /* contentType= */ null,
+        /* kmsKeyName= */ null,
         options,
         writeConditions,
-        objectMetadata,
-        null,
-        null);
+        objectMetadata);
   }
 
   /**
    * Constructs an instance of GoogleCloudStorageWriteChannel.
    *
-   * @param threadPool thread pool to use for running the upload operation
+   * @param uploadThreadPool thread pool to use for running the upload operation
    * @param gcs storage object instance
    * @param requestHelper a ClientRequestHelper to set extra headers
    * @param bucketName name of the bucket to create object in
@@ -91,8 +90,9 @@ public class GoogleCloudStorageWriteChannel
    * @param objectMetadata metadata to apply to the newly created object
    * @param contentType content type
    */
+  @Deprecated
   public GoogleCloudStorageWriteChannel(
-      ExecutorService threadPool,
+      ExecutorService uploadThreadPool,
       Storage gcs,
       ClientRequestHelper<StorageObject> requestHelper,
       String bucketName,
@@ -102,53 +102,53 @@ public class GoogleCloudStorageWriteChannel
       Map<String, String> objectMetadata,
       String contentType) {
     this(
-        threadPool,
+        uploadThreadPool,
         gcs,
         requestHelper,
         bucketName,
         objectName,
+        contentType,
+        /* kmsKeyName= */ null,
         options,
         writeConditions,
-        objectMetadata,
-        contentType,
-        null);
+        objectMetadata);
   }
 
   /**
    * Constructs an instance of GoogleCloudStorageWriteChannel.
    *
-   * @param threadPool thread pool to use for running the upload operation
+   * @param uploadThreadPool thread pool to use for running the upload operation
    * @param gcs storage object instance
    * @param requestHelper a ClientRequestHelper to set extra headers
    * @param bucketName name of the bucket to create object in
    * @param objectName name of the object to create
-   * @param writeConditions conditions on which write should be allowed to continue
-   * @param objectMetadata metadata to apply to the newly created object
    * @param contentType content type
    * @param kmsKeyName Name of Cloud KMS key to use to encrypt the newly created object
+   * @param writeConditions conditions on which write should be allowed to continue
+   * @param objectMetadata metadata to apply to the newly created object
    */
   public GoogleCloudStorageWriteChannel(
-      ExecutorService threadPool,
+      ExecutorService uploadThreadPool,
       Storage gcs,
       ClientRequestHelper<StorageObject> requestHelper,
       String bucketName,
       String objectName,
+      String contentType,
+      String kmsKeyName,
       AsyncWriteChannelOptions options,
       ObjectWriteConditions writeConditions,
-      Map<String, String> objectMetadata,
-      String contentType,
-      String kmsKeyName) {
-    super(threadPool, options);
-    this.setClientRequestHelper(requestHelper);
+      Map<String, String> objectMetadata) {
+    super(uploadThreadPool, options);
     this.gcs = gcs;
+    this.setClientRequestHelper(requestHelper);
     this.bucketName = bucketName;
     this.objectName = objectName;
-    this.writeConditions = writeConditions;
-    this.metadata = objectMetadata;
     if (contentType != null) {
       setContentType(contentType);
     }
     this.kmsKeyName = kmsKeyName;
+    this.writeConditions = writeConditions;
+    this.metadata = objectMetadata;
   }
 
   @Override


### PR DESCRIPTION
Hi!

I work on github.com/apache/beam.
This PR will allow us to create new GCS objects with user-specified KMS keys.

Beam usage of GoogleCloudStorageWriteChannel: https://github.com/apache/beam/blob/b953645ed6db837d24284d7fe1fe091e7309f821/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java#L417-L426