### PR TITLE
Switch Cooperative Locking timestamps to milliseconds

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/CoopLockRepairIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/CoopLockRepairIntegrationTest.java
@@ -110,15 +110,16 @@ public class CoopLockRepairIntegrationTest {
 
   @Test
   public void moveDirectoryOperationRolledForwardAfterFailedCopy() throws Exception {
-    moveDirectoryOperationRepairedAfterFailedCopy("--rollForward");
+    moveDirectoryOperationRepairedAfterFailedCopy("--rollForward", /* copySucceeded= */ true);
   }
 
   @Test
   public void moveDirectoryOperationRolledBackAfterFailedCopy() throws Exception {
-    moveDirectoryOperationRepairedAfterFailedCopy("--rollBack");
+    moveDirectoryOperationRepairedAfterFailedCopy("--rollBack", /* copySucceeded= */ false);
   }
 
-  private void moveDirectoryOperationRepairedAfterFailedCopy(String command) throws Exception {
+  private void moveDirectoryOperationRepairedAfterFailedCopy(String command, boolean copySucceeded)
+      throws Exception {
     String bucketName =
         gcsfsIHelper.createUniqueBucket(
             "cooperative-rename-" + command.toLowerCase().replace("--roll", "") + "-failed-move");
@@ -182,13 +183,13 @@ public class CoopLockRepairIntegrationTest {
     URI logFileUri = matchFile(lockFiles, filenamePattern + "\\.log").get();
 
     String lockContent = gcsfsIHelper.readTextFile(bucketName, lockFileUri.getPath());
-    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochSeconds(0))
+    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochMilli(0))
         .isEqualTo(
             new RenameOperation()
-                .setLockEpochSeconds(0)
+                .setLockEpochMilli(0)
                 .setSrcResource(srcDirUri.toString())
                 .setDstResource(dstDirUri.toString())
-                .setCopySucceeded(false));
+                .setCopySucceeded(copySucceeded));
     assertThat(gcsfsIHelper.readTextFile(bucketName, logFileUri.getPath()))
         .isEqualTo(srcDirUri.resolve(fileName) + " -> " + dstDirUri.resolve(fileName) + "\n");
   }
@@ -254,10 +255,10 @@ public class CoopLockRepairIntegrationTest {
     URI logFileUri = matchFile(lockFiles, filenameFormat + "\\.log").get();
 
     String lockContent = gcsfsIHelper.readTextFile(bucketName, lockFileUri.getPath());
-    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochSeconds(0))
+    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochMilli(0))
         .isEqualTo(
             new RenameOperation()
-                .setLockEpochSeconds(0)
+                .setLockEpochMilli(0)
                 .setSrcResource(srcDirUri.toString())
                 .setDstResource(dstDirUri.toString())
                 .setCopySucceeded(true));
