### PR TITLE
Using the new central-publishing-maven-plugin for hadoop connector repo

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -350,6 +350,64 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
+  public void read_withPositiveGeneration_usesGenerationMatchPrecondition() throws IOException {
+    long generation = 12345L;
+    byte[] testData = {0x01, 0x02, 0x03};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(newStorageObject(BUCKET_NAME, OBJECT_NAME).setGeneration(generation)),
+            dataResponse(testData));
+
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadChannel readChannel =
+        createReadChannel(
+            storage, GoogleCloudStorageReadOptions.builder().build(), generation);
+
+    // Trigger a read which will initiate a data request
+    readChannel.read(ByteBuffer.allocate(testData.length));
+
+    // The first request is for metadata, the second is for data.
+    // Verify the data request URL contains the generation parameter.
+    String mediaRequestUrl = getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation);
+    assertThat(requests.get(1).getUrl().toString()).isEqualTo(mediaRequestUrl);
+  }
+
+  @Test
+  public void read_withZeroGeneration_doesNotUseGenerationMatchPrecondition() throws IOException {
+    long requestedGeneration = 0L;
+    // The actual object has a real, positive generation ID.
+    long actualGeneration = 54321L;
+    byte[] testData = {0x04, 0x05, 0x06};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                newStorageObject(BUCKET_NAME, OBJECT_NAME).setGeneration(actualGeneration)),
+            dataResponse(testData));
+
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadChannel readChannel =
+        createReadChannel(
+            storage,
+            GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build(),
+            requestedGeneration);
+
+    // Trigger a read to make a data request.
+    readChannel.read(ByteBuffer.allocate(testData.length));
+
+    // The data request URL should *not* contain a generation parameter,
+    // because the requested generation was 0. The generation parameter in getMediaRequestString
+    // will be null when the check for generation > 0 fails.
+    String mediaRequestUrl = getMediaRequestString(BUCKET_NAME, OBJECT_NAME);
+    assertThat(requests.get(1).getUrl().toString()).isEqualTo(mediaRequestUrl);
+  }
+
+  @Test
   public void initGeneration_hasGenerationId() throws IOException {
     StorageObject storageObject = newStorageObject(BUCKET_NAME, OBJECT_NAME);
     MockHttpTransport transport = mockTransport(jsonDataResponse(storageObject));

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,6 @@
     <url>https://github.com/GoogleCloudDataproc/hadoop-connectors/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <argLine/>
 
@@ -177,15 +166,14 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-              <skipRemoteStaging>${nexus.remote.skip}</skipRemoteStaging>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <checksums>all</checksums>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
*  Reference [PR/](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/1396)
*  Official [documentation](https://central.sonatype.org/publish/publish-portal-maven/)