### PR TITLE
Implement Hadoop File Sytem concat method

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,5 +1,7 @@
 1.9.14 - 2019-XX-XX
 
+  1. Implement Hadoop FileSystem `concat` method using GCS compose API.
+
 
 1.9.13 - 2019-02-04
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -39,6 +39,7 @@ import static com.google.common.flogger.LazyArgs.lazy;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.FileInfo;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage.ListPage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
@@ -202,9 +203,6 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
 
   /** Identifies this version of the GoogleHadoopFileSystemBase library. */
   public static final String GHFS_ID;
-
-  /** The maximum number of objects that can be composed in one operation. */
-  public static final int MAX_COMPOSE_OBJECTS = 32;
 
   static {
     VERSION =
@@ -842,7 +840,7 @@ public abstract class GoogleHadoopFileSystemBase extends GoogleHadoopFileSystemB
 
     Preconditions.checkArgument(!srcPaths.contains(trgPath), "target must not be contained in sources");
 
-    List<List<URI>> partitions = Lists.partition(srcPaths, MAX_COMPOSE_OBJECTS - 1);
+    List<List<URI>> partitions = Lists.partition(srcPaths, GoogleCloudStorage.MAX_COMPOSE_OBJECTS - 1);
     logger.atFine().log("GHFS.concat: %s, %d partitions", trg, partitions.size());
     for (List<URI> partition : partitions) {
       // We need to include the target in the list of sources to compose since

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
@@ -1,0 +1,36 @@
+package com.google.cloud.hadoop.fs.gcs.contract;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractConcatTest;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.assertFileHasLength;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+
+public abstract class AbstractGoogleContractConcatTest extends AbstractContractConcatTest {
+  @Test
+  public void testConcatMultiple() throws Throwable {
+    int numFiles = GoogleHadoopFileSystemBase.MAX_COMPOSE_OBJECTS * 3 / 2;
+    Path testPath = path("test");
+
+    byte[][] blocks = new byte[numFiles][0];
+    Path[] srcs = new Path[numFiles];
+    for (int i = 0; i < numFiles; i++) {
+      Path srcFile = new Path(testPath, "" + i);
+      blocks[i] = dataset(TEST_FILE_LEN, i, 255);
+      createFile(getFileSystem(), srcFile, true, blocks[i]);
+      srcs[i] = srcFile;
+    }
+    Path target = new Path(testPath, "target");
+
+    createFile(getFileSystem(), target, false, new byte[0]);
+    getFileSystem().concat(target, srcs);
+    assertFileHasLength(getFileSystem(), target, TEST_FILE_LEN * numFiles);
+    ContractTestUtils.validateFileContent(
+        ContractTestUtils.readDataset(getFileSystem(),
+            target, TEST_FILE_LEN * numFiles), blocks);
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
@@ -1,6 +1,6 @@
 package com.google.cloud.hadoop.fs.gcs.contract;
 
-import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractConcatTest;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -13,7 +13,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 public abstract class AbstractGoogleContractConcatTest extends AbstractContractConcatTest {
   @Test
   public void testConcatMultiple() throws Throwable {
-    int numFiles = GoogleHadoopFileSystemBase.MAX_COMPOSE_OBJECTS * 3 / 2;
+    int numFiles = GoogleCloudStorage.MAX_COMPOSE_OBJECTS * 3 / 2;
     Path testPath = path("test");
 
     byte[][] blocks = new byte[numFiles][0];

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/AbstractGoogleContractConcatTest.java
@@ -1,16 +1,17 @@
 package com.google.cloud.hadoop.fs.gcs.contract;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.assertFileHasLength;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractConcatTest;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.Test;
 
-import static org.apache.hadoop.fs.contract.ContractTestUtils.assertFileHasLength;
-import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
-import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
-
 public abstract class AbstractGoogleContractConcatTest extends AbstractContractConcatTest {
+
   @Test
   public void testConcatMultiple() throws Throwable {
     int numFiles = GoogleCloudStorage.MAX_COMPOSE_OBJECTS * 3 / 2;
@@ -30,7 +31,6 @@ public abstract class AbstractGoogleContractConcatTest extends AbstractContractC
     getFileSystem().concat(target, srcs);
     assertFileHasLength(getFileSystem(), target, TEST_FILE_LEN * numFiles);
     ContractTestUtils.validateFileContent(
-        ContractTestUtils.readDataset(getFileSystem(),
-            target, TEST_FILE_LEN * numFiles), blocks);
+        ContractTestUtils.readDataset(getFileSystem(), target, TEST_FILE_LEN * numFiles), blocks);
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestGoogleContractConcat.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestGoogleContractConcat.java
@@ -1,0 +1,34 @@
+package com.google.cloud.hadoop.fs.gcs.contract;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/** GCS contract tests covering file concat. */
+public class TestGoogleContractConcat extends AbstractGoogleContractConcatTest {
+
+  private static final TestBucketHelper TEST_BUCKET_HELPER =
+      new TestBucketHelper(GoogleContract.TEST_BUCKET_NAME_PREFIX);
+
+  private static final AtomicReference<GoogleHadoopFileSystem> fs = new AtomicReference<>();
+
+  @Before
+  public void before() {
+    fs.compareAndSet(null, (GoogleHadoopFileSystem) getFileSystem());
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    TEST_BUCKET_HELPER.cleanup(fs.get().getGcsFs().getGcs());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new GoogleContract(conf, TEST_BUCKET_HELPER);
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestGoogleContractConcat.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestGoogleContractConcat.java
@@ -2,12 +2,11 @@ package com.google.cloud.hadoop.fs.gcs.contract;
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.AfterClass;
 import org.junit.Before;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 /** GCS contract tests covering file concat. */
 public class TestGoogleContractConcat extends AbstractGoogleContractConcatTest {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestInMemoryGoogleContractConcat.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/TestInMemoryGoogleContractConcat.java
@@ -1,0 +1,14 @@
+package com.google.cloud.hadoop.fs.gcs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestInMemoryGoogleContractConcat extends AbstractGoogleContractConcatTest {
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new InMemoryGoogleContract(conf);
+  }
+}

--- a/gcs/src/test/resources/contract/gs.xml
+++ b/gcs/src/test/resources/contract/gs.xml
@@ -56,7 +56,7 @@
 
   <property>
     <name>fs.contract.supports-concat</name>
-    <value>false</value>
+    <value>true</value>
   </property>
 
   <property>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -42,6 +42,9 @@ public interface GoogleCloudStorage {
    */
   public static final long MAX_RESULTS_UNLIMITED = -1;
 
+  /** The maximum number of objects that can be composed in one operation. */
+  public static final int MAX_COMPOSE_OBJECTS = 32;
+
   /**
    * Retrieve the options that were used to create this GoogleCloudStorage.
    */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -14,6 +14,8 @@
 
 package com.google.cloud.hadoop.gcsio.testing;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.api.client.util.Clock;
 import com.google.cloud.hadoop.gcsio.CreateBucketOptions;
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
@@ -547,8 +549,9 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       final StorageResourceId destination,
       CreateObjectOptions options)
       throws IOException {
-    Preconditions.checkArgument(sources.size() <= MAX_COMPOSE_OBJECTS,
-        "Cannot compose more than %s sources", MAX_COMPOSE_OBJECTS);
+    checkArgument(
+        sources.size() <= MAX_COMPOSE_OBJECTS,
+        "Can not compose more than %s sources", MAX_COMPOSE_OBJECTS);
     ByteArrayOutputStream tempOutput = new ByteArrayOutputStream();
     for (StorageResourceId sourceId : sources) {
       // TODO(user): If we change to also set generationIds for source objects in the base

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -547,7 +547,8 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       final StorageResourceId destination,
       CreateObjectOptions options)
       throws IOException {
-    Preconditions.checkArgument(sources.size() <= 32, "Cannot compose more than 32 sources");
+    Preconditions.checkArgument(sources.size() <= MAX_COMPOSE_OBJECTS,
+        "Cannot compose more than %s sources", MAX_COMPOSE_OBJECTS);
     ByteArrayOutputStream tempOutput = new ByteArrayOutputStream();
     for (StorageResourceId sourceId : sources) {
       // TODO(user): If we change to also set generationIds for source objects in the base

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -547,6 +547,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       final StorageResourceId destination,
       CreateObjectOptions options)
       throws IOException {
+    Preconditions.checkArgument(sources.size() <= 32, "Cannot compose more than 32 sources");
     ByteArrayOutputStream tempOutput = new ByteArrayOutputStream();
     for (StorageResourceId sourceId : sources) {
       // TODO(user): If we change to also set generationIds for source objects in the base


### PR DESCRIPTION
Adds an implementation of Hadoop FileSystem's concat method using GCS compose.

I have run the unit tests successfully on a GCS bucket, and I have run manual tests that concat thousands of files together.