### PR TITLE
fix BigQuery shading logic

### DIFF
--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -259,9 +259,11 @@
                     <include>com.google.**</include>
                   </includes>
                   <excludes>
+                    <exclude>com.google.gson.**</exclude>
                     <exclude>com.google.cloud.hadoop.io.bigquery.**</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken</exclude>
+                    <exclude>com.google.cloud.hadoop.repackaged.**</exclude>
                   </excludes>
                 </relocation>
                 <!-- Take special care of grpc-netty-shaded, it uses the package


### PR DESCRIPTION
1) package **com.google.code.gson** is not included in the shaded jar, hence excluding it from being relocated to **com.google.cloud.hadoop.repackaged.bigquery.com**.
2) I am not sure why **com.google.cloud.hadoop.repackaged.** ** was removed from exclude rule as part of  https://github.com/GoogleCloudPlatform/bigdata-interop/commit/4fc535cd001c838024f07d8d7a801b09a7d148ce commit, but this was breaking the shading in `META-INF/services/com.google.cloud.hadoop.repackaged.bigquery**` files.
For example, the contents of file : 
`META-INF/services/com.google.cloud.hadoop.repackaged.bigquery.io.grpc.ManagedChannelProvider ` were being rewritten to `com.google.cloud.hadoop.repackaged.bigquery.com.google.cloud.hadoop.repackaged.bigquery.io.grpc.netty.NettyChannelProvir`