### PR TITLE
Add configuration property to set GCS root url

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -20,6 +20,10 @@
   8. Repair implicit directories during delete operations instead of list
      operations.
 
+  9. Add configuration property to set GCS root URL:
+
+       fs.gs.http.rooturl (default: https://www.googleapis.com/)
+
 
 1.9.14 - 2019-02-13
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -23,6 +23,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.GcsFileChecksum
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.OutputStreamType;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.ParentTimestampUpdateIncludePredicate;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.GenerationReadConsistency;
@@ -378,6 +379,15 @@ public class GoogleHadoopFileSystemConfiguration {
       new GoogleHadoopFileSystemConfigurationProperty<>("fs.gs.http.read-timeout", 20 * 1000);
 
   /**
+   * Configuration key for setting GCS root URL. The URL
+   * must be of the form "https://host:port/".
+   */
+  public static final GoogleHadoopFileSystemConfigurationProperty<String> GCS_ROOT_URL =
+          new GoogleHadoopFileSystemConfigurationProperty<>(
+                  "fs.gs.http.rooturl",
+                  GoogleCloudStorageOptions.ROOT_URL_DEFAULT);
+
+  /**
    * Configuration key for setting a proxy for the connector to use to connect to GCS. The proxy
    * must be an HTTP proxy of the form "host:port".
    */
@@ -564,6 +574,7 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_MAX_WAIT_MILLIS_EMPTY_OBJECT_CREATE.get(config, config::getInt))
         .setReadChannelOptions(getReadChannelOptions(config))
         .setWriteChannelOptions(getWriteChannelOptions(config))
+        .setRootUrl(GCS_ROOT_URL.get(config, config::get))
         .setRequesterPaysOptions(getRequesterPaysOptions(config, projectId));
 
     return gcsFsOptionsBuilder;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -238,6 +238,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     this.gcs = new Storage.Builder(
         httpTransport, JSON_FACTORY, httpRequestInitializer)
         .setApplicationName(options.getAppName())
+        .setRootUrl(options.getRootUrl())
         .build();
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -17,6 +17,7 @@ package com.google.cloud.hadoop.gcsio;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.google.api.services.storage.Storage;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.HttpTransportFactory;
@@ -84,6 +85,10 @@ public abstract class GoogleCloudStorageOptions {
   public static final RequesterPaysOptions REQUESTER_PAYS_OPTIONS_DEFAULT =
       RequesterPaysOptions.DEFAULT;
 
+  /** Default setting for root URL pays feature. */
+  public static final String ROOT_URL_DEFAULT =
+      Storage.DEFAULT_ROOT_URL;
+
   public static Builder newBuilder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -103,6 +108,7 @@ public abstract class GoogleCloudStorageOptions {
         .setCopyBatchThreads(COPY_BATCH_THREADS_DEFAULT)
         .setReadChannelOptions(READ_CHANNEL_OPTIONS_DEFAULT)
         .setWriteChannelOptions(ASYNC_WRITE_CHANNEL_OPTIONS_DEFAULT)
+        .setRootUrl(ROOT_URL_DEFAULT)
         .setRequesterPaysOptions(REQUESTER_PAYS_OPTIONS_DEFAULT);
   }
 
@@ -154,6 +160,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract GoogleCloudStorageReadOptions getReadChannelOptions();
 
   public abstract AsyncWriteChannelOptions getWriteChannelOptions();
+
+  public abstract String getRootUrl();
 
   public abstract RequesterPaysOptions getRequesterPaysOptions();
 
@@ -235,6 +243,8 @@ public abstract class GoogleCloudStorageOptions {
           ? writeChannelOptionsBuilder = AsyncWriteChannelOptions.newBuilder()
           : writeChannelOptionsBuilder;
     }
+
+    public abstract Builder setRootUrl(String rootUrl);
 
     public abstract Builder setRequesterPaysOptions(RequesterPaysOptions requesterPaysOptions);
 


### PR DESCRIPTION
This is meant to be used to set GCS root URL to `https://restricted.googleapis.com/` for VPC-SC