### PR TITLE
Backport to branch-3.0.x : Using the new central-publishing-maven-plugin for hadoop connector repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,6 @@
     <url>https://github.com/GoogleCloudDataproc/hadoop-connectors/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <argLine/>
 
@@ -177,15 +166,14 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-              <skipRemoteStaging>${nexus.remote.skip}</skipRemoteStaging>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <checksums>all</checksums>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
*  Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1431)
*  Official [documentation](https://central.sonatype.org/publish/publish-portal-maven/)