### PR TITLE
Remove httpRequestInitializer override warning from GoogleCloudStorageImpl

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -325,8 +325,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       finalHttpRequestInitializer =
           new RetryHttpInitializer(finalCredentials, options.toRetryHttpInitializerOptions());
     } else {
-      logger.atWarning().log(
-          "ALERT: Overriding httpRequestInitializer - this should not be done in production!");
       finalHttpRequestInitializer = httpRequestInitializer;
     }
     this.httpRequestInitializer =


### PR DESCRIPTION
Rationale: my `GoogleCloudStorageImpl` is constructed from Apache Beam, which [constructs](https://github.com/apache/beam/blob/v2.67.0/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java#L122-L157) and [overrides](https://github.com/apache/beam/blob/v2.67.0/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java#L777-L778) its own `httpRequestInitializer`, as a `ChainingHttpRequestInitializer` that already stacks a credentials adapter + a retry adapter:

<img width="488" height="315" alt="Screenshot 2025-09-08 at 2 38 55 PM" src="https://github.com/user-attachments/assets/7a736d0b-af77-4a2f-a944-ed5129e27454" />

Therefore, it _should_ be safe to override in production (as far as I can tell 😅). 

Another option is that we could keep this log warning contingent on inspecting the contents of the `httpRequestInitializer` something like:

```diff
+      if (
+         !(httpRequestInitializer instanceof ChainingHttpRequestInitializer) ||
+         !((ChainingHttpRequestInitializer) + httpRequestInitializer).getInitializers().contains(..RetryHttpInitializer...)) {
       logger.atWarning().log(
            "ALERT: Overriding httpRequestInitializer to non-retry initializer - this should not be done in production!");
+      }
```

I feel like this is a bit messy. But lmk!