### PR TITLE
[DO-NOT-MERGE] Added remote address to grpc status exception

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -405,8 +405,9 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private static IOException convertError(
       StatusRuntimeException error, StorageResourceId resourceId) {
-    String msg = String.format("Error reading '%s'", resourceId);
-    switch (Status.fromThrowable(error).getCode()) {
+    Status status = error.getStatus();
+    String msg = String.format("Error reading '%s' got status: '%s'", resourceId, status);
+    switch (status.getCode()) {
       case NOT_FOUND:
         return GoogleCloudStorageExceptions.createFileNotFoundException(
             resourceId.getBucketName(), resourceId.getObjectName(), new IOException(msg, error));


### PR DESCRIPTION
This is reviving https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/441 which was removed by https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/471. This is required to help understand if the application retry logic actually kicks in with different backends over time.

Note that this relies on experimental apis so shouldn't be merged for distribution. But it's okay to be used locally.