### PR TITLE
Fix build failure without coverage profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
   </distributionManagement>
 
   <properties>
+    <argLine/>
+
     <build.java.source.version>8</build.java.source.version>
     <build.java.target.version>8</build.java.target.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
           </excludes>
           <reuseForks>false</reuseForks>
           <forkCount>2</forkCount>
-          <argLine>@{argLine} -mx2560m</argLine>
+          <argLine>@{argLine} -mx2650m</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fixes build failure when `argLine` parameter is not set by jacoco plugin (`-Pcoverage` argument is not specified)