### PR TITLE
Feature/define partition for bigquery import

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -16,6 +16,10 @@
 
 1.  Remove dependency on GCS connector code.
 
+1.  Add a property to specify BigQuery tables partitioning definition:
+
+        mapred.bq.output.table.partitioning
+
 ### 0.13.14 - 2019-02-13
 
 1.  POM updates for GCS connector 1.9.14.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -105,10 +105,10 @@ public class BigQueryConfiguration {
    * a {@link String}.
    */
   public static final String OUTPUT_TABLE_SCHEMA_KEY = "mapred.bq.output.table.schema";
-  
+
   /**
-   * Configuration key for the output table partitioning used by the output format. This key is stored as
-   * a {@link String}.
+   * Configuration key for the output table partitioning used by the output format. This key is
+   * stored as a {@link String}.
    */
   public static final String OUTPUT_TABLE_PARTITIONING_KEY = "mapred.bq.output.table.partitioning";
 

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -105,6 +105,12 @@ public class BigQueryConfiguration {
    * a {@link String}.
    */
   public static final String OUTPUT_TABLE_SCHEMA_KEY = "mapred.bq.output.table.schema";
+  
+  /**
+   * Configuration key for the output table partitioning used by the output format. This key is stored as
+   * a {@link String}.
+   */
+  public static final String OUTPUT_TABLE_PARTITIONING_KEY = "mapred.bq.output.table.partitioning";
 
   /**
    * Configuration key for the Cloud KMS encryption key that will be used to protect output BigQuery

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -139,7 +139,7 @@ public class BigQueryHelper {
         projectId,
         tableRef,
         schema,
-        null,
+        /* timePartitioning= */ null,
         kmsKeyName,
         sourceFormat,
         writeDisposition,
@@ -176,7 +176,7 @@ public class BigQueryHelper {
       boolean awaitCompletion)
       throws IOException, InterruptedException {
     logger.atInfo().log(
-        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  TimePartitioning: %s",
+        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  timePartitioning: %s",
         BigQueryStrings.toString(tableRef),
         gcsPaths.size(),
         gcsPaths.isEmpty() ? "(empty)" : gcsPaths.get(0),

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -13,6 +13,8 @@
  */
 package com.google.cloud.hadoop.io.bigquery;
 
+import static com.google.common.flogger.LazyArgs.lazy;
+
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.Bigquery.Jobs.Insert;
 import com.google.api.services.bigquery.model.Dataset;
@@ -115,45 +117,6 @@ public class BigQueryHelper {
    * @param projectId the project on whose behalf to perform the load.
    * @param tableRef the reference to the destination table.
    * @param schema the schema of the source data to populate the destination table by.
-   * @param kmsKeyName the Cloud KMS encryption key used to protect the output table.
-   * @param sourceFormat the file format of the source data.
-   * @param writeDisposition the write disposition of the output table.
-   * @param gcsPaths the location of the source data in GCS.
-   * @param awaitCompletion if true, block and poll until job completes, otherwise return as soon as
-   *     the job has been successfully dispatched.
-   * @throws IOException
-   * @throws InterruptedException if interrupted while waiting for job completion.
-   */
-  public void importFromGcs(
-      String projectId,
-      TableReference tableRef,
-      @Nullable TableSchema schema,
-      @Nullable String kmsKeyName,
-      BigQueryFileFormat sourceFormat,
-      String writeDisposition,
-      List<String> gcsPaths,
-      boolean awaitCompletion)
-      throws IOException, InterruptedException {
-
-    importFromGcs(
-        projectId,
-        tableRef,
-        schema,
-        /* timePartitioning= */ null,
-        kmsKeyName,
-        sourceFormat,
-        writeDisposition,
-        gcsPaths,
-        awaitCompletion);
-  }
-
-  /**
-   * Imports data from GCS into BigQuery via a load job. Optionally polls for completion before
-   * returning.
-   *
-   * @param projectId the project on whose behalf to perform the load.
-   * @param tableRef the reference to the destination table.
-   * @param schema the schema of the source data to populate the destination table by.
    * @param timePartitioning time partitioning to populate the destination table.
    * @param kmsKeyName the Cloud KMS encryption key used to protect the output table.
    * @param sourceFormat the file format of the source data.
@@ -176,8 +139,9 @@ public class BigQueryHelper {
       boolean awaitCompletion)
       throws IOException, InterruptedException {
     logger.atInfo().log(
-        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  timePartitioning: %s",
-        BigQueryStrings.toString(tableRef),
+        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;"
+            + " timePartitioning: %s",
+        lazy(() -> BigQueryStrings.toString(tableRef)),
         gcsPaths.size(),
         gcsPaths.isEmpty() ? "(empty)" : gcsPaths.get(0),
         awaitCompletion,

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -107,7 +107,7 @@ public class BigQueryHelper {
 
     service.tables().insert(projectId, tableRef.getDatasetId(), table).execute();
   }
-  
+
   /**
    * Imports data from GCS into BigQuery via a load job. Optionally polls for completion before
    * returning.
@@ -125,18 +125,26 @@ public class BigQueryHelper {
    * @throws InterruptedException if interrupted while waiting for job completion.
    */
   public void importFromGcs(
-      String projectId, 
-      TableReference tableRef, 
+      String projectId,
+      TableReference tableRef,
       @Nullable TableSchema schema,
-      @Nullable String kmsKeyName, 
-      BigQueryFileFormat sourceFormat, 
+      @Nullable String kmsKeyName,
+      BigQueryFileFormat sourceFormat,
       String writeDisposition,
-      List<String> gcsPaths, 
-      boolean awaitCompletion) throws IOException, InterruptedException {
-    
-    importFromGcs(projectId, tableRef, schema, null, kmsKeyName, sourceFormat, writeDisposition,
-        gcsPaths, awaitCompletion);
+      List<String> gcsPaths,
+      boolean awaitCompletion)
+      throws IOException, InterruptedException {
 
+    importFromGcs(
+        projectId,
+        tableRef,
+        schema,
+        null,
+        kmsKeyName,
+        sourceFormat,
+        writeDisposition,
+        gcsPaths,
+        awaitCompletion);
   }
 
   /**
@@ -168,12 +176,12 @@ public class BigQueryHelper {
       boolean awaitCompletion)
       throws IOException, InterruptedException {
     logger.atInfo().log(
-        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  TimePartitioning: {}",
+        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  TimePartitioning: %s",
         BigQueryStrings.toString(tableRef),
         gcsPaths.size(),
         gcsPaths.isEmpty() ? "(empty)" : gcsPaths.get(0),
         awaitCompletion,
-        timePartitioning != null ? timePartitioning : "null");
+        timePartitioning);
 
     // Create load conf with minimal requirements.
     JobConfigurationLoad loadConfig = new JobConfigurationLoad();
@@ -181,9 +189,7 @@ public class BigQueryHelper {
     loadConfig.setSourceFormat(sourceFormat.getFormatIdentifier());
     loadConfig.setSourceUris(gcsPaths);
     loadConfig.setDestinationTable(tableRef);
-    if(timePartitioning != null) {
-      loadConfig.setTimePartitioning(timePartitioning);
-    }
+    loadConfig.setTimePartitioning(timePartitioning);
     loadConfig.setWriteDisposition(writeDisposition);
     if (!Strings.isNullOrEmpty(kmsKeyName)) {
       loadConfig.setDestinationEncryptionConfiguration(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -26,6 +26,7 @@ import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.TimePartitioning;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -106,7 +107,7 @@ public class BigQueryHelper {
 
     service.tables().insert(projectId, tableRef.getDatasetId(), table).execute();
   }
-
+  
   /**
    * Imports data from GCS into BigQuery via a load job. Optionally polls for completion before
    * returning.
@@ -124,9 +125,42 @@ public class BigQueryHelper {
    * @throws InterruptedException if interrupted while waiting for job completion.
    */
   public void importFromGcs(
+      String projectId, 
+      TableReference tableRef, 
+      @Nullable TableSchema schema,
+      @Nullable String kmsKeyName, 
+      BigQueryFileFormat sourceFormat, 
+      String writeDisposition,
+      List<String> gcsPaths, 
+      boolean awaitCompletion) throws IOException, InterruptedException {
+    
+    importFromGcs(projectId, tableRef, schema, null, kmsKeyName, sourceFormat, writeDisposition,
+        gcsPaths, awaitCompletion);
+
+  }
+
+  /**
+   * Imports data from GCS into BigQuery via a load job. Optionally polls for completion before
+   * returning.
+   *
+   * @param projectId the project on whose behalf to perform the load.
+   * @param tableRef the reference to the destination table.
+   * @param schema the schema of the source data to populate the destination table by.
+   * @param timePartitioning time partitioning to populate the destination table.
+   * @param kmsKeyName the Cloud KMS encryption key used to protect the output table.
+   * @param sourceFormat the file format of the source data.
+   * @param writeDisposition the write disposition of the output table.
+   * @param gcsPaths the location of the source data in GCS.
+   * @param awaitCompletion if true, block and poll until job completes, otherwise return as soon as
+   *     the job has been successfully dispatched.
+   * @throws IOException
+   * @throws InterruptedException if interrupted while waiting for job completion.
+   */
+  public void importFromGcs(
       String projectId,
       TableReference tableRef,
       @Nullable TableSchema schema,
+      @Nullable TimePartitioning timePartitioning,
       @Nullable String kmsKeyName,
       BigQueryFileFormat sourceFormat,
       String writeDisposition,
@@ -134,11 +168,12 @@ public class BigQueryHelper {
       boolean awaitCompletion)
       throws IOException, InterruptedException {
     logger.atInfo().log(
-        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s",
+        "Importing into table '%s' from %s paths; path[0] is '%s'; awaitCompletion: %s;  TimePartitioning: {}",
         BigQueryStrings.toString(tableRef),
         gcsPaths.size(),
         gcsPaths.isEmpty() ? "(empty)" : gcsPaths.get(0),
-        awaitCompletion);
+        awaitCompletion,
+        timePartitioning != null ? timePartitioning : "null");
 
     // Create load conf with minimal requirements.
     JobConfigurationLoad loadConfig = new JobConfigurationLoad();
@@ -146,6 +181,9 @@ public class BigQueryHelper {
     loadConfig.setSourceFormat(sourceFormat.getFormatIdentifier());
     loadConfig.setSourceUris(gcsPaths);
     loadConfig.setDestinationTable(tableRef);
+    if(timePartitioning != null) {
+      loadConfig.setTimePartitioning(timePartitioning);
+    }
     loadConfig.setWriteDisposition(writeDisposition);
     if (!Strings.isNullOrEmpty(kmsKeyName)) {
       loadConfig.setDestinationEncryptionConfiguration(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -319,8 +319,10 @@ public class BigQueryOutputConfiguration {
    * Gets the output table time partitioning based on the given configuration.
    *
    * @param conf the configuration to reference the keys from.
-   * @return the derived table schema, absent value if no table schema exists in the configuration.
-   * @throws IOException if a table schema was set in the configuration but couldn't be parsed.
+   * @return the derived table time partitioning, absent value if no table time partitioning exists
+   *     in the configuration.
+   * @throws IOException if a table time partitioning was set in the configuration but couldn't be
+   *     parsed.
    */
   static Optional<BigQueryTimePartitioning> getTablePartitioning(Configuration conf)
       throws IOException {

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -15,6 +15,7 @@ package com.google.cloud.hadoop.io.bigquery.output;
 
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.TimePartitioning;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
 import com.google.cloud.hadoop.io.bigquery.BigQueryStrings;
@@ -313,6 +314,28 @@ public class BigQueryOutputConfiguration {
     }
     return Optional.empty();
   }
+  
+  /**
+   * Gets the output table time partitioning based on the given configuration.
+   *
+   * @param conf the configuration to reference the keys from.
+   * @return the derived table schema, absent value if no table schema exists in the configuration.
+   * @throws IOException if a table schema was set in the configuration but couldn't be parsed.
+   */
+  static Optional<BigQueryTimePartitioning> getTablePartitioning(Configuration conf) throws IOException {
+    String fieldsJson = conf.get(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY);
+    if (!Strings.isNullOrEmpty(fieldsJson)) {
+      try {
+        TimePartitioning tablePartitioning = BigQueryTimePartitioning.getFromJson(fieldsJson);
+        return Optional.of(BigQueryTimePartitioning.wrap(tablePartitioning));
+      } catch (IOException e) {
+        throw new IOException(
+            "Unable to parse key '" + BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY + "'.", e);
+      }
+    }
+    return Optional.empty();
+  }
+
 
   /**
    * Gets the output table KMS key name based on the given configuration.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -314,7 +314,7 @@ public class BigQueryOutputConfiguration {
     }
     return Optional.empty();
   }
-  
+
   /**
    * Gets the output table time partitioning based on the given configuration.
    *
@@ -322,7 +322,8 @@ public class BigQueryOutputConfiguration {
    * @return the derived table schema, absent value if no table schema exists in the configuration.
    * @throws IOException if a table schema was set in the configuration but couldn't be parsed.
    */
-  static Optional<BigQueryTimePartitioning> getTablePartitioning(Configuration conf) throws IOException {
+  static Optional<BigQueryTimePartitioning> getTablePartitioning(Configuration conf)
+      throws IOException {
     String fieldsJson = conf.get(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY);
     if (!Strings.isNullOrEmpty(fieldsJson)) {
       try {
@@ -330,12 +331,12 @@ public class BigQueryOutputConfiguration {
         return Optional.of(BigQueryTimePartitioning.wrap(tablePartitioning));
       } catch (IOException e) {
         throw new IOException(
-            "Unable to parse key '" + BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY + "'.", e);
+            "Unable to parse key '" + BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY + "'.",
+            e);
       }
     }
     return Optional.empty();
   }
-
 
   /**
    * Gets the output table KMS key name based on the given configuration.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
@@ -1,0 +1,98 @@
+package com.google.cloud.hadoop.io.bigquery.output;
+
+import java.io.IOException;
+import com.google.api.client.json.JsonParser;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.bigquery.model.TimePartitioning;
+
+/**
+ * Wrapper for BigQuery {@link TimePartitioning}.
+ *
+ * <p>
+ * This class is used to avoid client code to depend on BigQuery API classes, so that there is no
+ * potential conflict between different versions of BigQuery API libraries in the client.
+ *
+ * @see TableSchema.
+ */
+public class BigQueryTimePartitioning {
+  private final TimePartitioning timePartitioning;
+
+
+
+  
+  public BigQueryTimePartitioning() {
+    this.timePartitioning = new TimePartitioning();
+  }
+
+
+  public BigQueryTimePartitioning(TimePartitioning timePartitioning) {
+    this.timePartitioning = timePartitioning;
+  }
+  
+  
+  public String getType() {
+    return timePartitioning.getType();
+  }
+  
+  public void setType(String type) {
+    timePartitioning.setType(type);
+  }
+  
+  public String getField() {
+    return timePartitioning.getField();
+  }
+  
+  public void setField(String field) {
+    timePartitioning.setField(field);
+  }
+  
+  public long getExpirationMs() {
+    return timePartitioning.getExpirationMs();
+  }
+  
+  public void setExpirationMs(long expirationMs) {
+    timePartitioning.setExpirationMs(expirationMs);
+  }
+  
+  public Boolean getRequirePartitionFilter() {
+    return timePartitioning.getRequirePartitionFilter();
+  }
+  
+  public void setRequirePartitionFilter(Boolean requirePartitionFilter) {
+    timePartitioning.setRequirePartitionFilter(requirePartitionFilter);
+  }
+
+
+  @Override
+  public int hashCode() {
+    return  timePartitioning.hashCode();
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+   if(!(obj instanceof BigQueryTimePartitioning)) {
+     return false;
+   }
+    BigQueryTimePartitioning other = (BigQueryTimePartitioning) obj;
+    return timePartitioning.equals(other.timePartitioning);
+  }
+  
+  TimePartitioning get() {
+    return timePartitioning;
+  }
+  
+  static TimePartitioning getFromJson(String json) throws IOException {
+    JsonParser parser = JacksonFactory.getDefaultInstance().createJsonParser(json);
+    return parser.parseAndClose(TimePartitioning.class); }
+  
+  public String getAsJson() throws IOException {
+    return JacksonFactory.getDefaultInstance().toString(timePartitioning);
+  }
+  
+  static BigQueryTimePartitioning wrap(TimePartitioning tableTimePartitioning) {
+    return new BigQueryTimePartitioning(tableTimePartitioning);
+  }
+
+
+}

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
@@ -12,7 +12,7 @@ import com.google.api.services.bigquery.model.TimePartitioning;
  * This class is used to avoid client code to depend on BigQuery API classes, so that there is no
  * potential conflict between different versions of BigQuery API libraries in the client.
  *
- * @see TableSchema.
+ * @see TimePartitioning.
  */
 public class BigQueryTimePartitioning {
   private final TimePartitioning timePartitioning;

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
@@ -8,8 +8,7 @@ import com.google.api.services.bigquery.model.TimePartitioning;
 /**
  * Wrapper for BigQuery {@link TimePartitioning}.
  *
- * <p>
- * This class is used to avoid client code to depend on BigQuery API classes, so that there is no
+ * <p>This class is used to avoid client code to depend on BigQuery API classes, so that there is no
  * potential conflict between different versions of BigQuery API libraries in the client.
  *
  * @see TimePartitioning.
@@ -17,82 +16,74 @@ import com.google.api.services.bigquery.model.TimePartitioning;
 public class BigQueryTimePartitioning {
   private final TimePartitioning timePartitioning;
 
-
-
-  
   public BigQueryTimePartitioning() {
     this.timePartitioning = new TimePartitioning();
   }
 
-
   public BigQueryTimePartitioning(TimePartitioning timePartitioning) {
     this.timePartitioning = timePartitioning;
   }
-  
-  
+
   public String getType() {
     return timePartitioning.getType();
   }
-  
+
   public void setType(String type) {
     timePartitioning.setType(type);
   }
-  
+
   public String getField() {
     return timePartitioning.getField();
   }
-  
+
   public void setField(String field) {
     timePartitioning.setField(field);
   }
-  
+
   public long getExpirationMs() {
     return timePartitioning.getExpirationMs();
   }
-  
+
   public void setExpirationMs(long expirationMs) {
     timePartitioning.setExpirationMs(expirationMs);
   }
-  
+
   public Boolean getRequirePartitionFilter() {
     return timePartitioning.getRequirePartitionFilter();
   }
-  
+
   public void setRequirePartitionFilter(Boolean requirePartitionFilter) {
     timePartitioning.setRequirePartitionFilter(requirePartitionFilter);
   }
 
-
   @Override
   public int hashCode() {
-    return  timePartitioning.hashCode();
+    return timePartitioning.hashCode();
   }
-
 
   @Override
   public boolean equals(Object obj) {
-   if(!(obj instanceof BigQueryTimePartitioning)) {
-     return false;
-   }
+    if (!(obj instanceof BigQueryTimePartitioning)) {
+      return false;
+    }
     BigQueryTimePartitioning other = (BigQueryTimePartitioning) obj;
     return timePartitioning.equals(other.timePartitioning);
   }
-  
+
   TimePartitioning get() {
     return timePartitioning;
   }
-  
+
   static TimePartitioning getFromJson(String json) throws IOException {
     JsonParser parser = JacksonFactory.getDefaultInstance().createJsonParser(json);
-    return parser.parseAndClose(TimePartitioning.class); }
-  
+    return parser.parseAndClose(TimePartitioning.class);
+  }
+
   public String getAsJson() throws IOException {
     return JacksonFactory.getDefaultInstance().toString(timePartitioning);
   }
-  
+
   static BigQueryTimePartitioning wrap(TimePartitioning tableTimePartitioning) {
     return new BigQueryTimePartitioning(tableTimePartitioning);
   }
-
-
 }

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioning.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery.output;
 
-import java.io.IOException;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.bigquery.model.TimePartitioning;
+import java.io.IOException;
 
 /**
  * Wrapper for BigQuery {@link TimePartitioning}.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
@@ -62,6 +62,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
     String destProjectId = BigQueryOutputConfiguration.getProjectId(conf);
     String writeDisposition = BigQueryOutputConfiguration.getWriteDisposition(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
+    Optional<BigQueryTimePartitioning> timePartitioning = BigQueryOutputConfiguration.getTablePartitioning(conf);
     String kmsKeyName = BigQueryOutputConfiguration.getKmsKeyName(conf);
     BigQueryFileFormat outputFileFormat = BigQueryOutputConfiguration.getFileFormat(conf);
     List<String> sourceUris = getOutputFileURIs();
@@ -72,6 +73,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
               destProjectId,
               destTable,
               destSchema.isPresent() ? destSchema.get().get() : null,
+              timePartitioning.isPresent() ? timePartitioning.get().get() : null, 	  
               kmsKeyName,
               outputFileFormat,
               writeDisposition,

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
@@ -62,7 +62,8 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
     String destProjectId = BigQueryOutputConfiguration.getProjectId(conf);
     String writeDisposition = BigQueryOutputConfiguration.getWriteDisposition(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
-    Optional<BigQueryTimePartitioning> timePartitioning = BigQueryOutputConfiguration.getTablePartitioning(conf);
+    Optional<BigQueryTimePartitioning> timePartitioning =
+        BigQueryOutputConfiguration.getTablePartitioning(conf);
     String kmsKeyName = BigQueryOutputConfiguration.getKmsKeyName(conf);
     BigQueryFileFormat outputFileFormat = BigQueryOutputConfiguration.getFileFormat(conf);
     List<String> sourceUris = getOutputFileURIs();
@@ -73,7 +74,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
               destProjectId,
               destTable,
               destSchema.isPresent() ? destSchema.get().get() : null,
-              timePartitioning.isPresent() ? timePartitioning.get().get() : null, 	  
+              timePartitioning.isPresent() ? timePartitioning.get().get() : null,
               kmsKeyName,
               outputFileFormat,
               writeDisposition,

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelperTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelperTest.java
@@ -182,6 +182,7 @@ public class BigQueryHelperTest {
         jobProjectId,
         tableRef,
         fakeTableSchema,
+        /* timePartitioning= */ null,
         kmsKeyName,
         BigQueryFileFormat.NEWLINE_DELIMITED_JSON,
         BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_DEFAULT,

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/RegionalIntegrationTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/RegionalIntegrationTest.java
@@ -221,8 +221,9 @@ public class RegionalIntegrationTest {
             .setProjectId(PROJECT_ID)
             .setDatasetId(DATASET_ID)
             .setTableId("shakespeare"),
-        null,
-        null,
+        /* schema= */ null,
+        /* timePartitioning= */ null,
+        /* kmsKeyName= */ null,
         BigQueryFileFormat.NEWLINE_DELIMITED_JSON,
         "WRITE_EMPTY",
         ImmutableList.of("gs://" + testBucket + "/shakespeare"),

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
@@ -1,35 +1,50 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.hadoop.io.bigquery.output;
 
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+
 import java.io.IOException;
 import org.junit.Test;
 
 public class BigQueryTimePartitioningTest {
 
   public static final String TIME_PARTITIONING_JSON =
-      "{\"expirationMs\":\"1000\",\"field\":\"ingestDate\",\"requirePartitionFilter\":true,\"type\":\"day\"}";
+      "{\"expirationMs\":\"1000\",\"field\":\"ingestDate\",\"requirePartitionFilter\":true,"
+          + "\"type\":\"DAY\"}";
 
   @Test
   public void testConvertToJson() throws IOException {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
-    bigQueryTimePartitioning.setType("day");
+    bigQueryTimePartitioning.setType("DAY");
     bigQueryTimePartitioning.setExpirationMs(1000L);
     bigQueryTimePartitioning.setField("ingestDate");
     bigQueryTimePartitioning.setRequirePartitionFilter(true);
-    assertEquals(TIME_PARTITIONING_JSON, bigQueryTimePartitioning.getAsJson());
+
+    assertThat(bigQueryTimePartitioning.getAsJson()).isEqualTo(TIME_PARTITIONING_JSON);
   }
 
   @Test
   public void testConvertFromJson() throws IOException {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
-    bigQueryTimePartitioning.setType("day");
+    bigQueryTimePartitioning.setType("DAY");
     bigQueryTimePartitioning.setExpirationMs(1000L);
     bigQueryTimePartitioning.setField("ingestDate");
     bigQueryTimePartitioning.setRequirePartitionFilter(true);
 
-    assertEquals(
-        bigQueryTimePartitioning.get(),
-        BigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
+    assertThat(BigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON))
+        .isEqualTo(bigQueryTimePartitioning.get());
   }
 
   @Test
@@ -37,7 +52,8 @@ public class BigQueryTimePartitioningTest {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
     bigQueryTimePartitioning.setType("DAY");
     String json = bigQueryTimePartitioning.getAsJson();
-    assertEquals("{\"type\":\"DAY\"}", json);
-    assertEquals("DAY", BigQueryTimePartitioning.getFromJson(json).getType());
+
+    assertThat(json).isEqualTo("{\"type\":\"DAY\"}");
+    assertThat(BigQueryTimePartitioning.getFromJson(json).getType()).isEqualTo("DAY");
   }
 }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
@@ -18,8 +18,7 @@ public class BigQueryTimePartitioningTest {
     bigQueryTimePartitioning.setRequirePartitionFilter(true);
     assertEquals(TIME_PARTITIONING_JSON, bigQueryTimePartitioning.getAsJson());
   }
-  
-  
+
   @Test
   public void testConvertFromJson() throws IOException {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
@@ -27,10 +26,12 @@ public class BigQueryTimePartitioningTest {
     bigQueryTimePartitioning.setExpirationMs(1000L);
     bigQueryTimePartitioning.setField("ingestDate");
     bigQueryTimePartitioning.setRequirePartitionFilter(true);
-    
-    assertEquals(bigQueryTimePartitioning.get(), bigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
+
+    assertEquals(
+        bigQueryTimePartitioning.get(),
+        bigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
   }
-  
+
   @Test
   public void testConversion_OnlyTypeIsPresent() throws IOException {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
@@ -38,5 +39,4 @@ public class BigQueryTimePartitioningTest {
     String json = bigQueryTimePartitioning.getAsJson();
     assertEquals("DAY", BigQueryTimePartitioning.getFromJson(json).getType());
   }
-
 }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
@@ -1,0 +1,42 @@
+package com.google.cloud.hadoop.io.bigquery.output;
+
+import static org.junit.Assert.*;
+import java.io.IOException;
+import org.junit.Test;
+
+public class BigQueryTimePartitioningTest {
+
+  public static final String TIME_PARTITIONING_JSON =
+      "{\"expirationMs\":\"1000\",\"field\":\"ingestDate\",\"requirePartitionFilter\":true,\"type\":\"day\"}";
+
+  @Test
+  public void testConvertToJson() throws IOException {
+    BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
+    bigQueryTimePartitioning.setType("day");
+    bigQueryTimePartitioning.setExpirationMs(1000L);
+    bigQueryTimePartitioning.setField("ingestDate");
+    bigQueryTimePartitioning.setRequirePartitionFilter(true);
+    assertEquals(TIME_PARTITIONING_JSON, bigQueryTimePartitioning.getAsJson());
+  }
+  
+  
+  @Test
+  public void testConvertFromJson() throws IOException {
+    BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
+    bigQueryTimePartitioning.setType("day");
+    bigQueryTimePartitioning.setExpirationMs(1000L);
+    bigQueryTimePartitioning.setField("ingestDate");
+    bigQueryTimePartitioning.setRequirePartitionFilter(true);
+    
+    assertEquals(bigQueryTimePartitioning.get(), bigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
+  }
+  
+  @Test
+  public void testConversion_OnlyTypeIsPresent() throws IOException {
+    BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
+    bigQueryTimePartitioning.setType("DAY");
+    String json = bigQueryTimePartitioning.getAsJson();
+    assertEquals("DAY", BigQueryTimePartitioning.getFromJson(json).getType());
+  }
+
+}

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryTimePartitioningTest.java
@@ -29,7 +29,7 @@ public class BigQueryTimePartitioningTest {
 
     assertEquals(
         bigQueryTimePartitioning.get(),
-        bigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
+        BigQueryTimePartitioning.getFromJson(TIME_PARTITIONING_JSON));
   }
 
   @Test
@@ -37,6 +37,7 @@ public class BigQueryTimePartitioningTest {
     BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
     bigQueryTimePartitioning.setType("DAY");
     String json = bigQueryTimePartitioning.getAsJson();
+    assertEquals("{\"type\":\"DAY\"}", json);
     assertEquals("DAY", BigQueryTimePartitioning.getFromJson(json).getType());
   }
 }

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
@@ -69,7 +69,7 @@ public class IndirectBigQueryOutputCommitterTest {
   /** Sample qualified tableId for output. */
   private static final String QUALIFIED_TEST_TABLE_ID =
       String.format("%s:%s.%s", TEST_PROJECT_ID, TEST_DATASET_ID, TEST_TABLE_ID);
-  
+
   /** Sample table time partitioning used for output. */
   private static final BigQueryTimePartitioning TEST_TIME_PARTITIONING =
       BigQueryTimePartitioning.wrap(new TimePartitioning().setType("DAY"));
@@ -156,7 +156,8 @@ public class IndirectBigQueryOutputCommitterTest {
         TEST_FILE_FORMAT,
         TEST_OUTPUT_CLASS);
     BigQueryOutputConfiguration.setKmsKeyName(conf, TEST_KMS_KEY_NAME);
-    conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, TEST_TIME_PARTITIONING.getAsJson());
+    conf.set(
+        BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, TEST_TIME_PARTITIONING.getAsJson());
 
     // Setup sample data.
     outputTableRef = BigQueryOutputConfiguration.getTableReference(conf);

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.TimePartitioning;
 import com.google.cloud.hadoop.fs.gcs.InMemoryGoogleHadoopFileSystem;
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration;
 import com.google.cloud.hadoop.io.bigquery.BigQueryFileFormat;
@@ -68,6 +69,10 @@ public class IndirectBigQueryOutputCommitterTest {
   /** Sample qualified tableId for output. */
   private static final String QUALIFIED_TEST_TABLE_ID =
       String.format("%s:%s.%s", TEST_PROJECT_ID, TEST_DATASET_ID, TEST_TABLE_ID);
+  
+  /** Sample table time partitioning used for output. */
+  private static final BigQueryTimePartitioning TEST_TIME_PARTITIONING =
+      BigQueryTimePartitioning.wrap(new TimePartitioning().setType("DAY"));
 
   /** Sample output file format for the committer. */
   private static final BigQueryFileFormat TEST_FILE_FORMAT =
@@ -151,6 +156,7 @@ public class IndirectBigQueryOutputCommitterTest {
         TEST_FILE_FORMAT,
         TEST_OUTPUT_CLASS);
     BigQueryOutputConfiguration.setKmsKeyName(conf, TEST_KMS_KEY_NAME);
+    conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, TEST_TIME_PARTITIONING.getAsJson());
 
     // Setup sample data.
     outputTableRef = BigQueryOutputConfiguration.getTableReference(conf);
@@ -204,6 +210,7 @@ public class IndirectBigQueryOutputCommitterTest {
             eq(TEST_PROJECT_ID),
             eq(outputTableRef),
             eq(TEST_TABLE_SCHEMA.get()),
+            eq(TEST_TIME_PARTITIONING.get()),
             eq(TEST_KMS_KEY_NAME),
             eq(TEST_FILE_FORMAT),
             eq(TEST_WRITE_DISPOSITION),
@@ -234,6 +241,7 @@ public class IndirectBigQueryOutputCommitterTest {
             any(String.class),
             any(TableReference.class),
             any(TableSchema.class),
+            any(TimePartitioning.class),
             anyString(),
             any(BigQueryFileFormat.class),
             any(String.class),
@@ -249,6 +257,7 @@ public class IndirectBigQueryOutputCommitterTest {
             eq(TEST_PROJECT_ID),
             eq(outputTableRef),
             eq(TEST_TABLE_SCHEMA.get()),
+            eq(TEST_TIME_PARTITIONING.get()),
             eq(TEST_KMS_KEY_NAME),
             eq(TEST_FILE_FORMAT),
             eq(TEST_WRITE_DISPOSITION),


### PR DESCRIPTION
Hi,
I made some changes to allow partitioning when importing data into a BigQuery table.
The feature can be activated with the following configuration:
```java
BigQueryTimePartitioning bigQueryTimePartitioning = new BigQueryTimePartitioning();
bigQueryTimePartitioning.setType("DAY");
configuration.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, bigQueryTimePartitioning.getAsJson());
```
Regards