### PR TITLE
Added JMH Benchmark for ListStatus

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/benchmarking/GoogleHadoopFileSystemJMHBenchmarking.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/benchmarking/GoogleHadoopFileSystemJMHBenchmarking.java
@@ -55,6 +55,8 @@ public class GoogleHadoopFileSystemJMHBenchmarking extends GoogleHadoopFileSyste
   public FileStatus[] listStatus(Path hadoopPath) throws IOException {
     runJMHBenchmarkAndLog("LISTSTATUS", () -> GCSListStatusBenchmark.runBenchmark(hadoopPath));
     logger.atInfo().log("Benchmark complete. Now performing the actual 'listStatus' operation...");
-    return super.listStatus(hadoopPath); // Run actual listStatus Operation after benchmarking it.
+
+    // Run actual listStatus Operation after benchmarking it.
+    return super.listStatus(hadoopPath);
   }
 }


### PR DESCRIPTION
[go/gcs-jmh-ls](https://docs.google.com/document/d/1YnSbiVO02Atux4Ei6XMzx0mghzYsT1-an7_cwHqCX8U/edit?resourcekey=0-H2OrlX7JkhOzRYomXFlYmA&tab=t.k24c8nascfsi)

* **ListStatus Benchmark**: Created a dedicated JMH benchmark class, GCSListStatusBenchmark, to measure the performance of the listStatus operation on Google Cloud Storage paths. This benchmark includes setup and teardown phases to initialize and close the GoogleHadoopFileSystem instance, and uses a Blackhole to prevent compiler optimizations from affecting measurement accuracy.
