### PR TITLE
Fix infinite loop in record reader

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -73,12 +73,12 @@ public class BigQueryConfiguration {
    */
   public static final String DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_KEY =
       "mapred.bq.dynamic.file.list.record.reader.poll.interval";
-  public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT = 10000;
 
-  public static final String DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_KEY =
-      "mapred.bq.dynamic.file.list.record.reader.max.attempts";
-  public static final int DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_DEFAULT = 15;
+  public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT = 10_000;
 
+  public static final String DYNAMIC_FILE_LIST_RECORD_READER_POLL_MAX_ATTEMPTS_KEY =
+      "mapred.bq.dynamic.file.list.record.reader.poll.max.attempts";
+  public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_MAX_ATTEMPTS_DEFAULT = -1;
 
   /** A list of all necessary Configuration keys for input connector. */
   public static final ImmutableList<String> MANDATORY_CONFIG_PROPERTIES_INPUT =

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -75,6 +75,11 @@ public class BigQueryConfiguration {
       "mapred.bq.dynamic.file.list.record.reader.poll.interval";
   public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT = 10000;
 
+  public static final String DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_KEY =
+      "mapred.bq.dynamic.file.list.record.reader.max.attempts";
+  public static final int DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_DEFAULT = 15;
+
+
   /** A list of all necessary Configuration keys for input connector. */
   public static final ImmutableList<String> MANDATORY_CONFIG_PROPERTIES_INPUT =
       ImmutableList.of(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryConfiguration.java
@@ -73,7 +73,6 @@ public class BigQueryConfiguration {
    */
   public static final String DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_KEY =
       "mapred.bq.dynamic.file.list.record.reader.poll.interval";
-
   public static final int DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT = 10_000;
 
   public static final String DYNAMIC_FILE_LIST_RECORD_READER_POLL_MAX_ATTEMPTS_KEY =

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
@@ -13,6 +13,8 @@
  */
 package com.google.cloud.hadoop.io.bigquery;
 
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+
 import com.google.api.client.util.Sleeper;
 import com.google.cloud.hadoop.util.HadoopToStringUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -23,8 +25,10 @@ import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -53,8 +57,8 @@ public class DynamicFileListRecordReader<K, V>
   // The estimated number of records we will read in total.
   private long estimatedNumRecords;
 
-  // maximum number of attempts to wait for next file
-  private int maxAttempts;
+  // maximum number of poll attempts to wait for next file
+  private int maxPollAttempts;
 
   // The interval we will poll listStatus/globStatus inside nextKeyValue() if we don't already
   // have a file ready for reading.
@@ -124,16 +128,20 @@ public class DynamicFileListRecordReader<K, V>
       estimatedNumRecords = 1;
     }
 
-    // Grab pollIntervalMs out of the config.
-    pollIntervalMs = context.getConfiguration().getInt(
-        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_KEY,
-        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT);
-    // max number of attempts to wait for next file
-    maxAttempts = context.getConfiguration().getInt(
-        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_KEY,
-        BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_MAX_ATTEMPT_DEFAULT);
+    Configuration conf = context.getConfiguration();
 
-    fileSystem = inputDirectoryAndPattern.getFileSystem(context.getConfiguration());
+    // Grab pollIntervalMs out of the config.
+    pollIntervalMs =
+        conf.getInt(
+            BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_KEY,
+            BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_INTERVAL_MS_DEFAULT);
+    // max number of attempts to wait for next file
+    maxPollAttempts =
+        conf.getInt(
+            BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_MAX_ATTEMPTS_KEY,
+            BigQueryConfiguration.DYNAMIC_FILE_LIST_RECORD_READER_POLL_MAX_ATTEMPTS_DEFAULT);
+
+    fileSystem = inputDirectoryAndPattern.getFileSystem(conf);
 
     // TODO(user): Make the base export pattern configurable.
     String exportPatternRegex = inputDirectoryAndPattern.getName().replace("*", "(\\d+)");
@@ -143,15 +151,14 @@ public class DynamicFileListRecordReader<K, V>
   }
 
   /**
-   * Reads the next key, value pair. Gets next line and parses Json object. May hang for a long
-   * time waiting for more files to appear in this reader's directory.
+   * Reads the next key, value pair. Gets next line and parses Json object. May hang for a long time
+   * waiting for more files to appear in this reader's directory.
    *
    * @return true if a key/value pair was read.
    * @throws IOException on IO Error.
    */
   @Override
-  public boolean nextKeyValue()
-      throws IOException, InterruptedException {
+  public boolean nextKeyValue() throws IOException, InterruptedException {
     currentValue = null;
 
     // Check if we already have a reader in-progress.
@@ -166,27 +173,29 @@ public class DynamicFileListRecordReader<K, V>
     }
 
     boolean needRefresh = !isNextFileReady() && shouldExpectMoreFiles();
-    int numAttempt = 0;
-    while (needRefresh && numAttempt < maxAttempts) {
-      logger.atFine().log("No files available, but more are expected; refreshing...");
-      LOG.debug(String.format("Current attempt: %s", numAttempt));
+    int pollAttempt = 0;
+    while (needRefresh && (maxPollAttempts < 0 || pollAttempt < maxPollAttempts)) {
+      logger.atFine().log(
+          "No files available after %d attempt(s), but more are expected; refreshing ...",
+          pollAttempt + 1);
       refreshFileList();
       needRefresh = !isNextFileReady() && shouldExpectMoreFiles();
       if (needRefresh) {
         logger.atFine().log("No new files found, sleeping before trying again...");
-        try {
-          sleeper.sleep(pollIntervalMs);
-          context.progress();
-        } catch (InterruptedException ie) {
-          logger.atWarning().withCause(ie).log("Interrupted while sleeping.");
-        }
-        numAttempt++;
+        sleepUninterruptibly(pollIntervalMs, TimeUnit.MILLISECONDS);
+        context.progress();
+        pollAttempt++;
       }
     }
 
-    if (numAttempt == maxAttempts) {
-        throw new IllegalStateException(String.format("Couldn't obtain any files after %s retries. This could happen ",
-                maxAttempts));
+    if (needRefresh) {
+      throw new IllegalStateException(
+          String.format(
+              "Couldn't obtain any files after %d attempts. This could happen if in the first"
+                  + " failed task attempt BigQuery returned 0 records, but didn't create 0-record"
+                  + " file, in this case the second task attempt record reader will wait"
+                  + " indefinitely, but no files will appear.",
+              pollAttempt + 1));
     }
 
     if (isNextFileReady()) {

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReader.java
@@ -191,11 +191,11 @@ public class DynamicFileListRecordReader<K, V>
     if (needRefresh) {
       throw new IllegalStateException(
           String.format(
-              "Couldn't obtain any files after %d attempts. This could happen if in the first"
+              "Couldn't obtain any files after %d attempt(s). This could happen if in the first"
                   + " failed task attempt BigQuery returned 0 records, but didn't create 0-record"
                   + " file, in this case the second task attempt record reader will wait"
                   + " indefinitely, but no files will appear.",
-              pollAttempt + 1));
+              pollAttempt));
     }
 
     if (isNextFileReady()) {

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -64,6 +64,11 @@
 
 1.  Implement Hadoop File System `append` method using GCS compose API.
 
+1.  Add a property to control max number of attempts when polling for next file.
+    By default max number of attempts is unlimited (`-1` value):
+
+        mapred.bq.dynamic.file.list.record.reader.poll.max.attempts (default: -1)
+
 ### 1.9.14 - 2019-02-13
 
 1.  Implement Hadoop File System `concat` method using GCS compose API.

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -3713,7 +3713,7 @@ public class GoogleCloudStorageTest {
     return new StorageObject()
         .setBucket(bucketName)
         .setName(objectName)
-        .setSize(new BigInteger(64, r))
+        .setSize(BigInteger.valueOf(r.nextInt(Integer.MAX_VALUE)))
         .setGeneration((long) r.nextInt(Integer.MAX_VALUE))
         .setMetageneration((long) r.nextInt(Integer.MAX_VALUE))
         .setUpdated(new DateTime(new Date()));

--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,7 @@
           </excludes>
           <reuseForks>false</reuseForks>
           <forkCount>2</forkCount>
-          <argLine>@{argLine} -mx3g</argLine>
+          <argLine>@{argLine} -mx2750m</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
There is a problem with infinite loop in record reader in two cases:

1. BigQuery returned 0 records, but didn't create 0-record file
2. First task attempt failed. In that case on the second task attempt record reader will wait indefinitely, but no files will appear.

This PR based on the https://github.com/GoogleCloudPlatform/bigdata-interop/pull/26 PR with additional review fixes.