### PR TITLE
Upgrade Hadoop to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <google.oauth-client.version>1.34.1</google.oauth-client.version>
     <google.protobuf.version>3.25.3</google.protobuf.version>
     <grpc.version>1.68.0</grpc.version>
-    <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.version>3.4.2</hadoop.version>
     <opencensus.version>0.31.1</opencensus.version>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Currently `VectoredIOImpl` is not usable with Hadoop 3.4.x, due to the binary-incompatible signature change on `VectoredReadUtils#validateRangeRequest`:

[3.3.6](https://github.com/apache/hadoop/blob/rel%2Frelease-3.3.6/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/VectoredReadUtils.java#L80-L86):

```java
  public static void validateRangeRequest(FileRange range)
          throws EOFException {

    Preconditions.checkArgument(range.getLength() >= 0, "length is negative");
    if (range.getOffset() < 0) {
      throw new EOFException("position is negative");
    }
  }
```


[3.4.2](https://github.com/apache/hadoop/blob/rel%2Frelease-3.4.2/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/VectoredReadUtils.java#L76-L86)

```java
  public static <T extends FileRange> T validateRangeRequest(T range)
          throws EOFException {

    requireNonNull(range, "range is null");

    checkArgument(range.getLength() >= 0, "length is negative in %s", range);
    if (range.getOffset() < 0) {
      throw new EOFException("position is negative in range " + range);
    }
    return range;
  }
```

they're source compatible, so the hadoop-connectors still compiles, but as a downstream user on Hadoop 3.4, I get this runtime error when I enable vectored reads:

```
Caused by: java.lang.NoSuchMethodError: 'void org.apache.hadoop.fs.VectoredReadUtils.validateRangeRequest(org.apache.hadoop.fs.FileRange)'
	at com.google.cloud.hadoop.fs.gcs.VectoredIOImpl$VectoredReadChannel.readVectored(VectoredIOImpl.java:127)
	at com.google.cloud.hadoop.fs.gcs.VectoredIOImpl.readVectored(VectoredIOImpl.java:105)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream.lambda$readVectored$0(GoogleHadoopFSInputStream.java:185)
	at org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.invokeTrackingDuration(IOStatisticsBinding.java:547)
	at org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.lambda$trackDurationOfOperation$5(IOStatisticsBinding.java:528)
	at org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration(IOStatisticsBinding.java:449)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream.readVectored(GoogleHadoopFSInputStream.java:178)
	at org.apache.hadoop.fs.FSDataInputStream.readVectored(FSDataInputStream.java:307)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.parquet.util.DynMethods$UnboundMethod.invokeChecked(DynMethods.java:62)
	at org.apache.parquet.hadoop.util.wrapped.io.VectorIoBridge.readWrappedRanges(VectorIoBridge.java:244)
	at org.apache.parquet.hadoop.util.wrapped.io.VectorIoBridge.readVectoredRanges(VectorIoBridge.java:201)
	at org.apache.parquet.hadoop.util.H1SeekableInputStream.readVectored(H1SeekableInputStream.java:75)
	at org.apache.parquet.hadoop.ParquetFileReader.readVectored(ParquetFileReader.java:1305)
	at org.apache.parquet.hadoop.ParquetFileReader.readAllPartsVectoredOrNormal(ParquetFileReader.java:1222)
	at org.apache.parquet.hadoop.ParquetFileReader.internalReadRowGroup(ParquetFileReader.java:1133)
	at org.apache.parquet.hadoop.ParquetFileReader.readNextRowGroup(ParquetFileReader.java:1083)
```

currently I have to downgrade Hadoop to use the vectored read feature.