### PR TITLE
Add new DirectBigQueryInputFormat.

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -20,10 +20,10 @@
 
         mapred.bq.output.table.partitioning
 
-1. Add a new `DirectBigQueryInputFormat` for processing data through
-   [BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage/).
+1.  Add a new `DirectBigQueryInputFormat` for processing data through
+    [BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage/).
    
-   This input format is configurable via properties:
+    This input format is configurable via properties:
 
         mapred.bq.input.sql.filter
         mapred.bq.input.selected.fields

--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -20,6 +20,15 @@
 
         mapred.bq.output.table.partitioning
 
+1. Add a new `DirectBigQueryInputFormat` for processing data through
+   [BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage/).
+   
+   This input format is configurable via properties:
+
+        mapred.bq.input.sql.filter
+        mapred.bq.input.selected.fields
+        mapred.bq.input.skew.limit
+
 ### 0.13.14 - 2019-02-13
 
 1.  POM updates for GCS connector 1.9.14.

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -207,6 +207,7 @@
                 <filter>
                   <artifact>com.google.flogger:flogger-log4j-backend</artifact>
                   <includes>
+                    <!--Avoid cleanup with minimizeJar that breaks Log4j logging-->
                     <include>**</include>
                   </includes>
                 </filter>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -93,6 +93,10 @@
       <artifactId>google-api-services-bigquery</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquerystorage</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
@@ -201,11 +205,12 @@
                   </excludes>
                 </filter>
               </filters>
-              <artifactSet>
+              <!--artifactSet>
                 <includes>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.google.api-client</include>
                   <include>com.google.apis</include>
+                  <include>com.google.cloud</include>
                   <include>com.google.cloud.bigdataoss:util</include>
                   <include>com.google.cloud.bigdataoss:util-hadoop</include>
                   <include>com.google.guava</include>
@@ -214,28 +219,42 @@
                   <include>com.google.http-client:google-http-client-jackson2</include>
                   <include>com.google.oauth-client:google-oauth-client</include>
                   <include>com.google.oauth-client:google-oauth-client-java6</include>
+                  <include>io.grpc</include>
+                  <include>io.netty.intern</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>org.apache.httpcomponents:httpcore</include>
-                  <!-- needed by http client and versions conflict -->
+                  < needed by http client and versions conflict
                   <include>commons-codec:commons-codec</include>
                 </includes>
-              </artifactSet>
-              <minimizeJar>true</minimizeJar>
+              </artifactSet-->
+              <!--minimizeJar>true</minimizeJar-->
               <relocations>
                 <relocation>
                   <pattern>com</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.com</shadedPattern>
                   <includes>
                     <include>com.fasterxml.**</include>
-                    <include>com.google.api.**</include>
-                    <include>com.google.cloud.hadoop.util.**</include>
-                    <include>com.google.common.**</include>
+                    <include>com.google.**</include>
                   </includes>
                   <excludes>
+                    <exclude>com.google.cloud.hadoop.io.bigquery.**</exclude>
+                    <exclude>com.google.cloud.hadoop.repackaged.**</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken</exclude>
                   </excludes>
                 </relocation>
+                <!-- Take special care of grpc-netty-shaded, it uses the package
+                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
+                     ServicesResourceTransformer to replace both occurrences of io.grpc -->
+                <relocation>
+                  <pattern>io.grpc.netty.shaded.io.grpc.netty</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.io.grpc.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.io.grpc</shadedPattern>
+                </relocation>
+
                 <relocation>
                   <pattern>org</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.org</shadedPattern>
@@ -243,6 +262,10 @@
                     <include>org.apache.commons.codec.**</include>
                     <include>org.apache.http.**</include>
                   </includes>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_cloud_hadoop_repackaged_bigquery_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -209,6 +209,12 @@
                   </includes>
                 </filter>
                 <filter>
