### PR TITLE
MockHttpTransport instead of object mocks in GoogleCloudStorage

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/BatchHelperTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/BatchHelperTest.java
@@ -20,7 +20,7 @@ import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.BUCKET_N
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.HTTP_TRANSPORT;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.JSON_FACTORY;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.OBJECT_NAME;
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.metadataResponse;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.jsonDataResponse;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.batchRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.common.truth.Truth.assertThat;
@@ -119,7 +119,7 @@ public class BatchHelperTest {
     // 2. Configure mock HTTP transport with test request responses
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockBatchTransport(
-            /* requestsPerBatch= */ 2, metadataResponse(object1), metadataResponse(object2));
+            /* requestsPerBatch= */ 2, jsonDataResponse(object1), jsonDataResponse(object2));
 
     // 3. Configure BatchHelper with mocked HTTP transport
     Storage storage = new Storage(transport, JSON_FACTORY, httpRequestInitializer);
@@ -168,7 +168,7 @@ public class BatchHelperTest {
     // 2. Configure mock HTTP transport with test request responses
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockBatchTransport(
-            /* requestsPerBatch= */ 2, metadataResponse(object1), metadataResponse(object2));
+            /* requestsPerBatch= */ 2, jsonDataResponse(object1), jsonDataResponse(object2));
 
     // 3. Configure BatchHelper with mocked HTTP transport
     Storage storage = new Storage(transport, JSON_FACTORY, httpRequestInitializer);
@@ -210,7 +210,7 @@ public class BatchHelperTest {
 
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockBatchTransport(
-            /* requestsPerBatch= */ 1, metadataResponse(object1));
+            /* requestsPerBatch= */ 1, jsonDataResponse(object1));
 
     Storage storage = new Storage(transport, JSON_FACTORY, httpRequestInitializer);
     BatchHelper batchHelper =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.deleteRequestString;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.deleteMatchMetaGenerationRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.updateMetadataRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.uploadRequestString;
 import static com.google.cloud.hadoop.gcsio.cooplock.CoopLockOperationType.DELETE;
@@ -120,8 +120,8 @@ public class CoopLockIntegrationTest {
         .containsAtLeast(
             uploadRequestString(bucketName, LOCK_PATH, /* generationId= */ 6),
             updateMetadataRequestString(bucketName, LOCK_PATH, /* metaGenerationId= */ 1),
-            deleteRequestString(
-                bucketName, LOCK_PATH, /* generationId= */ 2, /* isMetaGeneration= */ true));
+            deleteMatchMetaGenerationRequestString(
+                bucketName, LOCK_PATH, /* metaGenerationId= */ 2));
 
     assertThat(gcsFs.exists(srcDirUri)).isFalse();
     assertThat(gcsFs.exists(srcDirUri.resolve(fileName))).isFalse();
