### PR TITLE
Update documentation

### DIFF
--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -150,7 +150,7 @@
     fs.gs.storage.http.headers.some-custom-header=custom_value
     fs.gs.storage.http.headers.another-custom-header=another_custom_value
     ```
-    
+
 *   `fs.gs.application.name.suffix` (not set by default)
 
     Suffix that will be added to HTTP `User-Agent` header set in all Cloud


### PR DESCRIPTION
The following configurations are not specific to JSON and have been moved to a more general section in the documentation for clarity:
- `fs.gs.application.name.suffix` 
- `fs.gs.proxy.address` 
- `fs.gs.proxy.username` 
- `fs.gs.proxy.password`
