### PR TITLE
Support dedicated load job project ID in BigQuery connector (#171)

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -234,6 +234,7 @@ public class BigQueryOutputConfiguration {
     ConfigurationUtil.getMandatoryConfig(conf, REQUIRED_KEYS);
 
     // Run through the individual getters as they manage error handling.
+    getProjectId(conf);
     getJobProjectId(conf);
     getTableSchema(conf);
     getFileFormat(conf);

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -234,7 +234,7 @@ public class BigQueryOutputConfiguration {
     ConfigurationUtil.getMandatoryConfig(conf, REQUIRED_KEYS);
 
     // Run through the individual getters as they manage error handling.
-    getProjectId(conf);
+    getJobProjectId(conf);
     getTableSchema(conf);
     getFileFormat(conf);
     getFileOutputFormat(conf);
@@ -252,15 +252,16 @@ public class BigQueryOutputConfiguration {
   }
 
   /**
-   * Gets the project id based on the given configuration. If the {@link
-   * BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY} is missing, this resolves to referencing the
-   * {@link BigQueryConfiguration#PROJECT_ID_KEY} key.
+   * Gets the output dataset project id based on the given configuration.
+   *
+   * If the {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY} is missing, this
+   * resolves to referencing the {@link BigQueryConfiguration#PROJECT_ID_KEY} key.
    *
    * @param conf the configuration to reference the keys from.
    * @return the project id based on the given configuration.
    * @throws IOException if a required key is missing.
    */
-  public static String getProjectId(Configuration conf) throws IOException {
+  public static String getOutputProjectId(Configuration conf) throws IOException {
     // Reference the default project ID as a backup.
     String projectId = conf.get(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY);
     if (Strings.isNullOrEmpty(projectId)) {
@@ -268,8 +269,32 @@ public class BigQueryOutputConfiguration {
     }
     if (Strings.isNullOrEmpty(projectId)) {
       throw new IOException(
+              "Must supply a value for configuration setting: "
+                      + BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY);
+    }
+    return projectId;
+  }
+
+  /**
+   * Gets the project id to be used to run BQ load job based on the given configuration.
+   *
+   * If the {@link BigQueryConfiguration#PROJECT_ID_KEY} is missing, this resolves to
+   * referencing the {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY} key.
+   *
+   * @param conf the configuration to reference the keys from.
+   * @return the project id based on the given configuration.
+   * @throws IOException if a required key is missing.
+   */
+  public static String getJobProjectId(Configuration conf) throws IOException {
+    // Reference the default project ID as a backup.
+    String projectId = conf.get(BigQueryConfiguration.PROJECT_ID_KEY);
+    if (Strings.isNullOrEmpty(projectId)) {
+      projectId = conf.get(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY);
+    }
+    if (Strings.isNullOrEmpty(projectId)) {
+      throw new IOException(
           "Must supply a value for configuration setting: "
-              + BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY);
+              + BigQueryConfiguration.PROJECT_ID_KEY);
     }
     return projectId;
   }
@@ -285,7 +310,7 @@ public class BigQueryOutputConfiguration {
    */
   static TableReference getTableReference(Configuration conf) throws IOException {
     // Ensure the BigQuery output information is valid.
-    String projectId = getProjectId(conf);
+    String projectId = getOutputProjectId(conf);
     String datasetId =
         ConfigurationUtil.getMandatoryConfig(conf, BigQueryConfiguration.OUTPUT_DATASET_ID_KEY);
     String tableId =

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfiguration.java
@@ -257,11 +257,16 @@ public class BigQueryOutputConfiguration {
    * If the {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY} is missing, this
    * resolves to referencing the {@link BigQueryConfiguration#PROJECT_ID_KEY} key.
    *
+   * The load job can be configured with two project identifiers. Configuration key
+   * {@link BigQueryConfiguration#PROJECT_ID_KEY} can set the project on whose behalf
+   * to perform BigQuery load operation, while {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY}
+   * can be used to name the project that the target dataset belongs to.
+   *
    * @param conf the configuration to reference the keys from.
    * @return the project id based on the given configuration.
    * @throws IOException if a required key is missing.
    */
-  public static String getOutputProjectId(Configuration conf) throws IOException {
+  public static String getProjectId(Configuration conf) throws IOException {
     // Reference the default project ID as a backup.
     String projectId = conf.get(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY);
     if (Strings.isNullOrEmpty(projectId)) {
@@ -280,6 +285,11 @@ public class BigQueryOutputConfiguration {
    *
    * If the {@link BigQueryConfiguration#PROJECT_ID_KEY} is missing, this resolves to
    * referencing the {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY} key.
+   *
+   * The load job can be configured with two project identifiers. Configuration key
+   * {@link BigQueryConfiguration#PROJECT_ID_KEY} can set the project on whose behalf
+   * to perform BigQuery load operation, while {@link BigQueryConfiguration#OUTPUT_PROJECT_ID_KEY}
+   * can be used to name the project that the target dataset belongs to.
    *
    * @param conf the configuration to reference the keys from.
    * @return the project id based on the given configuration.
@@ -310,7 +320,7 @@ public class BigQueryOutputConfiguration {
    */
   static TableReference getTableReference(Configuration conf) throws IOException {
     // Ensure the BigQuery output information is valid.
-    String projectId = getOutputProjectId(conf);
+    String projectId = getProjectId(conf);
     String datasetId =
         ConfigurationUtil.getMandatoryConfig(conf, BigQueryConfiguration.OUTPUT_DATASET_ID_KEY);
     String tableId =

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitter.java
@@ -59,7 +59,7 @@ public class FederatedBigQueryOutputCommitter extends ForwardingBigQueryFileOutp
     // Get the destination configuration information.
     Configuration conf = context.getConfiguration();
     TableReference destTable = BigQueryOutputConfiguration.getTableReference(conf);
-    String destProjectId = BigQueryOutputConfiguration.getProjectId(conf);
+    String destProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
     BigQueryFileFormat outputFileFormat = BigQueryOutputConfiguration.getFileFormat(conf);
     List<String> sourceUris = getOutputFileURIs();

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitter.java
@@ -59,14 +59,14 @@ public class FederatedBigQueryOutputCommitter extends ForwardingBigQueryFileOutp
     // Get the destination configuration information.
     Configuration conf = context.getConfiguration();
     TableReference destTable = BigQueryOutputConfiguration.getTableReference(conf);
-    String destProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
+    String jobProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
     BigQueryFileFormat outputFileFormat = BigQueryOutputConfiguration.getFileFormat(conf);
     List<String> sourceUris = getOutputFileURIs();
 
     getBigQueryHelper()
         .importFederatedFromGcs(
-            destProjectId,
+            jobProjectId,
             destTable,
             destSchema.isPresent() ? destSchema.get().get() : null,
             outputFileFormat,

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
@@ -59,7 +59,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
     // Get the destination configuration information.
     Configuration conf = context.getConfiguration();
     TableReference destTable = BigQueryOutputConfiguration.getTableReference(conf);
-    String destProjectId = BigQueryOutputConfiguration.getProjectId(conf);
+    String destProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
     String writeDisposition = BigQueryOutputConfiguration.getWriteDisposition(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
     Optional<BigQueryTimePartitioning> timePartitioning =

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitter.java
@@ -59,7 +59,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
     // Get the destination configuration information.
     Configuration conf = context.getConfiguration();
     TableReference destTable = BigQueryOutputConfiguration.getTableReference(conf);
-    String destProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
+    String jobProjectId = BigQueryOutputConfiguration.getJobProjectId(conf);
     String writeDisposition = BigQueryOutputConfiguration.getWriteDisposition(conf);
     Optional<BigQueryTableSchema> destSchema = BigQueryOutputConfiguration.getTableSchema(conf);
     Optional<BigQueryTimePartitioning> timePartitioning =
@@ -71,7 +71,7 @@ public class IndirectBigQueryOutputCommitter extends ForwardingBigQueryFileOutpu
     try {
       getBigQueryHelper()
           .importFromGcs(
-              destProjectId,
+              jobProjectId,
               destTable,
               destSchema.isPresent() ? destSchema.get().get() : null,
               timePartitioning.isPresent() ? timePartitioning.get().get() : null,

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfigurationTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfigurationTest.java
@@ -43,6 +43,9 @@ public class BigQueryOutputConfigurationTest {
   /** Sample projectId for the configuration. */
   private static final String TEST_PROJECT_ID = "domain:project";
 
+  /** Sample projectId for configuration that is dedicated to the load job. */
+  private static final String TEST_LOAD_PROJECT_ID = "domain:load-project";
+
   /** Sample datasetId for the configuration. */
   private static final String TEST_DATASET_ID = "dataset";
 
@@ -265,30 +268,78 @@ public class BigQueryOutputConfigurationTest {
     assertThrows(IOException.class, () -> BigQueryOutputConfiguration.validateConfiguration(conf));
   }
 
-  /** Test the getProjectId returns the correct data. */
+  /** Test the getOutputProjectId returns the correct data. */
   @Test
-  public void testGetProjectId() throws IOException {
+  public void testGetOutputProjectId() throws IOException {
     conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
 
-    String result = BigQueryOutputConfiguration.getProjectId(conf);
+    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
 
     assertThat(result).isEqualTo(TEST_PROJECT_ID);
   }
 
-  /** Test the getProjectId returns the correct data. */
+  /** Test the getOutputProjectId returns the correct data. */
   @Test
-  public void testGetProjectIdBackup() throws IOException {
+  public void testGetOutputProjectIdBackup() throws IOException {
     conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_PROJECT_ID);
 
-    String result = BigQueryOutputConfiguration.getProjectId(conf);
+    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
 
     assertThat(result).isEqualTo(TEST_PROJECT_ID);
   }
 
-  /** Test the getProjectId errors on missing data. */
+  /** Test the getOutputProjectId returns the correct data. */
   @Test
-  public void testGetProjectIdMissing() throws IOException {
-    assertThrows(IOException.class, () -> BigQueryOutputConfiguration.getProjectId(conf));
+  public void testGetOutputProjectIdPrecedence() throws IOException {
+    conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
+    conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_LOAD_PROJECT_ID);
+
+    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
+
+    assertThat(result).isEqualTo(TEST_PROJECT_ID);
+  }
+
+  /** Test the getOutputProjectId errors on missing data. */
+  @Test
+  public void testGetOutputProjectIdMissing() throws IOException {
+    assertThrows(IOException.class, () -> BigQueryOutputConfiguration.getOutputProjectId(conf));
+  }
+
+  /** Test the getJobProjectId returns the correct data. */
+  @Test
+  public void testGetJobProjectId() throws IOException {
+    conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_PROJECT_ID);
+
+    String result = BigQueryOutputConfiguration.getJobProjectId(conf);
+
+    assertThat(result).isEqualTo(TEST_PROJECT_ID);
+  }
+
+  /** Test the getJobProjectId returns the correct data. */
+  @Test
+  public void testGetJobProjectIdBackup() throws IOException {
+    conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
+
+    String result = BigQueryOutputConfiguration.getJobProjectId(conf);
+
+    assertThat(result).isEqualTo(TEST_PROJECT_ID);
+  }
+
+  /** Test the getJobProjectId returns the correct data. */
+  @Test
+  public void testGetJobProjectIdPrecedence() throws IOException {
+    conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
+    conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_LOAD_PROJECT_ID);
+
+    String result = BigQueryOutputConfiguration.getJobProjectId(conf);
+
+    assertThat(result).isEqualTo(TEST_LOAD_PROJECT_ID);
+  }
+
+  /** Test the getJobProjectId errors on missing data. */
+  @Test
+  public void testGetJobProjectIdMissing() throws IOException {
+    assertThrows(IOException.class, () -> BigQueryOutputConfiguration.getJobProjectId(conf));
   }
 
   /** Test the getTable returns the correct data. */

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfigurationTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/BigQueryOutputConfigurationTest.java
@@ -268,41 +268,41 @@ public class BigQueryOutputConfigurationTest {
     assertThrows(IOException.class, () -> BigQueryOutputConfiguration.validateConfiguration(conf));
   }
 
-  /** Test the getOutputProjectId returns the correct data. */
+  /** Test the getProjectId returns the correct data. */
   @Test
-  public void testGetOutputProjectId() throws IOException {
+  public void testGetProjectId() throws IOException {
     conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
 
-    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
+    String result = BigQueryOutputConfiguration.getProjectId(conf);
 
     assertThat(result).isEqualTo(TEST_PROJECT_ID);
   }
 
-  /** Test the getOutputProjectId returns the correct data. */
+  /** Test the getProjectId returns the correct data. */
   @Test
-  public void testGetOutputProjectIdBackup() throws IOException {
+  public void testGetProjectIdBackup() throws IOException {
     conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_PROJECT_ID);
 
-    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
+    String result = BigQueryOutputConfiguration.getProjectId(conf);
 
     assertThat(result).isEqualTo(TEST_PROJECT_ID);
   }
 
-  /** Test the getOutputProjectId returns the correct data. */
+  /** Test the getProjectId returns the correct data. */
   @Test
-  public void testGetOutputProjectIdPrecedence() throws IOException {
+  public void testGetProjectIdPrecedence() throws IOException {
     conf.set(BigQueryConfiguration.OUTPUT_PROJECT_ID_KEY, TEST_PROJECT_ID);
     conf.set(BigQueryConfiguration.PROJECT_ID_KEY, TEST_LOAD_PROJECT_ID);
 
-    String result = BigQueryOutputConfiguration.getOutputProjectId(conf);
+    String result = BigQueryOutputConfiguration.getProjectId(conf);
 
     assertThat(result).isEqualTo(TEST_PROJECT_ID);
   }
 
-  /** Test the getOutputProjectId errors on missing data. */
+  /** Test the getProjectId errors on missing data. */
   @Test
-  public void testGetOutputProjectIdMissing() throws IOException {
-    assertThrows(IOException.class, () -> BigQueryOutputConfiguration.getOutputProjectId(conf));
+  public void testGetProjectIdMissing() throws IOException {
+    assertThrows(IOException.class, () -> BigQueryOutputConfiguration.getProjectId(conf));
   }
 
   /** Test the getJobProjectId returns the correct data. */


### PR DESCRIPTION
Allow a BQ load to a table under a specific Project ID use a different Project ID to run the load job.