### PR TITLE
Fix: prevent clobbering of SSL trustCertificates

### DIFF
--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -34,6 +34,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -125,18 +126,27 @@ public class HttpTransportFactory {
             }
           });
     }
+    NetHttpTransport.Builder builder =
+        prepareNetHttpTransportBuilder(GoogleUtils.getCertificateTrustStore(), proxyUri);
+    return builder.build();
+  }
 
-    SslKeepAliveSocketFactory sslSocketFactory =
-        new SslKeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
-    return new NetHttpTransport.Builder()
-        .trustCertificates(GoogleUtils.getCertificateTrustStore())
-        .setSslSocketFactory(sslSocketFactory)
+  @VisibleForTesting
+  static NetHttpTransport.Builder prepareNetHttpTransportBuilder(
+      KeyStore keyStore, @Nullable URI proxyUri) throws GeneralSecurityException {
+    NetHttpTransport.Builder builder = new NetHttpTransport.Builder().trustCertificates(keyStore);
+    SSLSocketFactory socketFactory = builder.getSslSocketFactory();
+    if (socketFactory == null) {
+      socketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
+    }
+    return builder
+        .setSslSocketFactory(new SslKeepAliveSocketFactory(socketFactory))
         .setProxy(
             proxyUri == null
                 ? null
                 : new Proxy(
-                    Proxy.Type.HTTP, new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort())))
-        .build();
+                    Proxy.Type.HTTP,
+                    new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort())));
   }
 
   /**

--- a/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
@@ -17,6 +17,8 @@ package com.google.cloud.hadoop.util;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.client.googleapis.GoogleUtils;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.cloud.hadoop.util.HttpTransportFactory.SslKeepAliveSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +27,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -132,6 +135,14 @@ public class HttpTransportFactoryTest {
 
     assertThat(sslKeepAliveSocketFactory.getSupportedCipherSuites())
         .isEqualTo(SUPPORTED_TEST_SUITES);
+  }
+
+  @Test
+  public void testKeepAliveSettingIsNotCorrupted() throws GeneralSecurityException, IOException {
+    NetHttpTransport.Builder builder =
+        HttpTransportFactory.prepareNetHttpTransportBuilder(
+            GoogleUtils.getCertificateTrustStore(), null);
+    assertThat(builder.getSslSocketFactory()).isInstanceOf(SslKeepAliveSocketFactory.class);
   }
 
   @Test


### PR DESCRIPTION
Turns out NetHttpTransport.Builder#trustCertificates() clobbers any changes made to sslSocketFactory beforehand and this change is to handle modifying Socket keepAlive option while still supporting trustCertificates as expected.