@@ -320,8 +321,8 @@ public class CoopLockRepairIntegrationTest {
     URI lockFileUri = matchFile(lockFiles, filenamePattern + "\\.lock").get();
     URI logFileUri = matchFile(lockFiles, filenamePattern + "\\.log").get();
     String lockContent = gcsfsIHelper.readTextFile(bucketName, lockFileUri.getPath());
-    assertThat(GSON.fromJson(lockContent, DeleteOperation.class).setLockEpochSeconds(0))
-        .isEqualTo(new DeleteOperation().setLockEpochSeconds(0).setResource(dirUri.toString()));
+    assertThat(GSON.fromJson(lockContent, DeleteOperation.class).setLockEpochMilli(0))
+        .isEqualTo(new DeleteOperation().setLockEpochMilli(0).setResource(dirUri.toString()));
     assertThat(gcsfsIHelper.readTextFile(bucketName, logFileUri.getPath()))
         .isEqualTo(dirUri.resolve(fileName) + "\n" + dirUri + "\n");
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDao.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDao.java
@@ -103,7 +103,7 @@ public class CoopLockOperationDao {
             ImmutableList.of(
                 GSON.toJson(
                     new DeleteOperation()
-                        .setLockEpochSeconds(operationInstant.getEpochSecond())
+                        .setLockEpochMilli(operationInstant.toEpochMilli())
                         .setResource(resourceId.toString()))));
     List<String> logRecords =
         Streams.concat(itemsToDelete.stream(), bucketsToDelete.stream())
@@ -122,7 +122,7 @@ public class CoopLockOperationDao {
         operationId,
         operationLockPath,
         DeleteOperation.class,
-        (o, i) -> o.setLockEpochSeconds(i.getEpochSecond()));
+        (o, i) -> o.setLockEpochMilli(i.toEpochMilli()));
   }
 
   public Future<?> persistRenameOperation(
@@ -144,7 +144,7 @@ public class CoopLockOperationDao {
             ImmutableList.of(
                 GSON.toJson(
                     new RenameOperation()
-                        .setLockEpochSeconds(operationInstant.getEpochSecond())
+                        .setLockEpochMilli(operationInstant.toEpochMilli())
                         .setSrcResource(src.toString())
                         .setDstResource(dst.toString())
                         .setCopySucceeded(false))));
@@ -170,7 +170,7 @@ public class CoopLockOperationDao {
         operationId,
         operationLockPath,
         RenameOperation.class,
-        (o, i) -> o.setLockEpochSeconds(i.getEpochSecond()));
+        (o, i) -> o.setLockEpochMilli(i.toEpochMilli()));
   }
 
   public void checkpointRenameOperation(
@@ -190,7 +190,7 @@ public class CoopLockOperationDao {
         ImmutableList.of(
             GSON.toJson(
                 new RenameOperation()
-                    .setLockEpochSeconds(Instant.now().getEpochSecond())
+                    .setLockEpochMilli(Instant.now().toEpochMilli())
                     .setSrcResource(src.toString())
                     .setDstResource(dst.toString())
                     .setCopySucceeded(copySucceeded))));

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecord.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecord.java
@@ -24,9 +24,9 @@ import java.util.TreeSet;
 public class CoopLockRecord {
   private String clientId;
   private String operationId;
-  private long operationEpochSeconds;
+  private long operationEpochMilli;
   private CoopLockOperationType operationType;
-  private long lockEpochSeconds;
+  private long lockEpochMilli;
   private Set<String> resources = new TreeSet<>();
 
   public String getClientId() {
@@ -47,12 +47,12 @@ public class CoopLockRecord {
     return this;
   }
 
-  public long getOperationEpochSeconds() {
-    return operationEpochSeconds;
+  public long getOperationEpochMilli() {
+    return operationEpochMilli;
   }
 
-  public CoopLockRecord setOperationEpochSeconds(long operationEpochSeconds) {
-    this.operationEpochSeconds = operationEpochSeconds;
+  public CoopLockRecord setOperationEpochMilli(long operationEpochMilli) {
+    this.operationEpochMilli = operationEpochMilli;
     return this;
   }
 
@@ -65,12 +65,12 @@ public class CoopLockRecord {
     return this;
   }
 
-  public long getLockEpochSeconds() {
-    return lockEpochSeconds;
+  public long getLockEpochMilli() {
+    return lockEpochMilli;
   }
 
-  public CoopLockRecord setLockEpochSeconds(long lockEpochSeconds) {
-    this.lockEpochSeconds = lockEpochSeconds;
+  public CoopLockRecord setLockEpochMilli(long lockEpochMilli) {
+    this.lockEpochMilli = lockEpochMilli;
     return this;
   }
 
@@ -88,9 +88,9 @@ public class CoopLockRecord {
     return MoreObjects.toStringHelper(this)
         .add("clientId", clientId)
         .add("operationId", operationId)
-        .add("operationEpochSeconds", operationEpochSeconds)
+        .add("operationEpochMilli", operationEpochMilli)
         .add("operationType", operationType)
-        .add("lockEpochSeconds", lockEpochSeconds)
+        .add("lockEpochMilli", lockEpochMilli)
         .add("resources", resources)
         .toString();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecords.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecords.java
@@ -30,7 +30,7 @@ public class CoopLockRecords {
    * <p>When making any changes to cooperative locking persistent objects format (adding, renaming
    * or removing fields), then you need to increase this version number to prevent corruption.
    */
-  public static final long FORMAT_VERSION = 2;
+  public static final long FORMAT_VERSION = 3;
 
   private long formatVersion = -1;
   private Set<CoopLockRecord> locks =

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecordsDao.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockRecordsDao.java
@@ -87,12 +87,12 @@ public class CoopLockRecordsDao {
   }
 
   public void relockOperation(
-      String bucketName, String operationId, String clientId, long lockEpochSeconds)
+      String bucketName, String operationId, String clientId, long lockEpochMilli)
       throws IOException {
     long startMs = System.currentTimeMillis();
     logger.atFine().log("lockOperation(%s, %d)", operationId, clientId);
     modifyLock(
-        records -> reacquireOperationLock(records, operationId, clientId, lockEpochSeconds),
+        records -> reacquireOperationLock(records, operationId, clientId, lockEpochMilli),
         bucketName,
         operationId);
     logger.atFine().log(
@@ -233,7 +233,7 @@ public class CoopLockRecordsDao {
   }
 
   private boolean reacquireOperationLock(
-      CoopLockRecords lockRecords, String operationId, String clientId, long lockEpochSeconds) {
+      CoopLockRecords lockRecords, String operationId, String clientId, long lockEpochMilli) {
     Optional<CoopLockRecord> operationOptional =
         lockRecords.getLocks().stream()
             .filter(o -> o.getOperationId().equals(operationId))
@@ -247,11 +247,11 @@ public class CoopLockRecordsDao {
         clientId,
         operation.getClientId());
     checkState(
-        lockEpochSeconds == operation.getLockEpochSeconds(),
-        "operation %s should be locked at %s epoch seconds but was at %s",
-        lockEpochSeconds,
-        operation.getLockEpochSeconds());
-    operation.setLockEpochSeconds(Instant.now().getEpochSecond());
+        lockEpochMilli == operation.getLockEpochMilli(),
+        "operation %s should be locked at %s epoch milliseconds but was at %s",
+        lockEpochMilli,
+        operation.getLockEpochMilli());
+    operation.setLockEpochMilli(Instant.now().toEpochMilli());
     return true;
   }
 
@@ -284,8 +284,8 @@ public class CoopLockRecordsDao {
         new CoopLockRecord()
             .setClientId(newClientId(operationId))
             .setOperationId(operationId)
-            .setOperationEpochSeconds(operationInstant.getEpochSecond())
-            .setLockEpochSeconds(Instant.now().getEpochSecond())
+            .setOperationEpochMilli(operationInstant.toEpochMilli())
+            .setLockEpochMilli(Instant.now().toEpochMilli())
             .setOperationType(operationType)
             .setResources(resourcesToAdd);
     lockRecords.getLocks().add(record);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/DeleteOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/DeleteOperation.java
@@ -20,15 +20,15 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public class DeleteOperation {
-  private long lockEpochSeconds;
+  private long lockEpochMilli;
   private String resource = null;
 
-  public long getLockEpochSeconds() {
-    return lockEpochSeconds;
+  public long getLockEpochMilli() {
+    return lockEpochMilli;
   }
 
-  public DeleteOperation setLockEpochSeconds(long lockEpochSeconds) {
-    this.lockEpochSeconds = lockEpochSeconds;
+  public DeleteOperation setLockEpochMilli(long lockEpochMilli) {
+    this.lockEpochMilli = lockEpochMilli;
     return this;
   }
 
@@ -47,19 +47,19 @@ public class DeleteOperation {
   }
 
   private boolean equalsInternal(DeleteOperation other) {
-    return Objects.equals(lockEpochSeconds, other.lockEpochSeconds)
+    return Objects.equals(lockEpochMilli, other.lockEpochMilli)
         && Objects.equals(resource, other.resource);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(lockEpochSeconds, resource);
+    return Objects.hash(lockEpochMilli, resource);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("lockEpochSeconds", lockEpochSeconds)
+        .add("lockEpochMilli", lockEpochMilli)
         .add("resource", resource)
         .toString();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/RenameOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/RenameOperation.java
@@ -20,17 +20,17 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public class RenameOperation {
-  private long lockEpochSeconds;
+  private long lockEpochMilli;
   private String srcResource;
   private String dstResource;
   private boolean copySucceeded;
 
-  public long getLockEpochSeconds() {
-    return lockEpochSeconds;
+  public long getLockEpochMilli() {
+    return lockEpochMilli;
   }
 
-  public RenameOperation setLockEpochSeconds(long lockEpochSeconds) {
-    this.lockEpochSeconds = lockEpochSeconds;
+  public RenameOperation setLockEpochMilli(long lockEpochMilli) {
+    this.lockEpochMilli = lockEpochMilli;
     return this;
   }
 
@@ -67,7 +67,7 @@ public class RenameOperation {
   }
 
   private boolean equalsInternal(RenameOperation other) {
-    return Objects.equals(lockEpochSeconds, other.lockEpochSeconds)
+    return Objects.equals(lockEpochMilli, other.lockEpochMilli)
         && Objects.equals(srcResource, other.srcResource)
         && Objects.equals(dstResource, other.dstResource)
         && Objects.equals(copySucceeded, other.copySucceeded);
@@ -75,13 +75,13 @@ public class RenameOperation {
 
   @Override
   public int hashCode() {
-    return Objects.hash(lockEpochSeconds, srcResource, dstResource, copySucceeded);
+    return Objects.hash(lockEpochMilli, srcResource, dstResource, copySucceeded);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("lockEpochSeconds", lockEpochSeconds)
+        .add("lockEpochMilli", lockEpochMilli)
         .add("srcResource", srcResource)
         .add("dstResource", dstResource)
         .add("copySucceeded", copySucceeded)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
@@ -140,10 +140,10 @@ public class CoopLockIntegrationTest {
     URI logFileUri = matchFile(lockFiles, fileNamePattern + "\\.log").get();
 
     String lockContent = gcsfsIHelper.readTextFile(bucketName, lockFileUri.getPath());
-    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochSeconds(0))
+    assertThat(GSON.fromJson(lockContent, RenameOperation.class).setLockEpochMilli(0))
         .isEqualTo(
             new RenameOperation()
-                .setLockEpochSeconds(0)
+                .setLockEpochMilli(0)
                 .setSrcResource(srcDirUri.toString())
                 .setDstResource(dstDirUri.toString())
                 .setCopySucceeded(true));
@@ -189,8 +189,8 @@ public class CoopLockIntegrationTest {
     URI lockFileUri = matchFile(lockFiles, fileNamePattern + "\\.lock").get();
     URI logFileUri = matchFile(lockFiles, fileNamePattern + "\\.log").get();
     String lockContent = gcsfsIHelper.readTextFile(bucketName, lockFileUri.getPath());
-    assertThat(GSON.fromJson(lockContent, DeleteOperation.class).setLockEpochSeconds(0))
-        .isEqualTo(new DeleteOperation().setLockEpochSeconds(0).setResource(dirUri.toString()));
+    assertThat(GSON.fromJson(lockContent, DeleteOperation.class).setLockEpochMilli(0))
+        .isEqualTo(new DeleteOperation().setLockEpochMilli(0).setResource(dirUri.toString()));
     assertThat(gcsfsIHelper.readTextFile(bucketName, logFileUri.getPath()))
         .isEqualTo(dirUri.resolve(fileName) + "\n" + dirUri + "\n");
   }


### PR DESCRIPTION
 This fixes checkpointing for rename operation.