### PR TITLE
[Backport Fix to staging-2.2.x]: Prevent Hadoop directory copy failures by correctly setting generation id Preconditions

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -554,7 +554,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // To get decoded content
       blobReadOptions.add(BlobSourceOption.shouldReturnRawInputStream(false));
 
-      if (blobId.getGeneration() != null) {
+      if (blobId.getGeneration() != null && blobId.getGeneration() > 0) {
         blobReadOptions.add(BlobSourceOption.generationMatch(blobId.getGeneration()));
       }
       if (storageOptions.getEncryptionKey() != null) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -775,7 +775,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     size = gzipEncoded ? Long.MAX_VALUE : sizeFromMetadata;
     checkEncodingAndAccess();
 
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       checkState(
           resourceId.getGenerationId() == generation,
           "Provided generation (%s) should be equal to fetched generation (%s) for '%s'",
@@ -1134,7 +1134,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     Storage.Objects.Get getData =
         storageRequestFactory.objectsGetData(
             resourceId.getBucketName(), resourceId.getObjectName());
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       getData.setGeneration(resourceId.getGenerationId());
     }
     return getData;
@@ -1149,7 +1149,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     Storage.Objects.Get getMetadata =
         storageRequestFactory.objectsGetMetadata(
             resourceId.getBucketName(), resourceId.getObjectName());
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       getMetadata.setGeneration(resourceId.getGenerationId());
     }
     return getMetadata;


### PR DESCRIPTION
* Origin [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1363)