+                  <artifact>com.google.guava:*</artifact>
+                  <includes>
+                    <include>com/google/common/base/*</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>com.google.flogger:flogger-log4j-backend</artifact>
                   <includes>
                     <include>**</include>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -217,6 +217,12 @@
                     <exclude>bigquery.v2.json</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/*.proto</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <artifactSet>
                 <includes>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -191,10 +191,22 @@
                     implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
+                <!--minimizeJar breaks all the dynamic load hacks; add them explicitly-->
+                <filter>
+                  <artifact>io.grpc:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.opencensus:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
                 <filter>
                   <artifact>com.google.flogger:flogger-log4j-backend</artifact>
                   <includes>
-                    <!--Avoid cleanup with minimizeJar that breaks Log4j logging-->
                     <include>**</include>
                   </includes>
                 </filter>
@@ -205,11 +217,14 @@
                   </excludes>
                 </filter>
               </filters>
-              <!--artifactSet>
+              <artifactSet>
                 <includes>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.google.api</include>
+                  <include>com.google.api.grpc</include>
                   <include>com.google.api-client</include>
                   <include>com.google.apis</include>
+                  <include>com.google.auth</include>
                   <include>com.google.cloud</include>
                   <include>com.google.cloud.bigdataoss:util</include>
                   <include>com.google.cloud.bigdataoss:util-hadoop</include>
@@ -219,15 +234,17 @@
                   <include>com.google.http-client:google-http-client-jackson2</include>
                   <include>com.google.oauth-client:google-oauth-client</include>
                   <include>com.google.oauth-client:google-oauth-client-java6</include>
+                  <include>com.google.protobuf</include>
                   <include>io.grpc</include>
-                  <include>io.netty.intern</include>
+                  <include>io.opencensus</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>org.apache.httpcomponents:httpcore</include>
-                  < needed by http client and versions conflict
+                  <include>org.threeten</include>
+                  <!-- needed by http client and versions conflict -->
                   <include>commons-codec:commons-codec</include>
                 </includes>
-              </artifactSet-->
-              <!--minimizeJar>true</minimizeJar-->
+              </artifactSet>
+              <minimizeJar>true</minimizeJar>
               <relocations>
                 <relocation>
                   <pattern>com</pattern>
@@ -254,6 +271,10 @@
                   <pattern>io.grpc</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.io.grpc</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>io.opencensus</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.bigquery.io.opencensus</shadedPattern>
+                </relocation>
 
                 <relocation>
                   <pattern>org</pattern>
@@ -261,6 +282,10 @@
                   <includes>
                     <include>org.apache.commons.codec.**</include>
                     <include>org.apache.http.**</include>
+                    <include>org.checkerframework.**</include>
+                    <include>org.codehaus.mojo.animal_sniffer.**</include>
+                    <include>org.joda.**</include>
+                    <include>org.threeten.**</include>
                   </includes>
                 </relocation>
                 <relocation>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -101,6 +101,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -207,7 +211,6 @@
                 <filter>
                   <artifact>com.google.flogger:flogger-log4j-backend</artifact>
                   <includes>
-                    <!--Avoid cleanup with minimizeJar that breaks Log4j logging-->
                     <include>**</include>
                   </includes>
                 </filter>

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -174,6 +174,11 @@ public class BigQueryConfiguration {
           OUTPUT_TABLE_ID_KEY,
           OUTPUT_TABLE_SCHEMA_KEY);
 
+  public static final String SQL_FILTER_KEY = "mapred.bq.input.sql.filter";
+  public static final String SELECTED_FIELDS_KEY = "mapred.bq.input.selected.fields";
+  public static final String SKEW_LIMIT_KEY = "mapred.bq.input.skew.limit";
+  public static final double SKEW_LIMIT_DEFAULT = 1.5;
+
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   /**

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -174,8 +174,6 @@ public class BigQueryConfiguration {
           OUTPUT_TABLE_ID_KEY,
           OUTPUT_TABLE_SCHEMA_KEY);
 
-  public static final String SQL_FILTER_KEY = "mapred.bq.input.sql.filter";
-  public static final String SELECTED_FIELDS_KEY = "mapred.bq.input.selected.fields";
   public static final String SKEW_LIMIT_KEY = "mapred.bq.input.skew.limit";
   public static final double SKEW_LIMIT_DEFAULT = 1.5;
 

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -174,6 +174,8 @@ public class BigQueryConfiguration {
           OUTPUT_TABLE_ID_KEY,
           OUTPUT_TABLE_SCHEMA_KEY);
 
+  public static final String SQL_FILTER_KEY = "mapred.bq.input.sql.filter";
+  public static final String SELECTED_FIELDS_KEY = "mapred.bq.input.selected.fields";
   public static final String SKEW_LIMIT_KEY = "mapred.bq.input.skew.limit";
   public static final double SKEW_LIMIT_DEFAULT = 1.5;
 

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -54,8 +54,8 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 public class DirectBigQueryInputFormat extends InputFormat<NullWritable, GenericRecord> {
 
   private static final String STANDARD_TABLE_TYPE = "TABLE";
-  private static String DIRECT_PARALLELISM_KEY = MRJobConfig.NUM_MAPS;
-  private static int DIRECT_PARALLELISM_DEFAULT = 10;
+  private static final String DIRECT_PARALLELISM_KEY = MRJobConfig.NUM_MAPS;
+  private static final int DIRECT_PARALLELISM_DEFAULT = 10;
 
   @Override
   public List<InputSplit> getSplits(JobContext context) throws IOException {
@@ -72,9 +72,8 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
             BigQueryConfiguration.SKEW_LIMIT_KEY, BigQueryConfiguration.SKEW_LIMIT_DEFAULT);
     Preconditions.checkArgument(
         skewLimit >= 1.0,
-        String.format(
-            "%s is less than 1; not all records would be read. Exiting",
-            BigQueryConfiguration.SKEW_LIMIT_KEY));
+        "%s is less than 1; not all records would be read. Exiting",
+        BigQueryConfiguration.SKEW_LIMIT_KEY);
     Table table = getTable(configuration, bigQueryHelper);
     ReadSession session = startSession(configuration, table, client);
     long numRows = table.getNumRows().longValue();

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -1,0 +1,199 @@
+package com.google.cloud.hadoop.io.bigquery;
+
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions;
+import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions.Builder;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.DataFormat;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto;
+import com.google.cloud.hadoop.util.ConfigurationUtil;
+import com.google.common.base.Preconditions;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** InputFormat that directly reads data from BigQuery.
+ *
+ */
+@InterfaceStability.Evolving
+public class DirectBigQueryInputFormat extends InputFormat<NullWritable, GenericRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DirectBigQueryInputFormat.class);
+
+  private static final String STANDARD_TABLE_TYPE = "TABLE";
+  private static String DIRECT_PARALLELISM_KEY = MRJobConfig.NUM_MAPS;
+  private static int DIRECT_PARALLELISM_DEFAULT = 10;
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException {
+    final Configuration configuration = context.getConfiguration();
+    BigQueryStorageClient client = getClient(configuration);
+    BigQueryHelper bigQueryHelper;
+    try {
+      bigQueryHelper = getBigQueryHelper(configuration);
+    } catch (GeneralSecurityException gse) {
+      LOG.error("Failed to create BigQuery client", gse);
+      throw new IOException("Failed to create BigQuery client", gse);
+    }
+    double skewLimit = configuration.getDouble(BigQueryConfiguration.SKEW_LIMIT_KEY, BigQueryConfiguration.SKEW_LIMIT_DEFAULT);
+    Preconditions.checkArgument(
+        skewLimit >= 1.0,
+        BigQueryConfiguration.SKEW_LIMIT_KEY + " is less than 1, than not all records would be read. Exiting");
+    Table table = getTable(configuration, bigQueryHelper);
+    ReadSession session = startSession(configuration, table, client);
+    long numRows = table.getNumRows().longValue();
+    long limit = Math.round(skewLimit * numRows / session.getStreamsCount());
+
+    return session.getStreamsList().stream()
+        .map(
+            stream ->
+                new DirectBigQueryInputSplit(
+                    stream.getName(), session.getAvroSchema().getSchema(), limit))
+        .collect(Collectors.toList());
+  }
+
+  private static Table getTable(Configuration configuration, BigQueryHelper bigQueryHelper)
+      throws IOException {
+    Map<String, String> mandatoryConfig =
+        ConfigurationUtil.getMandatoryConfig(
+            configuration, BigQueryConfiguration.MANDATORY_CONFIG_PROPERTIES_INPUT);
+    String inputProjectId = mandatoryConfig.get(BigQueryConfiguration.INPUT_PROJECT_ID_KEY);
+    String datasetId = mandatoryConfig.get(BigQueryConfiguration.INPUT_DATASET_ID_KEY);
+    String tableName = mandatoryConfig.get(BigQueryConfiguration.INPUT_TABLE_ID_KEY);
+
+    TableReference tableReference =
+        new TableReference()
+            .setDatasetId(datasetId)
+            .setProjectId(inputProjectId)
+            .setTableId(tableName);
+    return bigQueryHelper.getTable(tableReference);
+  }
+
+  private static ReadSession startSession(
+      Configuration configuration, Table table, BigQueryStorageClient client) throws IOException {
+    // Extract relevant configuration settings.
+    String jobProjectId = configuration.get(BigQueryConfiguration.PROJECT_ID_KEY);
+    String filter = configuration.get(BigQueryConfiguration.SQL_FILTER_KEY, "");
+    Collection<String> selectedFields = configuration.getStringCollection(
+        BigQueryConfiguration.SELECTED_FIELDS_KEY);
+
+    Builder readOptions = TableReadOptions.newBuilder().setRowRestriction(filter);
+    if (!selectedFields.isEmpty()) {
+      readOptions.addAllSelectedFields(selectedFields);
+    }
+    CreateReadSessionRequest request =
+        CreateReadSessionRequest.newBuilder()
+            .setTableReference(
+                TableReferenceProto.TableReference.newBuilder()
+                    .setDatasetId(table.getTableReference().getDatasetId())
+                    .setProjectId(table.getTableReference().getProjectId())
+                    .setTableId(table.getTableReference().getTableId()))
+            .setRequestedStreams(getParallelism(configuration))
+            .setParent("projects/" + jobProjectId)
+            .setReadOptions(readOptions)
+            .setFormat(DataFormat.AVRO)
+            .build();
+    return client.createReadSession(request);
+  }
+
+  private static int getParallelism(Configuration configuration) {
+    return configuration.getInt(DIRECT_PARALLELISM_KEY, DIRECT_PARALLELISM_DEFAULT);
+  }
+
+  @Override
+  public RecordReader<NullWritable, GenericRecord> createRecordReader(
+      InputSplit inputSplit, TaskAttemptContext context) {
+    return new DirectBigQueryRecordReader();
+  }
+
+  /**
+   * Helper method to override for testing.
+   *
+   * @return Bigquery.
+   * @throws IOException on IO Error.
+   */
+  protected BigQueryStorageClient getClient(Configuration config) throws IOException {
+    return BigQueryStorageClient.create();
+  }
+
+  /** Helper method to override for testing. */
+  protected BigQueryHelper getBigQueryHelper(Configuration config)
+      throws GeneralSecurityException, IOException {
+    BigQueryFactory factory = new BigQueryFactory();
+    return factory.getBigQueryHelper(config);
+  }
+
+  /** InputSplit containing session metadata. */
+  public static class DirectBigQueryInputSplit extends InputSplit implements Writable {
+
+    private String name;
+    private String schema;
+    private long limit;
+
+    public DirectBigQueryInputSplit() {}
+
+    public DirectBigQueryInputSplit(String name, String schema, long limit) {
+      this.name = name;
+      this.schema = schema;
+      this.limit = limit;
+    }
+
+    @Override
+    public long getLength() {
+      // Unknown because of dynamic allocation
+      return -1;
+    }
+
+    @Override
+    public String[] getLocations() {
+      return new String[0];
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+      out.writeUTF(name);
+      out.writeUTF(schema);
+      out.writeLong(limit);
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+      name = in.readUTF();
+      schema = in.readUTF();
+      limit = in.readLong();
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getSchema() {
+      return schema;
+    }
+
+    public long getLimit() {
+      return limit;
+    }
+  }
+}

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -47,8 +47,8 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 /**
- * InputFormat that directly reads data from BigQuery using the BigQuery Storage API.
- * See https://cloud.google.com/bigquery/docs/reference/storage/.
+ * InputFormat that directly reads data from BigQuery using the BigQuery Storage API. See
+ * https://cloud.google.com/bigquery/docs/reference/storage/.
  */
 @InterfaceStability.Evolving
 public class DirectBigQueryInputFormat extends InputFormat<NullWritable, GenericRecord> {
@@ -67,8 +67,9 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
     } catch (GeneralSecurityException gse) {
       throw new IOException("Failed to create BigQuery client", gse);
     }
