### PR TITLE
Fix lock renewal race condition

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/CoopLockFsckRunner.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/CoopLockFsckRunner.java
@@ -194,7 +194,7 @@ class CoopLockFsckRunner {
           operationRecord.getOperationId(),
           StorageResourceId.fromObjectName(operation.getResource()));
     } finally {
-      lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ true);
+      lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ false);
     }
   }
 
@@ -259,7 +259,7 @@ class CoopLockFsckRunner {
           StorageResourceId.fromObjectName(operation.getSrcResource()),
           StorageResourceId.fromObjectName(operation.getDstResource()));
     } finally {
-      lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ true);
+      lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ false);
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDelete.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDelete.java
@@ -99,7 +99,7 @@ public class CoopLockOperationDelete {
   }
 
   public void cancelRenewal() {
-    lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ true);
+    lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ false);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationRename.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationRename.java
@@ -122,7 +122,7 @@ public class CoopLockOperationRename {
   }
 
   public void cancelRenewal() {
-    lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ true);
+    lockUpdateFuture.cancel(/* mayInterruptIfRunning= */ false);
   }
 
   @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/CoopLockIntegrationTest.java
@@ -238,7 +238,7 @@ public class CoopLockIntegrationTest {
             r -> {
               String reqUrl = "/b/" + bucketName + "/o/" + encodedFilePath;
               if ("DELETE".equals(r.getRequestMethod()) && r.getUrl().toString().contains(reqUrl)) {
-                sleepUninterruptibly(lockRenewalDelay.plusSeconds(1));
+                sleepUninterruptibly(lockRenewalDelay.plus(lockRenewalTimeout));
               }
             });
     GoogleCloudStorageFileSystem sleepingGcsFs = newGcsFs(gcsFsOptions, sleepingRequestInitializer);


### PR DESCRIPTION
If operation finishes during lock renewal then renewal future cancellation with interruption will fail whole operation (`System.exit(1)` will be called).

To fix this issue renewal future should be cancelled without interrupting active renewal.