### PR TITLE
Remove `testRenameWithMoveOperation` from the list of ignored tests for gRPC Client. 

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -64,10 +64,6 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
 
   @Ignore
   @Test
-  public void testRenameWithMoveOperation() {}
-
-  @Ignore
-  @Test
   public void testGcsJsonAPIMetrics() {
     // TODO: Update this will once gRPC API metrics are added
   }


### PR DESCRIPTION
Remove `testRenameWithMoveOperation` from the list of ignored tests for gRPC Client. 