-    double skewLimit = configuration
-        .getDouble(BigQueryConfiguration.SKEW_LIMIT_KEY, BigQueryConfiguration.SKEW_LIMIT_DEFAULT);
+    double skewLimit =
+        configuration.getDouble(
+            BigQueryConfiguration.SKEW_LIMIT_KEY, BigQueryConfiguration.SKEW_LIMIT_DEFAULT);
     Preconditions.checkArgument(
         skewLimit >= 1.0,
         String.format(
@@ -109,8 +110,8 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
     // Extract relevant configuration settings.
     String jobProjectId = configuration.get(BigQueryConfiguration.PROJECT_ID_KEY);
     String filter = configuration.get(BigQueryConfiguration.SQL_FILTER_KEY, "");
-    Collection<String> selectedFields = configuration.getStringCollection(
-        BigQueryConfiguration.SELECTED_FIELDS_KEY);
+    Collection<String> selectedFields =
+        configuration.getStringCollection(BigQueryConfiguration.SELECTED_FIELDS_KEY);
 
     Builder readOptions = TableReadOptions.newBuilder().setRowRestriction(filter);
     if (!selectedFields.isEmpty()) {
@@ -151,26 +152,21 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
     return BigQueryStorageClient.create();
   }
 
-  /**
-   * Helper method to override for testing.
-   */
+  /** Helper method to override for testing. */
   protected BigQueryHelper getBigQueryHelper(Configuration config)
       throws GeneralSecurityException, IOException {
     BigQueryFactory factory = new BigQueryFactory();
     return factory.getBigQueryHelper(config);
   }
 
-  /**
-   * InputSplit containing session metadata.
-   */
+  /** InputSplit containing session metadata. */
   public static class DirectBigQueryInputSplit extends InputSplit implements Writable {
 
     private String name;
     private String schema;
     private long limit;
 
-    public DirectBigQueryInputSplit() {
-    }
+    public DirectBigQueryInputSplit() {}
 
     public DirectBigQueryInputSplit(String name, String schema, long limit) {
       this.name = name;
@@ -221,7 +217,7 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
     }
 
     private Object[] vals() {
-      return new Object[]{name, schema, limit};
+      return new Object[] {name, schema, limit};
     }
 
     @Override

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 @InterfaceStability.Evolving
 public class DirectBigQueryInputFormat extends InputFormat<NullWritable, GenericRecord> {
 
-  private static final String STANDARD_TABLE_TYPE = "TABLE";
   private static final String DIRECT_PARALLELISM_KEY = MRJobConfig.NUM_MAPS;
   private static final int DIRECT_PARALLELISM_DEFAULT = 10;
 
@@ -105,7 +104,7 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
   }
 
   private static ReadSession startSession(
-      Configuration configuration, Table table, BigQueryStorageClient client) throws IOException {
+      Configuration configuration, Table table, BigQueryStorageClient client) {
     // Extract relevant configuration settings.
     String jobProjectId = configuration.get(BigQueryConfiguration.PROJECT_ID_KEY);
     String filter = configuration.get(BigQueryConfiguration.SQL_FILTER_KEY, "");
@@ -215,7 +214,7 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
       return Objects.hash(name, schema, limit);
     }
 
-    private Object[] vals() {
+    private Object[] values() {
       return new Object[] {name, schema, limit};
     }
 
@@ -224,7 +223,7 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
       if (!(o instanceof DirectBigQueryInputSplit)) {
         return false;
       }
-      return Arrays.equals(vals(), ((DirectBigQueryInputSplit) o).vals());
+      return Arrays.equals(values(), ((DirectBigQueryInputSplit) o).values());
     }
 
     @Override

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -11,6 +11,7 @@ import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
 import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto;
 import com.google.cloud.hadoop.util.ConfigurationUtil;
 import com.google.common.base.Preconditions;
+import com.google.common.flogger.FluentLogger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -32,8 +34,6 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * InputFormat that directly reads data from BigQuery.
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public class DirectBigQueryInputFormat extends InputFormat<NullWritable, GenericRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DirectBigQueryInputFormat.class);
+  private static final FluentLogger LOG = FluentLogger.forEnclosingClass();
 
   private static final String STANDARD_TABLE_TYPE = "TABLE";
   private static String DIRECT_PARALLELISM_KEY = MRJobConfig.NUM_MAPS;
@@ -55,7 +55,7 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
     try {
       bigQueryHelper = getBigQueryHelper(configuration);
     } catch (GeneralSecurityException gse) {
-      LOG.error("Failed to create BigQuery client", gse);
+      LOG.at(Level.SEVERE).log("Failed to create BigQuery client", gse);
       throw new IOException("Failed to create BigQuery client", gse);
     }
     double skewLimit = configuration

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -107,9 +107,9 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
       Configuration configuration, Table table, BigQueryStorageClient client) {
     // Extract relevant configuration settings.
     String jobProjectId = configuration.get(BigQueryConfiguration.PROJECT_ID_KEY);
-    String filter = configuration.get("mapred.bq.input.sql.filter", "");
+    String filter = configuration.get(BigQueryConfiguration.SQL_FILTER_KEY, "");
     Collection<String> selectedFields =
-        configuration.getStringCollection("mapred.bq.input.selected.fields");
+        configuration.getStringCollection(BigQueryConfiguration.SELECTED_FIELDS_KEY);
 
     Builder readOptions = TableReadOptions.newBuilder().setRowRestriction(filter);
     if (!selectedFields.isEmpty()) {

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormat.java
@@ -107,9 +107,9 @@ public class DirectBigQueryInputFormat extends InputFormat<NullWritable, Generic
       Configuration configuration, Table table, BigQueryStorageClient client) {
     // Extract relevant configuration settings.
     String jobProjectId = configuration.get(BigQueryConfiguration.PROJECT_ID_KEY);
-    String filter = configuration.get(BigQueryConfiguration.SQL_FILTER_KEY, "");
+    String filter = configuration.get("mapred.bq.input.sql.filter", "");
     Collection<String> selectedFields =
-        configuration.getStringCollection(BigQueryConfiguration.SELECTED_FIELDS_KEY);
+        configuration.getStringCollection("mapred.bq.input.selected.fields");
 
     Builder readOptions = TableReadOptions.newBuilder().setRowRestriction(filter);
     if (!selectedFields.isEmpty()) {

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -1,0 +1,147 @@
+package com.google.cloud.hadoop.io.bigquery;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamPosition;
+import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat.DirectBigQueryInputSplit;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+/** */
+public class DirectBigQueryRecordReader extends RecordReader<NullWritable, GenericRecord> {
+
+  private Schema schema;
+  private Stream stream;
+  private Parser parser = new Parser();
+  private GenericRecord current;
+  private boolean finalized;
+  private long limit;
+  private long idx;
+  private BigQueryStorageClient client;
+  private Iterator<ReadRowsResponse> responseIterator;
+  private Iterator<GenericRecord> recordIterator;
+
+  @Override
+  public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException {
+    DirectBigQueryInputSplit split =
+        (DirectBigQueryInputSplit) genericSplit;
+    schema = parser.parse(checkNotNull(split.getSchema(), "schema"));
+
+    stream = Stream.newBuilder().setName(checkNotNull(split.getName(), "name")).build();
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setReadPosition(StreamPosition.newBuilder().setStream(stream).build())
+            .build();
+
+    client = getClient(context.getConfiguration());
+    responseIterator = client.readRowsCallable().call(request).iterator();
+    recordIterator = Collections.emptyIterator();
+
+    limit = split.getLimit();
+    idx = 0;
+    finalized = false;
+  }
+
+  @Override
+  public boolean nextKeyValue() {
+    // Finalize reader once we hit limit. We must at that point keep reading until BigQuery stops
+    // sending records.
+    if (idx >= limit && !finalized) {
+      client.finalizeStream(stream);
+      finalized = true;
+    }
+    idx++;
+
+    // TODO: unwrap runtime exceptions thrown by responseIterator:
+    // RE(InterruptedException) -> InterruptedException
+    // RE(StatusException) -> IOException
+    // See ClientCalls.BlockingResponseStream.hasNext
+    if (responseIterator.hasNext() && !recordIterator.hasNext()) {
+      recordIterator =
+          new AvroRecordIterator(
+              schema, responseIterator.next().getAvroRows().getSerializedBinaryRows());
+    }
+    if (recordIterator.hasNext()) {
+      current = recordIterator.next();
+      return true;
+    }
+    current = null;
+    return false;
+  }
+
+  @Override
+  public NullWritable getCurrentKey() {
+    return NullWritable.get();
+  }
+
+  @Override
+  public GenericRecord getCurrentValue() {
+    return current;
+  }
+
+  @Override
+  public float getProgress() {
+    // TODO: report progress
+    return -1;
+  }
+
+  @Override
+  public void close() {}
+
+  /**
+   * Helper method to override for testing.
+   *
+   * @return Bigquery.
+   * @throws IOException on IO Error.
+   */
+  protected BigQueryStorageClient getClient(Configuration conf) throws IOException {
+    return BigQueryStorageClient.create();
+  }
+
+  private static class AvroRecordIterator implements Iterator<GenericRecord> {
+
+    private final BinaryDecoder in;
+    private final GenericDatumReader<GenericRecord> reader;
+
+    // TODO: replace nulls with reusable objects
+    public AvroRecordIterator(Schema schema, ByteString bytes) {
+      reader = new GenericDatumReader<>(schema);
+      in = new DecoderFactory().binaryDecoder(bytes.toByteArray(), null);
+    }
+
+    @Override
+    public boolean hasNext() {
+      try {
+        return !in.isEnd();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public GenericRecord next() {
+      try {
+        return reader.read(null, in);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -53,8 +53,7 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
 
   @Override
   public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException {
-    DirectBigQueryInputSplit split =
-        (DirectBigQueryInputSplit) genericSplit;
+    DirectBigQueryInputSplit split = (DirectBigQueryInputSplit) genericSplit;
     schema = parser.parse(checkNotNull(split.getSchema(), "schema"));
 
     stream = Stream.newBuilder().setName(checkNotNull(split.getName(), "name")).build();

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -143,7 +143,7 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
         return !in.isEnd();
       } catch (IOException e) {
         throw new RuntimeException(
-            "Failed to check for more records:\n" + e.getMessage());
+            "Failed to check for more records", e);
       }
     }
 
@@ -153,7 +153,7 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
         return reader.read(null, in);
       } catch (IOException e) {
         throw new RuntimeException(
-            "Failed to read more records:\n" + e.getMessage());
+            "Failed to read more records", e);
       }
     }
   }

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -132,9 +132,9 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
     private final GenericDatumReader<GenericRecord> reader;
 
     // TODO: replace nulls with reusable objects
-    public AvroRecordIterator(Schema schema, ByteString bytes) {
+    AvroRecordIterator(Schema schema, ByteString bytes) {
       reader = new GenericDatumReader<>(schema);
-      in = new DecoderFactory().binaryDecoder(bytes.toByteArray(), null);
+      in = new DecoderFactory().binaryDecoder(bytes.toByteArray(), /* reuse= */ null);
     }
 
     @Override
@@ -142,18 +142,16 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
       try {
         return !in.isEnd();
       } catch (IOException e) {
-        throw new RuntimeException(
-            "Failed to check for more records", e);
+        throw new RuntimeException("Failed to check for more records", e);
       }
     }
 
     @Override
     public GenericRecord next() {
       try {
-        return reader.read(null, in);
+        return reader.read(/* reuse= */ null, in);
       } catch (IOException e) {
-        throw new RuntimeException(
-            "Failed to read more records", e);
+        throw new RuntimeException("Failed to read more records", e);
       }
     }
   }

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -63,11 +63,10 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
   public boolean nextKeyValue() {
     // Finalize reader once we hit limit. We must at that point keep reading until BigQuery stops
     // sending records.
-    if (idx >= limit && !finalized) {
+    if (++idx >= limit && !finalized) {
       client.finalizeStream(stream);
       finalized = true;
     }
-    idx++;
 
     // TODO: unwrap runtime exceptions thrown by responseIterator:
     // RE(InterruptedException) -> InterruptedException

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -24,7 +37,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
-/** */
+/** {@link RecordReader} for {@link DirectBigQueryInputFormat}. */
 public class DirectBigQueryRecordReader extends RecordReader<NullWritable, GenericRecord> {
 
   private Schema schema;

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReader.java
@@ -142,7 +142,8 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
       try {
         return !in.isEnd();
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(
+            "Failed to check for more records:\n" + e.getMessage());
       }
     }
 
@@ -151,7 +152,8 @@ public class DirectBigQueryRecordReader extends RecordReader<NullWritable, Gener
       try {
         return reader.read(null, in);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(
+            "Failed to read more records:\n" + e.getMessage());
       }
     }
   }

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
@@ -113,9 +112,9 @@ public class DirectBigQueryWordCount {
     BigQueryConfiguration.configureBigQueryInput(conf, inputQualifiedTableId);
 
     // Set column and predicate filters
-    conf.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "word,word_count");
-    conf.set(BigQueryConfiguration.SQL_FILTER_KEY, "word >= 'A' AND word <= 'zzz'");
-    conf.set(MRJobConfig.NUM_MAPS, "999");
+    conf.set("spark.hadoop.mapred.bq.input.selected.fields", "word,word_count");
+    conf.set("spark.hadoop.mapred.bq.input.sql.filter", "word >= 'A' AND word <= 'zzz'");
+    conf.set("spark.hadoop.mapreduce.job.maps", "999");
 
     // This helps Hadoop identify the Jar which contains the mapper and reducer by specifying a
     // class in that Jar. This is required if the jar is being passed on the command line to Hadoop.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
@@ -112,9 +113,9 @@ public class DirectBigQueryWordCount {
     BigQueryConfiguration.configureBigQueryInput(conf, inputQualifiedTableId);
 
     // Set column and predicate filters
-    conf.set("spark.hadoop.mapred.bq.input.selected.fields", "word,word_count");
-    conf.set("spark.hadoop.mapred.bq.input.sql.filter", "word >= 'A' AND word <= 'zzz'");
-    conf.set("spark.hadoop.mapreduce.job.maps", "999");
+    conf.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "word,word_count");
+    conf.set(BigQueryConfiguration.SQL_FILTER_KEY, "word >= 'A' AND word <= 'zzz'");
+    conf.set(MRJobConfig.NUM_MAPS, "999");
 
     // This helps Hadoop identify the Jar which contains the mapper and reducer by specifying a
     // class in that Jar. This is required if the jar is being passed on the command line to Hadoop.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -43,8 +43,8 @@ public class DirectBigQueryWordCount {
 
   /** The mapper for our WordCount job. */
   public static class Map extends Mapper<NullWritable, GenericRecord, Text, LongWritable> {
-    private Text word = new Text();
-    private LongWritable count = new LongWritable();
+    private final Text word = new Text();
+    private final LongWritable count = new LongWritable();
 
     @Override
     public void setup(Context context) throws IOException, InterruptedException {}
@@ -60,7 +60,7 @@ public class DirectBigQueryWordCount {
 
   /** The reducer for our WordCount job. */
   public static class Reduce extends Reducer<Text, LongWritable, Text, LongWritable> {
-    private LongWritable count = new LongWritable();
+    private final LongWritable count = new LongWritable();
 
     @Override
     public void reduce(Text word, Iterable<LongWritable> counts, Context context)

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery.samples;
 
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
@@ -75,7 +88,7 @@ public class DirectBigQueryWordCount {
       System.out.println(
           "Usage: hadoop jar bigquery_wordcount.jar [ProjectId] [QualifiedInputTableId] "
               + "[GcsOutputPath]\n"
-              + "    ProjectId - Project under which to issue the BigQuery operations. Also"
+              + "    ProjectId - Project under which to issue the BigQuery operations. Also "
               + "serves as the default project for table IDs which don't explicitly specify a "
               + "project for the table.\n"
               + "    QualifiedInputTableId - Input table ID of the form "
@@ -90,7 +103,7 @@ public class DirectBigQueryWordCount {
     String inputQualifiedTableId = args[1];
     String outputPath = args[2];
 
-    // Create the job and get it's configuration.
+    // Create the job and get its configuration.
     Job job = new Job(parser.getConfiguration(), "wordcount");
     Configuration conf = job.getConfiguration();
 

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -1,0 +1,126 @@
+package com.google.cloud.hadoop.io.bigquery.samples;
+
+import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
+import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat;
+import java.io.IOException;
+import java.util.stream.StreamSupport;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.hadoop.util.GenericOptionsParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An example Hadoop WordCount program that counts the number of times a word appears in a BigQuery
+ * table column.
+ */
+public class DirectBigQueryWordCount {
+  private static final Logger log = LoggerFactory.getLogger(DirectBigQueryWordCount.class);
+
+  /** The mapper for our WordCount job. */
+  public static class Map extends Mapper<NullWritable, GenericRecord, Text, LongWritable> {
+    private Text word = new Text();
+    private LongWritable count = new LongWritable();
+
+    @Override
+    public void setup(Context context) throws IOException, InterruptedException {}
+
+    @Override
+    public void map(NullWritable unusedKey, GenericRecord row, Context context)
+        throws IOException, InterruptedException {
+      word.set(((Utf8) row.get("word")).toString());
+      count.set((Long) row.get("word_count"));
+      context.write(word, count);
+    }
+  }
+
+  /** The reducer for our WordCount job. */
+  public static class Reduce extends Reducer<Text, LongWritable, Text, LongWritable> {
+    private LongWritable count = new LongWritable();
+
+    @Override
+    public void reduce(Text word, Iterable<LongWritable> counts, Context context)
+        throws IOException, InterruptedException {
+      // Add up the values to get a total number of occurrences of our word.
+      count.set(
+          StreamSupport.stream(counts.spliterator(), false)
+              .mapToLong(LongWritable::get).sum());
+      context.write(word, count);
+    }
+  }
+
+  public static void main(String[] args)
+      throws IOException, InterruptedException, ClassNotFoundException {
+
+    // GenericOptionsParser is a utility to parse command line arguments generic to the Hadoop
+    // framework. This example won't cover the specifics, but will recognize several standard
+    // command line arguments, enabling applications to easily specify a namenode, a
+    // ResourceManager, additional configuration resources etc.
+    GenericOptionsParser parser = new GenericOptionsParser(args);
+    args = parser.getRemainingArgs();
+
+    // Make sure we have the right parameters.
+    if (args.length != 3) {
+      System.out.println(
+          "Usage: hadoop jar bigquery_wordcount.jar [ProjectId] [QualifiedInputTableId] "
+              + "[GcsOutputPath]\n"
+              + "    ProjectId - Project under which to issue the BigQuery operations. Also"
+              + "serves as the default project for table IDs which don't explicitly specify a "
+              + "project for the table.\n"
+              + "    QualifiedInputTableId - Input table ID of the form "
+              + "(Optional ProjectId):[DatasetId].[TableId]\n"
+              + "    OutputPath - The output path to write data, e.g. "
+              + "gs://bucket/dir/");
+      System.exit(1);
+    }
+
+    // Get the individual parameters from the command line.
+    String projectId = args[0];
+    String inputQualifiedTableId = args[1];
+    String outputPath = args[2];
+
+    // Create the job and get it's configuration.
+    Job job = new Job(parser.getConfiguration(), "wordcount");
+    Configuration conf = job.getConfiguration();
+
+    // Set the job-level projectId.
+    conf.set(BigQueryConfiguration.PROJECT_ID_KEY, projectId);
+
+    // Configure input and output.
+    BigQueryConfiguration.configureBigQueryInput(conf, inputQualifiedTableId);
+
+    // Set column and predicate filters
+    conf.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "word,word_count");
+    conf.set(BigQueryConfiguration.SQL_FILTER_KEY, "word >= 'A' AND word <= 'zzz'");
+    conf.set(MRJobConfig.NUM_MAPS, "999");
+
+    // This helps Hadoop identify the Jar which contains the mapper and reducer by specifying a
+    // class in that Jar. This is required if the jar is being passed on the command line to Hadoop.
+    job.setJarByClass(DirectBigQueryWordCount.class);
+
+    // Tell the job what the output will be.
+    job.setOutputKeyClass(Text.class);
+    job.setOutputValueClass(LongWritable.class);
+
+    job.setMapperClass(Map.class);
+    job.setReducerClass(Reduce.class);
+
+    job.setInputFormatClass(DirectBigQueryInputFormat.class);
+    job.setOutputFormatClass(TextOutputFormat.class);
+
+    FileOutputFormat.setOutputPath(job, new Path(outputPath));
+
+    job.waitForCompletion(true);
+  }
+}

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/samples/DirectBigQueryWordCount.java
@@ -67,8 +67,7 @@ public class DirectBigQueryWordCount {
         throws IOException, InterruptedException {
       // Add up the values to get a total number of occurrences of our word.
       count.set(
-          StreamSupport.stream(counts.spliterator(), false)
-              .mapToLong(LongWritable::get).sum());
+          StreamSupport.stream(counts.spliterator(), false).mapToLong(LongWritable::get).sum());
       context.write(word, count);
     }
   }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
@@ -53,12 +53,9 @@ import org.mockito.MockitoAnnotations;
 @RunWith(JUnit4.class)
 public class DirectBigQueryInputFormatTest {
 
-  @Mock
-  private BigQueryHelper bqHelper;
-  @Mock
-  private BigQueryStorageClient bqClient;
-  @Mock
-  private TaskAttemptContext taskContext;
+  @Mock private BigQueryHelper bqHelper;
+  @Mock private BigQueryStorageClient bqClient;
+  @Mock private TaskAttemptContext taskContext;
 
   private JobConf config;
   private DirectBigQueryInputFormat input;
@@ -76,14 +73,18 @@ public class DirectBigQueryInputFormatTest {
     MockitoAnnotations.initMocks(this);
 
     // Create table reference.
-    tableRef = new TableReference()
-        .setProjectId(dataProjectId).setDatasetId(datasetId).setTableId(tableId);
+    tableRef =
+        new TableReference()
+            .setProjectId(dataProjectId)
+            .setDatasetId(datasetId)
+            .setTableId(tableId);
 
-    Table table = new Table()
-        .setTableReference(tableRef)
-        .setLocation("test_location")
-        .setNumRows(BigInteger.valueOf(23))
-        .setNumBytes(3L * 128 * 1024 * 1024);
+    Table table =
+        new Table()
+            .setTableReference(tableRef)
+            .setLocation("test_location")
+            .setNumRows(BigInteger.valueOf(23))
+            .setNumBytes(3L * 128 * 1024 * 1024);
 
     when(bqHelper.getTable(any(TableReference.class))).thenReturn(table);
 
@@ -127,15 +128,18 @@ public class DirectBigQueryInputFormatTest {
             .setFormat(DataFormat.AVRO)
             .build();
 
-    ReadSession session = ReadSession.newBuilder()
-        .setAvroSchema(AvroSchema.newBuilder().setSchema("schema").build())
-        .addAllStreams(ImmutableList.of(
-            Stream.newBuilder().setName("stream1").build(),
-            Stream.newBuilder().setName("stream2").build()))
-        .build();
-    ImmutableList<DirectBigQueryInputSplit> expected = ImmutableList.of(
-        new DirectBigQueryInputSplit("stream1", "schema", 14),
-        new DirectBigQueryInputSplit("stream2", "schema", 14));
+    ReadSession session =
+        ReadSession.newBuilder()
+            .setAvroSchema(AvroSchema.newBuilder().setSchema("schema").build())
+            .addAllStreams(
+                ImmutableList.of(
+                    Stream.newBuilder().setName("stream1").build(),
+                    Stream.newBuilder().setName("stream2").build()))
+            .build();
+    ImmutableList<DirectBigQueryInputSplit> expected =
+        ImmutableList.of(
+            new DirectBigQueryInputSplit("stream1", "schema", 14),
+            new DirectBigQueryInputSplit("stream2", "schema", 14));
 
     when(bqClient.createReadSession(any(CreateReadSessionRequest.class))).thenReturn(session);
     try {
@@ -152,8 +156,8 @@ public class DirectBigQueryInputFormatTest {
 
   @Test
   public void createRecordReader() {
-    assertThat(input.createRecordReader(
-        new DirectBigQueryInputSplit("foo", "schema", 7), taskContext))
+    assertThat(
+            input.createRecordReader(new DirectBigQueryInputSplit("foo", "schema", 7), taskContext))
         .isInstanceOf(DirectBigQueryRecordReader.class);
   }
 

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
@@ -95,8 +95,8 @@ public class DirectBigQueryInputFormatTest {
     config.set(BigQueryConfiguration.INPUT_TABLE_ID_KEY, tableId);
     config.set(MRJobConfig.NUM_MAPS, "3");
     config.set(BigQueryConfiguration.SKEW_LIMIT_KEY, "1.2");
-    config.set("mapred.bq.input.sql.filter", "foo == 0");
-    config.set("mapred.bq.input.selected.fields", "foo,bar");
+    config.set(BigQueryConfiguration.SQL_FILTER_KEY, "foo == 0");
+    config.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "foo,bar");
 
     input = new TestDirectBigQueryInputFormat();
   }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
@@ -1,0 +1,159 @@
+package com.google.cloud.hadoop.io.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.cloud.bigquery.storage.v1beta1.AvroProto.AvroSchema;
+import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.DataFormat;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
+import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto;
+import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat.DirectBigQueryInputSplit;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class DirectBigQueryInputFormatTest {
+
+  @Mock
+  private BigQueryHelper bqHelper;
+  @Mock
+  private BigQueryStorageClient bqClient;
+  @Mock
+  private TaskAttemptContext taskContext;
+
+  private JobConf config;
+  private DirectBigQueryInputFormat input;
+  private TableReference tableRef;
+
+  // Sample projectIds for testing; one for owning the BigQuery jobs, another for the
+  // TableReference.
+  private String jobProjectId = "foo-project";
+  private String dataProjectId = "publicdata";
+  private String datasetId = "test_dataset";
+  private String tableId = "test_table";
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    // Create table reference.
+    tableRef = new TableReference()
+        .setProjectId(dataProjectId).setDatasetId(datasetId).setTableId(tableId);
+
+    Table table = new Table()
+        .setTableReference(tableRef)
+        .setLocation("test_location")
+        .setNumRows(BigInteger.valueOf(23))
+        .setNumBytes(3L * 128 * 1024 * 1024);
+
+    when(bqHelper.getTable(any(TableReference.class))).thenReturn(table);
+
+    config = new JobConf();
+    config.set(BigQueryConfiguration.PROJECT_ID_KEY, jobProjectId);
+    config.set(BigQueryConfiguration.INPUT_PROJECT_ID_KEY, dataProjectId);
+    config.set(BigQueryConfiguration.INPUT_DATASET_ID_KEY, datasetId);
+    config.set(BigQueryConfiguration.INPUT_TABLE_ID_KEY, tableId);
+    config.set(MRJobConfig.NUM_MAPS, "3");
+    config.set(BigQueryConfiguration.SKEW_LIMIT_KEY, "1.2");
+    config.set(BigQueryConfiguration.SQL_FILTER_KEY, "foo == 0");
+    config.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "foo,bar");
+
+    input = new TestDirectBigQueryInputFormat();
+  }
+
+  @After
+  public void tearDown() {
+    verifyNoMoreInteractions(bqClient);
+    verifyNoMoreInteractions(bqHelper);
+  }
+
+  @Test
+  public void getSplits() throws IOException {
+    JobContext jobContext = new JobContextImpl(config, new JobID());
+
+    CreateReadSessionRequest request =
+        CreateReadSessionRequest.newBuilder()
+            .setTableReference(
+                TableReferenceProto.TableReference.newBuilder()
+                    .setProjectId("publicdata")
+                    .setDatasetId("test_dataset")
+                    .setTableId("test_table"))
+            .setRequestedStreams(3) // request 3, but only get 2 back
+            .setParent("projects/foo-project")
+            .setReadOptions(
+                TableReadOptions.newBuilder()
+                    .addAllSelectedFields(ImmutableList.of("foo", "bar"))
+                    .setRowRestriction("foo == 0")
+                    .build())
+            .setFormat(DataFormat.AVRO)
+            .build();
+
+    ReadSession session = ReadSession.newBuilder()
+        .setAvroSchema(AvroSchema.newBuilder().setSchema("schema").build())
+        .addAllStreams(ImmutableList.of(
+            Stream.newBuilder().setName("stream1").build(),
+            Stream.newBuilder().setName("stream2").build()))
+        .build();
+    ImmutableList<DirectBigQueryInputSplit> expected = ImmutableList.of(
+        new DirectBigQueryInputSplit("stream1", "schema", 14),
+        new DirectBigQueryInputSplit("stream2", "schema", 14));
+
+    when(bqClient.createReadSession(any(CreateReadSessionRequest.class))).thenReturn(session);
+    try {
+      List<InputSplit> splits = input.getSplits(jobContext);
+      assertThat(splits).containsExactlyElementsIn(expected);
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+
+    verify(bqHelper).getTable(tableRef);
+    verify(bqClient).createReadSession(request);
+  }
+
+  @Test
+  public void createRecordReader() {
+    assertThat(input.createRecordReader(
+        new DirectBigQueryInputSplit("foo", "schema", 7), taskContext))
+        .isInstanceOf(DirectBigQueryRecordReader.class);
+  }
+
+  class TestDirectBigQueryInputFormat extends DirectBigQueryInputFormat {
+
+    @Override
+    protected BigQueryStorageClient getClient(Configuration config) {
+      return bqClient;
+    }
+
+    @Override
+    protected BigQueryHelper getBigQueryHelper(Configuration config) {
+      return bqHelper;
+    }
+  }
+}

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryInputFormatTest.java
@@ -95,8 +95,8 @@ public class DirectBigQueryInputFormatTest {
     config.set(BigQueryConfiguration.INPUT_TABLE_ID_KEY, tableId);
     config.set(MRJobConfig.NUM_MAPS, "3");
     config.set(BigQueryConfiguration.SKEW_LIMIT_KEY, "1.2");
-    config.set(BigQueryConfiguration.SQL_FILTER_KEY, "foo == 0");
-    config.set(BigQueryConfiguration.SELECTED_FIELDS_KEY, "foo,bar");
+    config.set("mapred.bq.input.sql.filter", "foo == 0");
+    config.set("mapred.bq.input.selected.fields", "foo,bar");
 
     input = new TestDirectBigQueryInputFormat();
   }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
@@ -1,7 +1,177 @@
 package com.google.cloud.hadoop.io.bigquery;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import com.google.api.gax.rpc.ServerStream;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.cloud.bigquery.storage.v1beta1.AvroProto.AvroRows;
+import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamPosition;
+import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat.DirectBigQueryInputSplit;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
 public class DirectBigQueryRecordReaderTest {
 
+  // Corresponds to a single nullable INTEGER
+  private static final String RAW_SCHEMA = "{\"type\": \"record\", \"name\": \"__root__\", \"fields\": [{\"name\": \"f0_\", \"type\": [\"null\", \"long\"]}]}";
+  private Schema parsedSchema;
+
+  private static final List<ReadRowsResponse> RESPONSES_123 = ImmutableList.of(
+      ReadRowsResponse.newBuilder()
+          .setAvroRows(AvroRows.newBuilder()
+              .setRowCount(2)
+              .setSerializedBinaryRows(ByteString.copyFrom(new byte[]{2, 2, 2, 4}))) // 1, 2
+          .build(),
+      ReadRowsResponse.newBuilder()
+          .setAvroRows(AvroRows.newBuilder()
+              .setRowCount(1)
+              .setSerializedBinaryRows(ByteString.copyFrom(new byte[]{2, 6}))) // 3
+          .build());
+
+  private DirectBigQueryInputSplit split = new DirectBigQueryInputSplit("session", RAW_SCHEMA, 100);
+  private static final Stream STREAM = Stream.newBuilder().setName("session").build();
+
+  @Mock
+  private BigQueryStorageClient bqClient;
+  // TODO: investigate google-cloud-java test classes to avoid so many mocks.
+  @Mock
+  private ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRows;
+  @Mock
+  private TaskAttemptContext taskContext;
+  @Mock
+  private ServerStream<ReadRowsResponse> rowsStream;
+
+  private DirectBigQueryRecordReader reader;
+
+
+  @Before
+  public void setUp() {
+    // Manually creating the parsed Schema is a pain so duplicate logic
+    Parser parser = new Parser();
+    parsedSchema = parser.parse(RAW_SCHEMA);
+
+    MockitoAnnotations.initMocks(this);
+    when(bqClient.readRowsCallable()).thenReturn(readRows);
+    when(readRows.call(any(ReadRowsRequest.class))).thenReturn(rowsStream);
+
+    reader = new TestDirectBigQueryRecordReader();
+  }
+
+  @After
+  public void tearDown() {
+    verifyNoMoreInteractions(bqClient);
+  }
+
+  private void initialize() throws Exception {
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setReadPosition(StreamPosition.newBuilder().setStream(STREAM))
+            .build();
+
+    reader.initialize(split, taskContext);
+
+    verify(bqClient).readRowsCallable();
+    verify(readRows).call(eq(request));
+  }
+
+  @Test
+  public void testInitialize() throws Exception {
+    initialize();
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    when(rowsStream.iterator()).thenReturn(ImmutableList.<ReadRowsResponse>of().iterator());
+
+    // Set up reader
+    initialize();
+
+    // Don't bother testing current value before nextKeyValue, because it is undefined.
+
+    assertThat(reader.nextKeyValue()).isFalse();
+
+    // Don't bother testing current values after end, because it's undefined.
+  }
+
+  private GenericRecord avroRecord(int i) {
+    Record rec = new Record(parsedSchema);
+    rec.put(0, Integer.toUnsignedLong(i));
+    return rec;
+  }
+
+  @Test
+  public void testRead() throws Exception {
+    when(rowsStream.iterator()).thenReturn(RESPONSES_123.iterator());
+
+    // Set up reader
+    initialize();
+
+    for (int i = 1; i <= 3; i++) {
+      assertThat(reader.nextKeyValue()).isTrue();
+      assertThat(reader.getCurrentKey()).isEqualTo(NullWritable.get());
+      assertThat(reader.getCurrentValue()).isEqualTo(avroRecord(i));
+    }
+    assertThat(reader.nextKeyValue()).isFalse();
+  }
+
+  @Test
+  public void testLimiting() throws Exception {
+    when(rowsStream.iterator()).thenReturn(RESPONSES_123.iterator());
+
+    // Set limit lower
+    split = new DirectBigQueryInputSplit("session", RAW_SCHEMA, 1);
+
+    // Set up reader
+    initialize();
+
+    assertThat(reader.nextKeyValue()).isTrue();
+
+    verify(bqClient).finalizeStream(eq(STREAM));
+
+    assertThat(reader.getCurrentKey()).isEqualTo(NullWritable.get());
+    assertThat(reader.getCurrentValue()).isEqualTo(avroRecord(1));
+
+    // Test that we keep reading anyways
+
+    for (int i = 2; i <= 3; i++) {
+      assertThat(reader.nextKeyValue()).isTrue();
+      assertThat(reader.getCurrentKey()).isEqualTo(NullWritable.get());
+      assertThat(reader.getCurrentValue()).isEqualTo(avroRecord(i));
+    }
+    assertThat(reader.nextKeyValue()).isFalse();
+  }
+
+
+  class TestDirectBigQueryRecordReader extends DirectBigQueryRecordReader {
+
+    @Override
+    protected BigQueryStorageClient getClient(Configuration conf) {
+      return bqClient;
+    }
+  }
 }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
@@ -53,7 +53,7 @@ public class DirectBigQueryRecordReaderTest {
               .setSerializedBinaryRows(ByteString.copyFrom(new byte[]{2, 6}))) // 3
           .build());
 
-  private DirectBigQueryInputSplit split = new DirectBigQueryInputSplit("session", RAW_SCHEMA, 100);
+  private DirectBigQueryInputSplit split = new DirectBigQueryInputSplit("session", RAW_SCHEMA, 5);
   private static final Stream STREAM = Stream.newBuilder().setName("session").build();
 
   @Mock

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
@@ -51,36 +51,37 @@ import org.mockito.MockitoAnnotations;
 public class DirectBigQueryRecordReaderTest {
 
   // Corresponds to a single nullable INTEGER
-  private static final String RAW_SCHEMA = "{\"type\": \"record\", \"name\": \"__root__\", \"fields\": [{\"name\": \"f0_\", \"type\": [\"null\", \"long\"]}]}";
+  private static final String RAW_SCHEMA =
+      "{\"type\": \"record\", \"name\": \"__root__\", \"fields\": [{\"name\": \"f0_\", \"type\":"
+          + " [\"null\", \"long\"]}]}";
   private Schema parsedSchema;
 
-  private static final List<ReadRowsResponse> RESPONSES_123 = ImmutableList.of(
-      ReadRowsResponse.newBuilder()
-          .setAvroRows(AvroRows.newBuilder()
-              .setRowCount(2)
-              .setSerializedBinaryRows(ByteString.copyFrom(new byte[]{2, 2, 2, 4}))) // 1, 2
-          .build(),
-      ReadRowsResponse.newBuilder()
-          .setAvroRows(AvroRows.newBuilder()
-              .setRowCount(1)
-              .setSerializedBinaryRows(ByteString.copyFrom(new byte[]{2, 6}))) // 3
-          .build());
+  private static final List<ReadRowsResponse> RESPONSES_123 =
+      ImmutableList.of(
+          ReadRowsResponse.newBuilder()
+              .setAvroRows(
+                  AvroRows.newBuilder()
+                      .setRowCount(2)
+                      .setSerializedBinaryRows(
+                          ByteString.copyFrom(new byte[] {2, 2, 2, 4}))) // 1, 2
+              .build(),
+          ReadRowsResponse.newBuilder()
+              .setAvroRows(
+                  AvroRows.newBuilder()
+                      .setRowCount(1)
+                      .setSerializedBinaryRows(ByteString.copyFrom(new byte[] {2, 6}))) // 3
+              .build());
 
   private DirectBigQueryInputSplit split = new DirectBigQueryInputSplit("session", RAW_SCHEMA, 5);
   private static final Stream STREAM = Stream.newBuilder().setName("session").build();
 
-  @Mock
-  private BigQueryStorageClient bqClient;
+  @Mock private BigQueryStorageClient bqClient;
   // TODO: investigate google-cloud-java test classes to avoid so many mocks.
-  @Mock
-  private ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRows;
-  @Mock
-  private TaskAttemptContext taskContext;
-  @Mock
-  private ServerStream<ReadRowsResponse> rowsStream;
+  @Mock private ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRows;
+  @Mock private TaskAttemptContext taskContext;
+  @Mock private ServerStream<ReadRowsResponse> rowsStream;
 
   private DirectBigQueryRecordReader reader;
-
 
   @Before
   public void setUp() {
@@ -178,7 +179,6 @@ public class DirectBigQueryRecordReaderTest {
     }
     assertThat(reader.nextKeyValue()).isFalse();
   }
-
 
   class TestDirectBigQueryRecordReader extends DirectBigQueryRecordReader {
 

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
@@ -1,0 +1,7 @@
+package com.google.cloud.hadoop.io.bigquery;
+
+import static org.junit.Assert.*;
+
+public class DirectBigQueryRecordReaderTest {
+
+}

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DirectBigQueryRecordReaderTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/bigquery/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/bigquery/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
     <google.api-bigquery.version>v2-rev20181221-${google.api.version}</google.api-bigquery.version>
     <google.api-storage.version>v1-rev20181109-${google.api.version}</google.api-storage.version>
     <google.auto-value.version>1.6.3</google.auto-value.version>
+    <google.cloud-bigquery-storage.version>0.79.0-alpha</google.cloud-bigquery-storage.version>
     <google.flogger.version>0.3.1</google.flogger.version>
     <google.guava.version>27.0.1-jre</google.guava.version>
     <google.truth.version>0.44</google.truth.version>
@@ -124,6 +125,12 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.two.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -137,6 +144,12 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.two.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -160,6 +173,12 @@
             <artifactId>hadoop-client-api</artifactId>
             <version>${hadoop.three.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -314,6 +333,11 @@
         <version>${google.api-bigquery.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigquerystorage</artifactId>
+        <version>${google.cloud-bigquery-storage.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${google.gson.version}</version>
@@ -450,6 +474,10 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.0</version>
+          <!--I get weird test failures without this-->
+          <configuration>
+            <useSystemClassLoader>false</useSystemClassLoader>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -474,10 +474,6 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.0</version>
-          <!--I get weird test failures without this-->
-          <configuration>
-            <useSystemClassLoader>false</useSystemClassLoader>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <google.api-bigquery.version>v2-rev20181221-${google.api.version}</google.api-bigquery.version>
     <google.api-storage.version>v1-rev20181109-${google.api.version}</google.api-storage.version>
     <google.auto-value.version>1.6.3</google.auto-value.version>
-    <google.cloud-bigquery-storage.version>0.79.0-alpha</google.cloud-bigquery-storage.version>
+    <google.cloud-bigquery-storage.version>0.87.0-alpha</google.cloud-bigquery-storage.version>
     <google.flogger.version>0.3.1</google.flogger.version>
     <google.guava.version>27.0.1-jre</google.guava.version>
     <google.truth.version>0.44</google.truth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <google.api-bigquery.version>v2-rev20181221-${google.api.version}</google.api-bigquery.version>
     <google.api-storage.version>v1-rev20181109-${google.api.version}</google.api-storage.version>
     <google.auto-value.version>1.6.3</google.auto-value.version>
-    <google.cloud-bigquery-storage.version>0.87.0-alpha</google.cloud-bigquery-storage.version>
+    <google.cloud-bigquery-storage.version>0.88.0-alpha</google.cloud-bigquery-storage.version>
     <google.flogger.version>0.3.1</google.flogger.version>
     <google.guava.version>27.0.1-jre</google.guava.version>
     <google.truth.version>0.44</google.truth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,10 @@
     <google.api-bigquery.version>v2-rev20181221-${google.api.version}</google.api-bigquery.version>
     <google.api-storage.version>v1-rev20181109-${google.api.version}</google.api-storage.version>
     <google.auto-value.version>1.6.3</google.auto-value.version>
-    <google.cloud-bigquery-storage.version>0.88.0-alpha</google.cloud-bigquery-storage.version>
+    <google.cloud-bigquery-storage.version>0.95.0-beta</google.cloud-bigquery-storage.version>
     <google.flogger.version>0.3.1</google.flogger.version>
     <google.guava.version>27.0.1-jre</google.guava.version>
+    <google.protobuf.version>3.8.0</google.protobuf.version>
     <google.truth.version>0.44</google.truth.version>
     <hadoop.two.version>2.9.2</hadoop.two.version>
     <hadoop.three.version>3.2.0</hadoop.three.version>
@@ -125,12 +126,6 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.two.version}</version>
             <scope>provided</scope>
-            <exclusions>
-              <exclusion>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>*</artifactId>
-              </exclusion>
-            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -144,12 +139,6 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.two.version}</version>
             <scope>provided</scope>
-            <exclusions>
-              <exclusion>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>*</artifactId>
-              </exclusion>
-            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -173,12 +162,6 @@
             <artifactId>hadoop-client-api</artifactId>
             <version>${hadoop.three.version}</version>
             <scope>provided</scope>
-            <exclusions>
-              <exclusion>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>*</artifactId>
-              </exclusion>
-            </exclusions>
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -342,6 +325,11 @@
         <artifactId>gson</artifactId>
         <version>${google.gson.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${google.protobuf.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
It leverages the new BigQuery Storage Read API to directly stream Avro from BigQuery without using GCS as an intermediary.