### PR TITLE
Add name Tags in util and coverage package

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -24,6 +24,8 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <name>coverage</name>
+
   <artifactId>coverage</artifactId>
   <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -25,6 +25,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <name>util</name>
+
   <artifactId>util</artifactId>
   <version>3.0.0-SNAPSHOT</version>
 


### PR DESCRIPTION
Add name Tags in util and coverage package to fix project name not found error in the gcs-connector release pipeline. 
