### PR TITLE
HNS Bug Fix

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -1040,7 +1040,8 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
     List<GoogleCloudStorageItemInfo> dirItemInfos = getFromFuture(dirItemInfosFuture);
     if (pathId.isStorageObject() && dirItemInfos.isEmpty()) {
       if (isHnsOptimized(path)
-          && gcs.getFolderInfo(StorageResourceId.fromUriPath(path, true)).exists()) {
+          && gcs.getFolderInfo(StorageResourceId.fromUriPath(path, true).toDirectoryId())
+              .exists()) {
         return FileInfo.fromItemInfos(dirItemInfos);
       }
       GoogleCloudStorageEventBus.postOnException();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
@@ -1795,6 +1795,34 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
   }
 
   @Test
+  public void listFileInfo_emptyNativeFolder_withoutTrailingSlash_returnsEmptyList()
+      throws Exception {
+    gcsFs =
+        newGcsFs(
+            newGcsFsOptions()
+                .setCloudStorageOptions(
+                    gcsOptions.toBuilder()
+                        .setHnOptimizationEnabled(true)
+                        .setHnBucketRenameEnabled(true)
+                        .build())
+                .build());
+    String hnsBucketName = gcsfsIHelper.getUniqueBucketName("hns-list-test-no-slash");
+    gcsFs
+        .getGcs()
+        .createBucket(
+            hnsBucketName,
+            CreateBucketOptions.builder().setHierarchicalNamespaceEnabled(true).build());
+    String testResource = getTestResource();
+    URI folderUriWithSlash = new URI(String.format("gs://%s/%s/", hnsBucketName, testResource));
+    URI folderUriWithoutSlash = new URI(String.format("gs://%s/%s", hnsBucketName, testResource));
+
+    gcsFs.mkdir(folderUriWithSlash);
+    List<FileInfo> fileInfos = gcsFs.listFileInfo(folderUriWithoutSlash);
+
+    assertThat(fileInfos).isEmpty();
+  }
+
+  @Test
   public void concurrentCreation_newObjet_overwrite_oneSucceeds() throws Exception {
     concurrentCreate_oneSucceeds(/* overwriteExisting= */ false);
   }


### PR DESCRIPTION
* Errors occur when listing empty directories in HNS-Enabled buckets with both HNS flags enabled.
The root cause is checking directory existence ([link/](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/91a095acae9066c15d5671f6048a415061c73710/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java#L1043)) by passing the path as a simple object rather than a directory.
* Fix : Convert the path to a Directory Path. 

More detail in the bug [b/](http://b/491669891)