### PR TITLE
Add Additional Metrics to track thread_wait, TTFB and data transfer

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
@@ -129,6 +129,21 @@ public enum GhfsStatistic {
       "Discarded read bytes during readVectored operation",
       TYPE_COUNTER),
 
+  STREAM_READ_VECTORED_THREAD_WAIT_DURATION(
+      "stream_readVectored_thread_wait_duration",
+      "Tracks how long a read task waits in the thread pool queue before execution starts",
+      TYPE_DURATION),
+
+  STREAM_READ_CONNECTION_DURATION(
+      "stream_read_connection_duration",
+      "Captures the time taken to establish a connection and receive the initial response from GCS",
+      TYPE_DURATION),
+
+  STREAM_READ_DATA_TRANSFER_DURATION(
+      "stream_read_data_transfer_duration",
+      "Measures the duration of the actual data transfer after the connection is established",
+      TYPE_DURATION),
+
   STREAM_READ_VECTORED_READ_RANGE_DURATION(
       "stream_readVectored_range_duration", "Latency of individual FileRange", TYPE_DURATION),
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
@@ -25,6 +25,7 @@ import com.google.cloud.hadoop.util.GCSChecksumFailureEvent;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent.EventType;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent.RequestType;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
 import com.google.cloud.hadoop.util.GcsRequestExecutionEvent;
 import com.google.cloud.hadoop.util.IGcsJsonApiEvent;
 import com.google.common.annotations.VisibleForTesting;
@@ -62,6 +63,7 @@ public class GoogleCloudStorageEventSubscriber {
       logger.atFiner().log("Subscriber class invoked for first time");
       INSTANCE = new GoogleCloudStorageEventSubscriber(storageStatistics);
     }
+    GoogleCloudStorageEventSubscriber.storageStatistics = storageStatistics;
     return INSTANCE;
   }
 