@@ -172,8 +172,8 @@ public class CoopLockIntegrationTest {
         .containsAtLeast(
             uploadRequestString(bucketName, LOCK_PATH, /* generationId= */ 3),
             updateMetadataRequestString(bucketName, LOCK_PATH, /* metaGenerationId= */ 1),
-            deleteRequestString(
-                bucketName, LOCK_PATH, /* generationId= */ 2, /* isMetaGeneration= */ true));
+            deleteMatchMetaGenerationRequestString(
+                bucketName, LOCK_PATH, /* metaGenerationId= */ 2));
 
     assertThat(gcsFs.exists(dirUri)).isFalse();
     assertThat(gcsFs.exists(dirUri.resolve(fileName))).isFalse();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -21,7 +21,7 @@ import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.OBJECT_N
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.createReadChannel;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.dataRangeResponse;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.dataResponse;
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.metadataResponse;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.jsonDataResponse;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
@@ -51,7 +51,7 @@ public class GoogleCloudStorageReadChannelTest {
   @Test
   public void metadataInitialization_eager() throws IOException {
     MockHttpTransport transport =
-        GoogleCloudStorageTestUtils.mockTransport(metadataResponse(newStorageObject()));
+        GoogleCloudStorageTestUtils.mockTransport(jsonDataResponse(newStorageObject()));
 
     List<HttpRequest> requests = new ArrayList<>();
 
@@ -70,7 +70,7 @@ public class GoogleCloudStorageReadChannelTest {
   @Test
   public void metadataInitialization_lazy() throws IOException {
     MockHttpTransport transport =
-        GoogleCloudStorageTestUtils.mockTransport(metadataResponse(newStorageObject()));
+        GoogleCloudStorageTestUtils.mockTransport(jsonDataResponse(newStorageObject()));
 
     List<HttpRequest> requests = new ArrayList<>();
 
@@ -239,7 +239,7 @@ public class GoogleCloudStorageReadChannelTest {
 
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockTransport(
-            metadataResponse(object.setSize(BigInteger.ZERO)));
+            jsonDataResponse(object.setSize(BigInteger.ZERO)));
 
     Storage storage = new Storage(transport, JSON_FACTORY, r -> {});
 
@@ -254,7 +254,7 @@ public class GoogleCloudStorageReadChannelTest {
   public void size_whenObjectIsGzipEncoded_shouldBeSetToMaxLongValue() throws IOException {
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockTransport(
-            metadataResponse(newStorageObject().setContentEncoding("gzip")));
+            jsonDataResponse(newStorageObject().setContentEncoding("gzip")));
     Storage storage = new Storage(transport, JSON_FACTORY, r -> {});
 
     GoogleCloudStorageReadChannel readChannel =
@@ -306,7 +306,7 @@ public class GoogleCloudStorageReadChannelTest {
 
     MockHttpTransport transport =
         GoogleCloudStorageTestUtils.mockTransport(
-            metadataResponse(newStorageObject().setContentEncoding("gzip")),
+            jsonDataResponse(newStorageObject().setContentEncoding("gzip")),
             dataRangeResponse(testData, 0, testData.length));
 
     Storage storage = new Storage(transport, JSON_FACTORY, r -> {});

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
@@ -29,9 +29,6 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.storage.Storage;
-import com.google.api.services.storage.model.Bucket;
-import com.google.api.services.storage.model.Buckets;
-import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
@@ -160,11 +157,6 @@ public final class GoogleCloudStorageTestUtils {
     return new MockLowLevelHttpResponse().setStatusCode(statusCode);
   }
 
-  public static MockLowLevelHttpResponse metadataResponse(StorageObject metadataObject)
-      throws IOException {
-    return dataResponse(JSON_FACTORY.toByteArray(metadataObject));
-  }
-
   public static MockLowLevelHttpResponse dataRangeResponse(
       byte[] content, long rangeStart, long totalSize) {
     long rangeEnd = rangeStart + content.length - 1;
@@ -172,22 +164,14 @@ public final class GoogleCloudStorageTestUtils {
         .addHeader("Content-Range", rangeStart + "-" + rangeEnd + "/" + totalSize);
   }
 
+  public static MockLowLevelHttpResponse jsonDataResponse(Object object) throws IOException {
+    return dataResponse(JSON_FACTORY.toByteArray(object));
+  }
+
   public static MockLowLevelHttpResponse dataResponse(byte[] content) {
     return new MockLowLevelHttpResponse()
         .addHeader("Content-Length", String.valueOf(content.length))
         .setContent(content);
-  }
-
-  public static MockLowLevelHttpResponse bucketsResponse(Buckets buckets) throws IOException {
-    return dataResponse(JSON_FACTORY.toByteArray(buckets));
-  }
-
-  public static MockLowLevelHttpResponse bucketResponse(Bucket bucket) throws IOException {
-    return dataResponse(JSON_FACTORY.toByteArray(bucket));
-  }
-
-  public static MockLowLevelHttpResponse objectsResponse(Objects objects) throws IOException {
-    return dataResponse(JSON_FACTORY.toByteArray(objects));
   }
 
   public static MockLowLevelHttpResponse resumableUploadResponse(String bucket, String object) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
@@ -29,6 +29,8 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.Buckets;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
@@ -173,6 +175,16 @@ public final class GoogleCloudStorageTestUtils {
     return new MockLowLevelHttpResponse()
         .addHeader("Content-Length", String.valueOf(content.length))
         .setContent(content);
+  }
+
+  public static MockLowLevelHttpResponse bucketsResponse(Buckets buckets) throws IOException {
+
+    return dataResponse(JSON_FACTORY.toByteArray(buckets));
+  }
+
+  public static MockLowLevelHttpResponse bucketResponse(Bucket bucket) throws IOException {
+
+    return dataResponse(JSON_FACTORY.toByteArray(bucket));
   }
 
   public static MockLowLevelHttpResponse resumableUploadResponse(String bucket, String object) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTestUtils.java
@@ -31,6 +31,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Buckets;
+import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
@@ -178,13 +179,15 @@ public final class GoogleCloudStorageTestUtils {
   }
 
   public static MockLowLevelHttpResponse bucketsResponse(Buckets buckets) throws IOException {
-
     return dataResponse(JSON_FACTORY.toByteArray(buckets));
   }
 
   public static MockLowLevelHttpResponse bucketResponse(Bucket bucket) throws IOException {
-
     return dataResponse(JSON_FACTORY.toByteArray(bucket));
+  }
+
+  public static MockLowLevelHttpResponse objectsResponse(Objects objects) throws IOException {
+    return dataResponse(JSON_FACTORY.toByteArray(objects));
   }
 
   public static MockLowLevelHttpResponse resumableUploadResponse(String bucket, String object) {


### PR DESCRIPTION
I moved some tests to not use Mocks anymore.