### PR TITLE
Enabled parallel integration tests

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -106,7 +106,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
   /** Validates rename(). */
   @Test
   @Override
-  public void testRename() throws IOException {
+  public void testRename() throws Exception {
     renameHelper(
         new HdfsBehavior() {
           /**

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -330,7 +330,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
    */
   @Test @Override
   public void testDelete()
-      throws IOException {
+          throws Exception {
     deleteHelper(new HdfsBehavior());
   }
 
@@ -348,7 +348,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
    */
   @Test @Override
   public void testRename()
-      throws IOException {
+          throws Exception {
     renameHelper(new HdfsBehavior());
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/LocalFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/LocalFileSystemIntegrationTest.java
@@ -98,7 +98,7 @@ public class LocalFileSystemIntegrationTest
    */
   @Test @Override
   public void testDelete()
-      throws IOException {
+          throws Exception {
     deleteHelper(new HdfsBehavior());
   }
 
@@ -160,7 +160,7 @@ public class LocalFileSystemIntegrationTest
               return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
             }
           });
-    } catch (AssertionError ae) {
+    } catch (AssertionError | Exception ae) {
       // LocalFileSystem behaves differently for the case where dst is an existing directory,
       // and src is a directory with a file underneath it. GHFS places the src directory
       // as a subdirectory into dst; LocalFileSystem just clobbers dst directly.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
@@ -109,7 +109,7 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
    */
   @Test @Override
   public void testDelete()
-      throws IOException {
+          throws Exception {
     deleteHelper(new HdfsBehavior());
   }
 
@@ -127,7 +127,7 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
    */
   @Test @Override
   public void testRename()
-      throws IOException {
+          throws Exception {
     renameHelper(new HdfsBehavior() {
         @Override
         public MethodOutcome renameRootOutcome() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
@@ -26,6 +26,8 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
+import org.junit.rules.TestName;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
@@ -33,6 +35,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,10 @@
               <includes>
                 <include>**/*IntegrationTest.java</include>
               </includes>
-              <reuseForks>false</reuseForks>
-              <forkCount>1C</forkCount>
+              <reuseForks>true</reuseForks>
+              <forkCount>1</forkCount>
+              <parallel>methods</parallel>
+              <useUnlimitedThreads>true</useUnlimitedThreads>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
I fixed test execution by adding extra before and setup methods where I create bucket for each test and remove this afterwards. Name of newly created bucket is related to the actual test name so chance for any distractions is decreased.