@@ -96,6 +98,10 @@ public class GoogleCloudStorageEventSubscriber {
       storageStatistics.incrementCounter(GoogleCloudStorageStatistics.GCS_API_TIME, duration);
 
       RequestType requestType = (RequestType) event.getProperty(GcsJsonApiEvent.REQUEST_TYPE);
+      if (requestType == RequestType.GET_MEDIA) {
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_CONNECTION_DURATION, duration, eventContext);
+      }
       if (requestToGcsStatMap.containsKey(requestType)) {
         updateMetric(requestToGcsStatMap.get(requestType), duration, eventContext);
       } else if (requestToGhfsStatMap.containsKey(requestType)) {
@@ -112,6 +118,26 @@ public class GoogleCloudStorageEventSubscriber {
           GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, backOffTime);
     } else if (eventType == EventType.EXCEPTION) {
       storageStatistics.incrementGcsExceptionCount();
+    }
+  }
+
+  @Subscribe
+  private void subscriberOnGcsReadMetricEvent(@Nonnull GcsReadMetricEvent event) {
+    if (event.getConnectionDurationMs() > 0) {
+      storageStatistics.updateStats(
+          GhfsStatistic.STREAM_READ_CONNECTION_DURATION,
+          event.getConnectionDurationMs(),
+          event.getStreamPath());
+    }
+    if (event.getDataTransferDurationMs() > 0) {
+      storageStatistics.updateStats(
+          GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION,
+          event.getDataTransferDurationMs(),
+          event.getStreamPath());
+      if (event.isLatencyThresholdBreached()) {
+        storageStatistics.incrementCounter(
+            GoogleCloudStorageStatistics.GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT, 1);
+      }
     }
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
@@ -123,21 +123,23 @@ public class GoogleCloudStorageEventSubscriber {
 
   @Subscribe
   private void subscriberOnGcsReadMetricEvent(@Nonnull GcsReadMetricEvent event) {
-    if (event.getConnectionDurationMs() > 0) {
-      storageStatistics.updateStats(
-          GhfsStatistic.STREAM_READ_CONNECTION_DURATION,
-          event.getConnectionDurationMs(),
-          event.getStreamPath());
-    }
-    if (event.getDataTransferDurationMs() > 0) {
-      storageStatistics.updateStats(
-          GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION,
-          event.getDataTransferDurationMs(),
-          event.getStreamPath());
-      if (event.isLatencyThresholdBreached()) {
-        storageStatistics.incrementCounter(
-            GoogleCloudStorageStatistics.GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT, 1);
-      }
+    switch (event.getType()) {
+      case CONNECTION:
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_CONNECTION_DURATION,
+            event.getDurationMs(),
+            event.getStreamPath());
+        break;
+      case DATA_TRANSFER:
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION,
+            event.getDurationMs(),
+            event.getStreamPath());
+        if (event.isLatencyThresholdBreached()) {
+          storageStatistics.incrementCounter(
+              GoogleCloudStorageStatistics.GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT, 1);
+        }
+        break;
     }
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -380,6 +380,16 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.inputstream.min.range.request.size",
           GoogleCloudStorageReadOptions.DEFAULT.getMinRangeRequestSize());
 
+  /**
+   * Threshold for data transfer latency, if the transfer takes longer than this threshold, then a
+   * high latency warning will be logged.
+   */
+  public static final HadoopConfigurationProperty<Long>
+      GCS_INPUT_STREAM_LATENCY_LOGGING_THRESHOLD_MS =
+          new HadoopConfigurationProperty<>(
+              "fs.gs.inputstream.latency.logging.threshold.ms",
+              GoogleCloudStorageReadOptions.DEFAULT.getLatencyLoggingThreshold());
+
   /** Minimum distance that will be seeked without merging the ranges together. */
   public static final HadoopConfigurationProperty<Integer> GCS_VECTORED_READ_RANGE_MIN_SEEK =
       new HadoopConfigurationProperty<>(
@@ -749,6 +759,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setFadviseRequestTrackCount(GCS_FADVISE_REQUEST_TRACK_COUNT.get(config, config::getInt))
         .setBidiThreadCount(GCS_BIDI_THREAD_COUNT.get(config, config::getInt))
         .setBidiClientTimeout(GCS_BIDI_CLIENT_INITIALIZATION_TIMEOUT.get(config, config::getInt))
+        .setLatencyLoggingThreshold(
+            GCS_INPUT_STREAM_LATENCY_LOGGING_THRESHOLD_MS.get(config, config::getLong))
         .build();
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -145,19 +145,25 @@ public class VectoredIOImpl implements Closeable {
         updateRangeSizeCounters(sortedRanges.size(), sortedRanges.size());
         // case when ranges are not merged
         for (FileRange sortedRange : sortedRanges) {
-          long startTimer = System.currentTimeMillis();
+          long submissionTime = System.currentTimeMillis();
           Future<?> executionFuture =
               boundedThreadPool.submit(
                   () -> {
+                    long startTime = System.currentTimeMillis();
+                    long queueWaitTime = startTime - submissionTime;
                     logger.atFiner().log("Submitting range %s for execution.", sortedRange);
                     // Reset thread stats as a new task is being submitted to this thread.
                     // all required stats must be collected before task is finished.
                     resetThreadLocalStats();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION,
+                        queueWaitTime,
+                        channelProvider.gcsPath);
                     readSingleRange(sortedRange, allocate, channelProvider);
                     long endTimer = System.currentTimeMillis();
                     storageStatistics.updateStats(
                         GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                        endTimer - startTimer,
+                        endTimer - submissionTime,
                         channelProvider.gcsPath);
                   });
           addCancellationListener(sortedRange, executionFuture);
@@ -169,21 +175,27 @@ public class VectoredIOImpl implements Closeable {
         for (CombinedFileRange combinedFileRange : combinedFileRanges) {
           CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
           combinedFileRange.setData(result);
-          long startTimer = System.currentTimeMillis();
+          long submissionTime = System.currentTimeMillis();
           Future<?> executionFuture =
               boundedThreadPool.submit(
                   () -> {
+                    long startTime = System.currentTimeMillis();
+                    long queueWaitTime = startTime - submissionTime;
                     logger.atFiner().log(
                         "Submitting combinedRange %s for execution.", combinedFileRange);
 
                     // Reset thread stats as a new task is being submitted to this thread.
                     // all required stats must be collected before task is finished.
                     resetThreadLocalStats();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION,
+                        queueWaitTime,
+                        channelProvider.gcsPath);
                     readCombinedRange(combinedFileRange, allocate, channelProvider);
                     long endTimer = System.currentTimeMillis();
                     storageStatistics.updateStats(
                         GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                        endTimer - startTimer,
+                        endTimer - submissionTime,
                         channelProvider.gcsPath);
                   });
           addCancellationListener(combinedFileRange, executionFuture);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -93,6 +93,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.fadvise", Fadvise.AUTO);
           put("fs.gs.inputstream.fast.fail.on.not.found.enable", true);
           put("fs.gs.inputstream.inplace.seek.limit", 8 * 1024 * 1024L);
+          put("fs.gs.inputstream.latency.logging.threshold.ms", 1000L);
           put("fs.gs.inputstream.min.range.request.size", 2 * 1024 * 1024L);
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.lazy.init.enable", false);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
@@ -49,7 +49,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -63,7 +62,10 @@ public class GoogleHadoopFileSystemNewIntegrationTest {
   private static HadoopFileSystemIntegrationHelper ghfsIHelper;
   private static String testBucketName;
 
-  @Rule public TestName name = new TestName();
+  @Rule
+  public GoogleHadoopFileSystemTestBase.SanitizedTestName name =
+      new GoogleHadoopFileSystemTestBase.SanitizedTestName();
+
   private TrackingHttpRequestInitializer gcsRequestsTracker;
 
   @Parameterized.Parameter public ClientType storageClientType;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -83,15 +83,16 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     return newConfig;
   }
 
-  @Rule
-  public TestName name =
-      new TestName() {
-        // With parametrization method name will get [index] appended in their name.
-        @Override
-        public String getMethodName() {
-          return super.getMethodName().replaceAll("[\\[,\\],\\s+]", "");
-        }
-      };
+  /** TestName rule that sanitizes method names for use in GCS paths. */
+  public static class SanitizedTestName extends TestName {
+    @Override
+    public String getMethodName() {
+      // With parametrization method name will get [index] appended in their name.
+      return super.getMethodName().replaceAll("[\\[,\\],\\s+]", "");
+    }
+  }
+
+  @Rule public SanitizedTestName name = new SanitizedTestName();
 
   // -----------------------------------------------------------------------------------------
   // Tests that vary according to the GHFS variant, but which we want to make sure get tested.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -696,7 +696,9 @@ public class VectoredIOImplTest {
     doAnswer(
             invocation -> {
               GoogleCloudStorageEventBus.postReadMetricEvent(
-                  new GcsReadMetricEvent(100L, 200L, fileInfo.getPath(), false));
+                  GcsReadMetricEvent.ofConnection(100L, fileInfo.getPath()));
+              GoogleCloudStorageEventBus.postReadMetricEvent(
+                  GcsReadMetricEvent.ofDataTransfer(200L, fileInfo.getPath(), false));
               return null;
             })
         .when(mockedChannel)

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,7 +34,10 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -84,6 +88,8 @@ public class VectoredIOImplTest {
 
   @Before
   public void before() throws Exception {
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventSubscriber.reset();
     this.ghfs = createInMemoryGoogleHadoopFileSystem();
     // Write a file which will be used across test case to validate the ranges reads
     this.path = new Path(ghfs.getUri().resolve(OBJECT_NAME));
@@ -98,6 +104,8 @@ public class VectoredIOImplTest {
     this.gcsFs = spy(ghfs.getGcsFs());
     this.statistics = new FileSystem.Statistics(ghfs.getScheme());
     this.ghfsStorageStatistics = new GhfsGlobalStorageStatistics();
+    GoogleCloudStorageEventBus.register(
+        GoogleCloudStorageEventSubscriber.getInstance(ghfsStorageStatistics));
     this.vectoredIO = new VectoredIOImpl(vectoredReadOptions, ghfsStorageStatistics);
     this.streamStatistics = ghfs.getInstrumentation().newInputStreamStatistics(statistics);
     this.rangeReadThreadStats = new ConcurrentHashMap<>();
@@ -109,6 +117,8 @@ public class VectoredIOImplTest {
       vectoredIO.close();
     }
     ghfsStorageStatistics.reset();
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventSubscriber.reset();
     streamStatistics.close();
     rangeReadThreadStats = null;
   }
@@ -659,5 +669,74 @@ public class VectoredIOImplTest {
 
   private void verifyGcsFsOpenCalls(int callCount) throws IOException {
     verify(gcsFs, times(callCount)).open((FileInfo) any(), any());
+  }
+
+  @Test
+  public void testVectoredIOMetricsWithReadChannel() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    // valid range
+    fileRanges.add(FileRange.createFileRange(/* offset */ 0, /* length */ 10));
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+
+    GoogleCloudStorageReadChannel mockedChannel = mock(GoogleCloudStorageReadChannel.class);
+
+    when(mockedChannel.read(any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              int length = buffer.remaining();
+              buffer.position(buffer.position() + length);
+              return length;
+            });
+    when(mockedChannel.isOpen()).thenReturn(true);
+    when(mockedChannel.position(org.mockito.ArgumentMatchers.anyLong())).thenReturn(mockedChannel);
+
+    doAnswer(
+            invocation -> {
+              GoogleCloudStorageEventBus.postReadMetricEvent(
+                  new GcsReadMetricEvent(100L, 200L, fileInfo.getPath(), false));
+              return null;
+            })
+        .when(mockedChannel)
+        .close();
+
+    when(mockedGcsFs.open((FileInfo) any(), any())).thenReturn(mockedChannel);
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the asynchronous tasks to complete
+    for (FileRange range : fileRanges) {
+      range.getData().get(1, TimeUnit.MINUTES);
+    }
+
+    long connectionTime = 0;
+    long dataTransferTime = 0;
+    for (int i = 0; i < 100; i++) {
+      connectionTime =
+          ghfsStorageStatistics.getMax(GhfsStatistic.STREAM_READ_CONNECTION_DURATION.getSymbol());
+      dataTransferTime =
+          ghfsStorageStatistics.getMax(
+              GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION.getSymbol());
+      if (connectionTime == 100L && dataTransferTime == 200L) {
+        break;
+      }
+      Thread.sleep(50);
+    }
+
+    assertThat(connectionTime).isEqualTo(100L);
+    assertThat(dataTransferTime).isEqualTo(200L);
+    assertThat(
+            ghfsStorageStatistics.getMax(
+                GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION.getSymbol()))
+        .isAtLeast(0L);
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -35,6 +35,8 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
+import com.google.cloud.hadoop.util.GcsReadDurationTrackerStream;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.cloud.hadoop.util.ResilientOperation;
@@ -48,6 +50,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
@@ -868,7 +871,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
   }
 
   /**
-   * Opens the underlying stream, sets its position to the {@link #currentPosition}.
+   * Opens an {@link InputStream} to the GCS object at the current position, wrapped with
+   * performance tracking.
    *
    * <p>If the file encoding in GCS is gzip (and therefore the HTTP client will decompress it), the
    * entire file is always requested, and we seek to the position requested. If the file encoding is
@@ -876,6 +880,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
    *
    * @param bytesToRead number of bytes to read from new stream. Ignored if {@link
    *     GoogleCloudStorageReadOptions#getFadvise()} is equal to {@link Fadvise#SEQUENTIAL}.
+   * @return an {@link InputStream} to the object content, typically a {@link
+   *     GcsReadDurationTrackerStream}.
    * @throws IOException on IO error
    */
   protected InputStream openStream(long bytesToRead) throws IOException {
@@ -962,8 +968,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
 
     Storage.Objects.Get getObject = createDataRequest(rangeHeader);
     HttpResponse response;
+    long startTime = System.currentTimeMillis();
     try {
       response = getObject.executeMedia();
+      GoogleCloudStorageEventBus.postReadMetricEvent(
+          GcsReadMetricEvent.ofConnection(
+              System.currentTimeMillis() - startTime, URI.create(resourceId.toString())));
       // TODO(b/110832992): validate response range header against expected/request range
     } catch (IOException e) {
       if (!metadataInitialized && errorExtractor.rangeNotSatisfiable(e) && currentPosition == 0) {
@@ -1083,7 +1093,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           currentPosition,
           resourceId);
 
-      return contentStream;
+      return new GcsReadDurationTrackerStream(
+          contentStream,
+          URI.create(resourceId.toString()),
+          response.getHeaders(),
+          readOptions.getLatencyLoggingThreshold());
     } catch (IOException e) {
       GoogleCloudStorageEventBus.postOnException();
       try {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -60,7 +60,8 @@ public abstract class GoogleCloudStorageReadOptions {
         .setFadviseRequestTrackCount(3)
         .setReadExactRequestedBytesEnabled(false)
         .setBidiThreadCount(16)
-        .setBidiClientTimeout(30);
+        .setBidiClientTimeout(30)
+        .setLatencyLoggingThreshold(1000L);
   }
 
   public abstract Builder toBuilder();
@@ -119,6 +120,9 @@ public abstract class GoogleCloudStorageReadOptions {
 
   /** See {@link Builder#setBidiClientTimeout(int)}. */
   public abstract int getBidiClientTimeout();
+
+  /** See {@link Builder#setLatencyLoggingThreshold(long)}. */
+  public abstract long getLatencyLoggingThreshold();
 
   /** Mutable builder for GoogleCloudStorageReadOptions. */
   @AutoValue.Builder
@@ -233,6 +237,12 @@ public abstract class GoogleCloudStorageReadOptions {
 
     /** Sets the total amount of time, we would wait for bidi client initialization. */
     public abstract Builder setBidiClientTimeout(int bidiClientTimeout);
+
+    /**
+     * Sets the threshold for data transfer latency, if the transfer takes longer than this
+     * threshold, then a high latency warning will be logged.
+     */
+    public abstract Builder setLatencyLoggingThreshold(long latencyLoggingThresholdMillis);
 
     abstract GoogleCloudStorageReadOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
@@ -115,6 +115,11 @@ public enum GoogleCloudStorageStatistics {
   GCS_API_TIME(
       "gcs_api_time", "Tracks the amount of time spend while calling GCS APIs.", TYPE_COUNTER),
 
+  GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT(
+      "gcs_read_data_transfer_latency_breached_count",
+      "Counts the number of times the read data transfer latency threshold was breached.",
+      TYPE_COUNTER),
+
   GCS_METADATA_REQUEST(
       "gcs_metadata_request", "Tracks GCS GET metadata API calls.", TYPE_DURATION_TOTAL),
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.common.flogger.GoogleLogger;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+/** A decorator for {@link InputStream} that tracks the data transfer duration. */
+public class GcsReadDurationTrackerStream extends FilterInputStream {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final String UPLOAD_ID_HEADER = "x-guploader-uploadid";
+
+  private final URI streamPath;
+  private final Object responseHeaders;
+  private final long latencyLoggingThresholdMs;
+  private long cumulativeTransferDurationMs;
+
+  public GcsReadDurationTrackerStream(
+      InputStream delegate,
+      URI streamPath,
+      Object responseHeaders,
+      long latencyLoggingThresholdMs) {
+    super(delegate);
+    this.streamPath = streamPath;
+    this.responseHeaders = responseHeaders;
+    this.latencyLoggingThresholdMs = latencyLoggingThresholdMs;
+    this.cumulativeTransferDurationMs = 0;
+  }
+
+  @Override
+  public int read() throws IOException {
+    long startTime = System.currentTimeMillis();
+    try {
+      return super.read();
+    } finally {
+      cumulativeTransferDurationMs += System.currentTimeMillis() - startTime;
+    }
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    long startTime = System.currentTimeMillis();
+    try {
+      return super.read(b, off, len);
+    } finally {
+      cumulativeTransferDurationMs += System.currentTimeMillis() - startTime;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      boolean latencyThresholdBreached = cumulativeTransferDurationMs > latencyLoggingThresholdMs;
+      if (latencyThresholdBreached) {
+        String uploadId =
+            responseHeaders instanceof HttpHeaders
+                ? ((HttpHeaders) responseHeaders).getFirstHeaderStringValue(UPLOAD_ID_HEADER)
+                : String.valueOf(responseHeaders);
+        logger.atInfo().atMostEvery(10, TimeUnit.SECONDS).log(
+            "Detected high latency for %s. durationMs=%d; upload_id=%s",
+            streamPath, cumulativeTransferDurationMs, uploadId);
+      }
+      GoogleCloudStorageEventBus.postReadMetricEvent(
+          GcsReadMetricEvent.ofDataTransfer(
+              cumulativeTransferDurationMs, streamPath, latencyThresholdBreached));
+    }
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
@@ -20,41 +20,42 @@ import java.net.URI;
 
 /** Event for providing GCS read metrics. */
 public class GcsReadMetricEvent {
-  private final long connectionDurationMs;
-  private final long dataTransferDurationMs;
+
+  /** Types of read metric events. */
+  public enum Type {
+    CONNECTION,
+    DATA_TRANSFER
+  }
+
+  private final Type type;
+  private final long durationMs;
   private final URI streamPath;
   private final boolean latencyThresholdBreached;
 
   public static GcsReadMetricEvent ofConnection(long durationMs, URI streamPath) {
-    return new GcsReadMetricEvent(durationMs, 0, streamPath, false);
-  }
-
-  public static GcsReadMetricEvent ofDataTransfer(long durationMs, URI streamPath) {
-    return ofDataTransfer(durationMs, streamPath, false);
+    return new GcsReadMetricEvent(Type.CONNECTION, durationMs, streamPath, false);
   }
 
   public static GcsReadMetricEvent ofDataTransfer(
       long durationMs, URI streamPath, boolean latencyThresholdBreached) {
-    return new GcsReadMetricEvent(0, durationMs, streamPath, latencyThresholdBreached);
+    return new GcsReadMetricEvent(
+        Type.DATA_TRANSFER, durationMs, streamPath, latencyThresholdBreached);
   }
 
-  public GcsReadMetricEvent(
-      long connectionDurationMs,
-      long dataTransferDurationMs,
-      URI streamPath,
-      boolean latencyThresholdBreached) {
-    this.connectionDurationMs = connectionDurationMs;
-    this.dataTransferDurationMs = dataTransferDurationMs;
+  private GcsReadMetricEvent(
+      Type type, long durationMs, URI streamPath, boolean latencyThresholdBreached) {
+    this.type = type;
+    this.durationMs = durationMs;
     this.streamPath = streamPath;
     this.latencyThresholdBreached = latencyThresholdBreached;
   }
 
-  public long getConnectionDurationMs() {
-    return connectionDurationMs;
+  public Type getType() {
+    return type;
   }
 
-  public long getDataTransferDurationMs() {
-    return dataTransferDurationMs;
+  public long getDurationMs() {
+    return durationMs;
   }
 
   public URI getStreamPath() {

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import java.net.URI;
+
+/** Event for providing GCS read metrics. */
+public class GcsReadMetricEvent {
+  private final long connectionDurationMs;
+  private final long dataTransferDurationMs;
+  private final URI streamPath;
+  private final boolean latencyThresholdBreached;
+
+  public static GcsReadMetricEvent ofConnection(long durationMs, URI streamPath) {
+    return new GcsReadMetricEvent(durationMs, 0, streamPath, false);
+  }
+
+  public static GcsReadMetricEvent ofDataTransfer(long durationMs, URI streamPath) {
+    return ofDataTransfer(durationMs, streamPath, false);
+  }
+
+  public static GcsReadMetricEvent ofDataTransfer(
+      long durationMs, URI streamPath, boolean latencyThresholdBreached) {
+    return new GcsReadMetricEvent(0, durationMs, streamPath, latencyThresholdBreached);
+  }
+
+  public GcsReadMetricEvent(
+      long connectionDurationMs,
+      long dataTransferDurationMs,
+      URI streamPath,
+      boolean latencyThresholdBreached) {
+    this.connectionDurationMs = connectionDurationMs;
+    this.dataTransferDurationMs = dataTransferDurationMs;
+    this.streamPath = streamPath;
+    this.latencyThresholdBreached = latencyThresholdBreached;
+  }
+
+  public long getConnectionDurationMs() {
+    return connectionDurationMs;
+  }
+
+  public long getDataTransferDurationMs() {
+    return dataTransferDurationMs;
+  }
+
+  public URI getStreamPath() {
+    return streamPath;
+  }
+
+  public boolean isLatencyThresholdBreached() {
+    return latencyThresholdBreached;
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -48,6 +48,11 @@ public class GoogleCloudStorageEventBus {
     eventBus.unregister(obj);
   }
 
+  /** Resets the event bus by creating a new instance. */
+  public static void reset() {
+    eventBus = new EventBus();
+  }
+
   /**
    * Posting Gcs request execution event i.e. request to gcs is being initiated.
    *
@@ -76,6 +81,10 @@ public class GoogleCloudStorageEventBus {
 
   public static void postGcsJsonApiEvent(IGcsJsonApiEvent gcsJsonApiEvent) {
     eventBus.post(gcsJsonApiEvent);
+  }
+
+  public static void postReadMetricEvent(GcsReadMetricEvent gcsReadMetricEvent) {
+    eventBus.post(gcsReadMetricEvent);
   }
 
   public static void postWriteChecksumFailure() {

--- a/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
@@ -43,7 +43,9 @@ public class GcsReadDurationTrackerStreamTest {
         new Object() {
           @Subscribe
           public void onGcsReadMetricEvent(GcsReadMetricEvent event) {
-            events.add(event);
+            if (event.getType() == GcsReadMetricEvent.Type.DATA_TRANSFER) {
+              events.add(event);
+            }
           }
         });
   }
@@ -70,7 +72,7 @@ public class GcsReadDurationTrackerStreamTest {
 
     assertThat(events).hasSize(1);
     GcsReadMetricEvent event = events.get(0);
-    assertThat(event.getDataTransferDurationMs()).isAtLeast(100L);
+    assertThat(event.getDurationMs()).isAtLeast(100L);
     assertThat(event.getStreamPath()).isEqualTo(path);
   }
 

--- a/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.common.eventbus.Subscribe;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GcsReadDurationTrackerStreamTest {
+
+  private final List<GcsReadMetricEvent> events = new ArrayList<>();
+  private final URI path = URI.create("gs://bucket/obj");
+
+  @Before
+  public void setUp() {
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventBus.register(
+        new Object() {
+          @Subscribe
+          public void onGcsReadMetricEvent(GcsReadMetricEvent event) {
+            events.add(event);
+          }
+        });
+  }
+
+  @Test
+  public void testDurationTracking() throws IOException {
+    byte[] data = new byte[100];
+    ByteArrayInputStream bais =
+        new ByteArrayInputStream(data) {
+          @Override
+          public synchronized int read(byte[] b, int off, int len) {
+            try {
+              Thread.sleep(100);
+            } catch (InterruptedException e) {
+              // ignore
+            }
+            return super.read(b, off, len);
+          }
+        };
+
+    GcsReadDurationTrackerStream stream = new GcsReadDurationTrackerStream(bais, path, null, 1000L);
+    stream.read(new byte[10]);
+    stream.close();
+
+    assertThat(events).hasSize(1);
+    GcsReadMetricEvent event = events.get(0);
+    assertThat(event.getDataTransferDurationMs()).isAtLeast(100L);
+    assertThat(event.getStreamPath()).isEqualTo(path);
+  }
+
+  @Test
+  public void testLatencyThresholdBreached() throws IOException {
+    ByteArrayInputStream bais =
+        new ByteArrayInputStream(new byte[10]) {
+          @Override
+          public synchronized int read(byte[] b, int off, int len) {
+            try {
+              Thread.sleep(1100);
+            } catch (InterruptedException e) {
+              // ignore
+            }
+            return super.read(b, off, len);
+          }
+        };
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("x-guploader-uploadid", "test-upload-id");
+
+    GcsReadDurationTrackerStream stream =
+        new GcsReadDurationTrackerStream(bais, path, headers, 1000L);
+    stream.read(new byte[1]);
+    stream.close();
+
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).isLatencyThresholdBreached()).isTrue();
+  }
+}


### PR DESCRIPTION
###   Summary of Changes

This PR introduces new telemetry and performance metrics to track latency across Google Cloud Storage (GCS) reads, specifically focusing on thread queue times, Time To First Byte (TTFB), and data transfer durations.

  High-Level Summary of Changes:

   1. Introduced Event-Driven Latency Tracking: 
     We created a new, reusable stream decorator (GcsReadDurationTracker). Instead of hardcoding timing logic inside the GCS read channels, this decorator cleanly wraps the network stream. It measures exactly
  how long it takes to transfer data and automatically publishes those metrics (like data_transfer_duration and latency_breached_count) to the global Hadoop Event Bus.

   2. Added Vectored IO Wait Time Metrics:
     We updated the asynchronous VectoredIOImpl engine. When Hadoop requests multiple file ranges in parallel, we now explicitly track how long those background tasks sit waiting in the thread pool queue
  (STREAM_READ_VECTORED_THREAD_WAIT_DURATION) before execution begins.

   3. Improved High-Latency Logging:
     When a read operation takes longer than the expected threshold (1000ms), the system now logs a warning that surgically includes the specific GCS x-guploader-uploadid. This makes it significantly easier for user to correlate slow Hadoop reads with backend Google Cloud server logs.
