### PR TITLE
Break and stop the pagination if we have the results

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -6,6 +6,9 @@
 
   3. Do not parallelize GCS list requests, because it leads to too high QPS.
 
+  4. Fix bug when GCS connector lists all files in directory instead of
+     specified limit.
+
 
 1.9.14 - 2019-02-13
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1211,7 +1211,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       }
       pageToken =
           listStorageObjectsAndPrefixesPage(listObject, maxResults, listedObjects, listedPrefixes);
-    } while (pageToken != null && listedObjects.size() < maxResults);
+    } while (pageToken != null
+        && (maxResults <= 0 || listedObjects.size() + listedPrefixes.size() < maxResults));
   }
 
   private String listStorageObjectsAndPrefixesPage(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1211,7 +1211,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       }
       pageToken =
           listStorageObjectsAndPrefixesPage(listObject, maxResults, listedObjects, listedPrefixes);
-    } while (pageToken != null);
+    } while (pageToken != null && listedObjects.size() < maxResults);
   }
 
   private String listStorageObjectsAndPrefixesPage(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -2758,12 +2758,9 @@ public class GoogleCloudStorageTest {
     verify(mockStorageObjectsList, times(2)).execute();
   }
 
-  /**
-   * Test GoogleCloudStorage.listObjectNames(3) with maxResults set.
-   */
+  /** Test GoogleCloudStorage.listObjectNames(3) with maxResults set. */
   @Test
-  public void testListObjectNamesPrefixLimited()
-      throws IOException {
+  public void testListObjectNamesPrefixLimited() throws IOException {
     String objectPrefix = "foo/bar/baz/";
     String delimiter = "/";
     long maxResults = 3;
@@ -2772,17 +2769,18 @@ public class GoogleCloudStorageTest {
         .thenReturn(mockStorageObjectsList);
     when(mockStorageObjectsList.getPrefix()).thenReturn(objectPrefix);
     when(mockStorageObjectsList.execute())
-        .thenReturn(new Objects()
-            .setPrefixes(ImmutableList.of(
-                "foo/bar/baz/dir0/",
-                "foo/bar/baz/dir1/"))
-            .setNextPageToken("token0"))
-        .thenReturn(new Objects()
-            .setItems(ImmutableList.of(
-                new StorageObject().setName("foo/bar/baz/"),
-                new StorageObject().setName("foo/bar/baz/obj0"),
-                new StorageObject().setName("foo/bar/baz/obj1")))
-            .setNextPageToken(null));
+        .thenReturn(
+            new Objects()
+                .setPrefixes(ImmutableList.of("foo/bar/baz/dir0/", "foo/bar/baz/dir1/"))
+                .setItems(
+                    ImmutableList.of(
+                        new StorageObject().setName("foo/bar/baz/"),
+                        new StorageObject().setName("foo/bar/baz/obj0")))
+                .setNextPageToken("token0"))
+        .thenReturn(
+            new Objects()
+                .setItems(ImmutableList.of(new StorageObject().setName("foo/bar/baz/obj1")))
+                .setNextPageToken(null));
 
     List<String> objectNames =
         gcs.listObjectNames(BUCKET_NAME, objectPrefix, delimiter, maxResults);
@@ -2796,9 +2794,8 @@ public class GoogleCloudStorageTest {
     verify(mockStorageObjectsList).setDelimiter(eq(delimiter));
     verify(mockStorageObjectsList).setIncludeTrailingDelimiter(eq(Boolean.FALSE));
     verify(mockStorageObjectsList).setPrefix(eq(objectPrefix));
-    verify(mockStorageObjectsList).setPageToken("token0");
     verify(mockStorageObjectsList).getPrefix();
-    verify(mockStorageObjectsList, times(2)).execute();
+    verify(mockStorageObjectsList).execute();
   }
 
   /**


### PR DESCRIPTION
Hi Googlers,

I would like to suggest the following optimization. Right now the while loop will continue to fetch results while we already have the max results. For example, will become very inefficient when you're looking if a directory exists, and it will fetch all the pages.

This caused our cluster to do 10th of thousands of requests per second, which became quite expensive.

Regards, Fokko