### PR TITLE
Add configuration property to override GCS root url for VPC-SC

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -23,6 +23,10 @@
   9. Log HTTP `429 Too Many Requests` responses from GCS at 1 per 10 seconds
      rate.
 
+  10. Add configuration property to force usage of VPC-SC via restricted.googleapis.com:
+
+       `fs.gs.vpcsc.enable` (default: false)
+
 
 1.9.14 - 2019-02-13
 

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -269,7 +269,12 @@
       `fs.gs.requester.pays.mode` property value is set to CUSTOM.
     </description>
   </property>
-
+  <property>
+    <name>fs.gs.vpcsc.enable</name>
+    <description>
+      Optional. Whether or not to override GCS endpoint to restricted.googleapis.com for VPC-SC.
+    </description>
+  </property>
   <property>
     <name>fs.gs.config.override.file</name>
     <description>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -378,6 +378,13 @@ public class GoogleHadoopFileSystemConfiguration {
       new GoogleHadoopFileSystemConfigurationProperty<>("fs.gs.http.read-timeout", 20 * 1000);
 
   /**
+   * Configuration key for enabling VPC-SC override of GCS root URL.
+   */
+  public static final GoogleHadoopFileSystemConfigurationProperty<Boolean> GCS_VPCSC_ENABLE =
+          new GoogleHadoopFileSystemConfigurationProperty<>(
+                  "fs.gs.vpcsc.enable", false);
+
+  /**
    * Configuration key for setting a proxy for the connector to use to connect to GCS. The proxy
    * must be an HTTP proxy of the form "host:port".
    */
@@ -564,6 +571,7 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_MAX_WAIT_MILLIS_EMPTY_OBJECT_CREATE.get(config, config::getInt))
         .setReadChannelOptions(getReadChannelOptions(config))
         .setWriteChannelOptions(getWriteChannelOptions(config))
+        .setVpcSc(GCS_VPCSC_ENABLE.get(config, config::getBoolean))
         .setRequesterPaysOptions(getRequesterPaysOptions(config, projectId));
 
     return gcsFsOptionsBuilder;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -84,6 +84,9 @@ public abstract class GoogleCloudStorageOptions {
   public static final RequesterPaysOptions REQUESTER_PAYS_OPTIONS_DEFAULT =
       RequesterPaysOptions.DEFAULT;
 
+  /** Default setting for VPC-SC flag. */
+  public static final Boolean VPC_SC_DEFAULT = false;
+
   public static Builder newBuilder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -103,6 +106,7 @@ public abstract class GoogleCloudStorageOptions {
         .setCopyBatchThreads(COPY_BATCH_THREADS_DEFAULT)
         .setReadChannelOptions(READ_CHANNEL_OPTIONS_DEFAULT)
         .setWriteChannelOptions(ASYNC_WRITE_CHANNEL_OPTIONS_DEFAULT)
+        .setVpcSc(VPC_SC_DEFAULT)
         .setRequesterPaysOptions(REQUESTER_PAYS_OPTIONS_DEFAULT);
   }
 
@@ -154,6 +158,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract GoogleCloudStorageReadOptions getReadChannelOptions();
 
   public abstract AsyncWriteChannelOptions getWriteChannelOptions();
+
+  public abstract Boolean getVpcSc();
 
   public abstract RequesterPaysOptions getRequesterPaysOptions();
 
@@ -235,6 +241,8 @@ public abstract class GoogleCloudStorageOptions {
           ? writeChannelOptionsBuilder = AsyncWriteChannelOptions.newBuilder()
           : writeChannelOptionsBuilder;
     }
+
+    public abstract Builder setVpcSc(Boolean vpcsc);
 
     public abstract Builder setRequesterPaysOptions(RequesterPaysOptions requesterPaysOptions);
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/VpcScHttpRequestInitializer.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/VpcScHttpRequestInitializer.java
@@ -1,0 +1,24 @@
+package com.google.cloud.hadoop.util;
+
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+
+import java.io.IOException;
+
+public class VpcScHttpRequestInitializer implements HttpRequestInitializer {
+
+    private final HttpRequestInitializer initializer;
+    private final String host;
+
+    public VpcScHttpRequestInitializer(String host, HttpRequestInitializer initializer) {
+        this.host = host;
+        this.initializer = initializer;
+    }
+
+    @Override
+    public void initialize(HttpRequest request) throws IOException {
+        initializer.initialize(request);
+        request.getHeaders().set("Host", host);
+    }
+}


### PR DESCRIPTION
This is meant to be used to set GCS root URL to https://restricted.googleapis.com/ for VPC-SC
Because GCS does not accept `Host: restricted.googleapis.com` a HttpRequestInitializer is used to override the Host header on all requests.