### PR TITLE
Fix zombie threads and background resource leaks in vectored reads

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -31,6 +31,7 @@ import com.google.cloud.hadoop.gcsio.ReadVectoredSeekableByteChannel;
 import com.google.cloud.hadoop.gcsio.VectoredIORange;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
 import java.net.URI;
@@ -176,46 +177,53 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
   @Override
   public void readVectored(List<? extends FileRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
-    trackDuration(
-        streamStatistics,
-        STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
-        () -> {
-          if (channel instanceof ReadVectoredSeekableByteChannel) {
-            ReadVectoredSeekableByteChannel readVectoredSeekableByteChannelChannel =
-                (ReadVectoredSeekableByteChannel) channel;
-            ranges.forEach(
-                range -> {
-                  CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
-                  range.setData(result);
-                });
-            readVectoredSeekableByteChannelChannel.readVectored(
-                ranges.stream()
-                    .map(
-                        range ->
-                            VectoredIORange.builder()
-                                .setLength(range.getLength())
-                                .setOffset(range.getOffset())
-                                .setData(range.getData())
-                                .build())
-                    .collect(Collectors.toList()),
-                allocate);
-          } else {
-            long startTimeNs = System.nanoTime();
-            vectoredIOSupplier
-                .get()
-                .readVectored(
-                    ranges,
-                    allocate,
-                    gcsFs,
-                    fileInfo,
-                    gcsPath,
-                    streamStatistics,
-                    rangeReadThreadStats);
-            statistics.incrementReadOps(1);
-            vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
-          }
-          return null;
-        });
+    try {
+      trackDuration(
+          streamStatistics,
+          STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
+          () -> {
+            if (channel instanceof ReadVectoredSeekableByteChannel) {
+              ReadVectoredSeekableByteChannel readVectoredSeekableByteChannelChannel =
+                  (ReadVectoredSeekableByteChannel) channel;
+              ranges.forEach(
+                  range -> {
+                    CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
+                    range.setData(result);
+                  });
+              readVectoredSeekableByteChannelChannel.readVectored(
+                  ranges.stream()
+                      .map(
+                          range ->
+                              VectoredIORange.builder()
+                                  .setLength(range.getLength())
+                                  .setOffset(range.getOffset())
+                                  .setData(range.getData())
+                                  .build())
+                      .collect(Collectors.toList()),
+                  allocate);
+            } else {
+              long startTimeNs = System.nanoTime();
+              vectoredIOSupplier
+                  .get()
+                  .readVectored(
+                      ranges,
+                      allocate,
+                      gcsFs,
+                      fileInfo,
+                      gcsPath,
+                      streamStatistics,
+                      rangeReadThreadStats);
+              statistics.incrementReadOps(1);
+              vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
+            }
+            return null;
+          });
+    } catch (IOException e) {
+      if (IoExceptionHelper.isInterrupted(e)) {
+        Thread.currentThread().interrupt();
+      }
+      throw e;
+    }
   }
 
   @Override
@@ -260,6 +268,9 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             storageStatistics.streamReadOperationInComplete(length, Math.max(numRead, 0));
             response = numRead;
           } catch (IOException e) {
+            if (IoExceptionHelper.isInterrupted(e)) {
+              Thread.currentThread().interrupt();
+            }
             streamStatistics.readException();
             throw e;
           }
@@ -290,6 +301,11 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
           }
           try {
             channel.position(pos);
+          } catch (IOException e) {
+            if (IoExceptionHelper.isInterrupted(e)) {
+              Thread.currentThread().interrupt();
+            }
+            throw e;
           } catch (IllegalArgumentException e) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(e);

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -37,9 +37,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -143,19 +145,31 @@ public class VectoredIOImpl implements Closeable {
         // case when ranges are not merged
         for (FileRange sortedRange : sortedRanges) {
           long startTimer = System.currentTimeMillis();
-          boundedThreadPool.submit(
-              () -> {
-                logger.atFiner().log("Submitting range %s for execution.", sortedRange);
-                // Reset thread stats as a new task is being submitted to this thread.
-                // all required stats must be collected before task is finished.
-                resetThreadLocalStats();
-                readSingleRange(sortedRange, allocate, channelProvider);
-                long endTimer = System.currentTimeMillis();
-                storageStatistics.updateStats(
-                    GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                    endTimer - startTimer,
-                    channelProvider.gcsPath);
-              });
+          Future<?> executionFuture =
+              boundedThreadPool.submit(
+                  () -> {
+                    logger.atFiner().log("Submitting range %s for execution.", sortedRange);
+                    // Reset thread stats as a new task is being submitted to this thread.
+                    // all required stats must be collected before task is finished.
+                    resetThreadLocalStats();
+                    readSingleRange(sortedRange, allocate, channelProvider);
+                    long endTimer = System.currentTimeMillis();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
+                        endTimer - startTimer,
+                        channelProvider.gcsPath);
+                  });
+          sortedRange
+              .getData()
+              .whenComplete(
+                  (res, ex) -> {
+                    if (ex instanceof CancellationException) {
+                      logger.atFiner().log(
+                          "Cancelling execution future for range %s due to CancellationException",
+                          sortedRange);
+                      executionFuture.cancel(true);
+                    }
+                  });
         }
       } else {
         List<CombinedFileRange> combinedFileRanges = getCombinedFileRange(sortedRanges);
@@ -165,21 +179,33 @@ public class VectoredIOImpl implements Closeable {
           CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
           combinedFileRange.setData(result);
           long startTimer = System.currentTimeMillis();
-          boundedThreadPool.submit(
-              () -> {
-                logger.atFiner().log(
-                    "Submitting combinedRange %s for execution.", combinedFileRange);
+          Future<?> executionFuture =
+              boundedThreadPool.submit(
+                  () -> {
+                    logger.atFiner().log(
+                        "Submitting combinedRange %s for execution.", combinedFileRange);
 
-                // Reset thread stats as a new task is being submitted to this thread.
-                // all required stats must be collected before task is finished.
-                resetThreadLocalStats();
-                readCombinedRange(combinedFileRange, allocate, channelProvider);
-                long endTimer = System.currentTimeMillis();
-                storageStatistics.updateStats(
-                    GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                    endTimer - startTimer,
-                    channelProvider.gcsPath);
-              });
+                    // Reset thread stats as a new task is being submitted to this thread.
+                    // all required stats must be collected before task is finished.
+                    resetThreadLocalStats();
+                    readCombinedRange(combinedFileRange, allocate, channelProvider);
+                    long endTimer = System.currentTimeMillis();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
+                        endTimer - startTimer,
+                        channelProvider.gcsPath);
+                  });
+          combinedFileRange
+              .getData()
+              .whenComplete(
+                  (res, ex) -> {
+                    if (ex instanceof CancellationException) {
+                      logger.atFiner().log(
+                          "Cancelling execution future for combined range %s due to CancellationException",
+                          combinedFileRange);
+                      executionFuture.cancel(true);
+                    }
+                  });
         }
       }
     }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.fs.VectoredReadUtils.validateRangeRequest;
 import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -199,6 +200,11 @@ public class VectoredIOImpl implements Closeable {
      * @param executionFuture the future representing the background thread execution.
      */
     private void addCancellationListener(FileRange range, Future<?> executionFuture) {
+      if (range instanceof CombinedFileRange) {
+        for (FileRange child : ((CombinedFileRange) range).getUnderlying()) {
+          addCancellationListener(child, executionFuture);
+        }
+      }
       range
           .getData()
           .whenComplete(
@@ -321,6 +327,9 @@ public class VectoredIOImpl implements Closeable {
         }
         combinedFileRange.getData().complete(readContent);
       } catch (Exception e) {
+        if (IoExceptionHelper.isInterrupted(e)) {
+          Thread.currentThread().interrupt();
+        }
         logger.atWarning().withCause(e).log(
             "Exception while reading combinedFileRange:%s for path: %s",
             combinedFileRange, channelProvider.gcsPath);
@@ -374,6 +383,9 @@ public class VectoredIOImpl implements Closeable {
             "Read single range completed from range: %s, path: %s", range, channelProvider.gcsPath);
         range.getData().complete(dst);
       } catch (Exception e) {
+        if (IoExceptionHelper.isInterrupted(e)) {
+          Thread.currentThread().interrupt();
+        }
         logger.atWarning().withCause(e).log(
             "Exception while reading range:%s for path: %s", range, channelProvider.gcsPath);
         captureAndResetThreadLocalStats();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -159,17 +159,7 @@ public class VectoredIOImpl implements Closeable {
                         endTimer - startTimer,
                         channelProvider.gcsPath);
                   });
-          sortedRange
-              .getData()
-              .whenComplete(
-                  (res, ex) -> {
-                    if (ex instanceof CancellationException) {
-                      logger.atFiner().log(
-                          "Cancelling execution future for range %s due to CancellationException",
-                          sortedRange);
-                      executionFuture.cancel(true);
-                    }
-                  });
+          addCancellationListener(sortedRange, executionFuture);
         }
       } else {
         List<CombinedFileRange> combinedFileRanges = getCombinedFileRange(sortedRanges);
@@ -195,19 +185,31 @@ public class VectoredIOImpl implements Closeable {
                         endTimer - startTimer,
                         channelProvider.gcsPath);
                   });
-          combinedFileRange
-              .getData()
-              .whenComplete(
-                  (res, ex) -> {
-                    if (ex instanceof CancellationException) {
-                      logger.atFiner().log(
-                          "Cancelling execution future for combined range %s due to CancellationException",
-                          combinedFileRange);
-                      executionFuture.cancel(true);
-                    }
-                  });
+          addCancellationListener(combinedFileRange, executionFuture);
         }
       }
+    }
+
+    /**
+     * Adds a listener to the range's data future that will interrupt the background execution
+     * thread if the future is cancelled. This prevents background "zombie" threads from continuing
+     * to read data after a timeout or explicit cancellation by the caller.
+     *
+     * @param range the file range being read.
+     * @param executionFuture the future representing the background thread execution.
+     */
+    private void addCancellationListener(FileRange range, Future<?> executionFuture) {
+      range
+          .getData()
+          .whenComplete(
+              (res, ex) -> {
+                if (ex instanceof CancellationException) {
+                  logger.atWarning().log(
+                      "Cancelling execution future for range %s due to CancellationException",
+                      range);
+                  executionFuture.cancel(true);
+                }
+              });
     }
 
     private void updateRangeSizeCounters(int incomingRangeSize, int combinedRangeSize) {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -37,11 +37,13 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
@@ -490,6 +492,40 @@ public class VectoredIOImplTest {
         .isEqualTo(1);
   }
 
+  @Test
+  public void testZombieThreadPrevention() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    fileRanges.add(FileRange.createFileRange(0, 10));
+
+    CountDownLatch readStartedLatch = new CountDownLatch(1);
+    CountDownLatch interruptLatch = new CountDownLatch(1);
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    when(mockedGcsFs.open((FileInfo) any(), any()))
+        .thenReturn(new BlockingReadChannel(readStartedLatch, interruptLatch));
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the background thread to actually start reading
+    assertTrue("Read should have started", readStartedLatch.await(5, TimeUnit.SECONDS));
+
+    // Cancel the range's data future (simulating a Spark/Parquet timeout)
+    fileRanges.get(0).getData().cancel(true);
+
+    // Verify that the background thread was interrupted
+    assertTrue(
+        "Background thread should have been interrupted",
+        interruptLatch.await(5, TimeUnit.SECONDS));
+  }
+
   private void verifyRangeContent(List<FileRange> fileRanges) throws Exception {
     for (FileRange range : fileRanges) {
       ByteBuffer result = range.getData().get(1, TimeUnit.MINUTES);
@@ -549,6 +585,30 @@ public class VectoredIOImplTest {
     @Override
     public void close() {
       isOpen = false;
+    }
+  }
+
+  private class BlockingReadChannel extends MockedReadChannel {
+    private final CountDownLatch startLatch;
+    private final CountDownLatch interruptLatch;
+
+    public BlockingReadChannel(CountDownLatch startLatch, CountDownLatch interruptLatch) {
+      this.startLatch = startLatch;
+      this.interruptLatch = interruptLatch;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+      startLatch.countDown();
+      try {
+        // Simulating a long-running/blocked read that waits for an interrupt
+        Thread.sleep(10000);
+      } catch (InterruptedException e) {
+        interruptLatch.countDown();
+        Thread.currentThread().interrupt();
+        throw new ClosedByInterruptException();
+      }
+      return 0;
     }
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -526,6 +526,51 @@ public class VectoredIOImplTest {
         interruptLatch.await(5, TimeUnit.SECONDS));
   }
 
+  @Test
+  public void testCombinedRangeZombieThreadPrevention() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    // These two ranges will be merged based on default options
+    fileRanges.add(FileRange.createFileRange(0, 10));
+    fileRanges.add(FileRange.createFileRange(15, 10));
+
+    CountDownLatch readStartedLatch = new CountDownLatch(1);
+    CountDownLatch interruptLatch = new CountDownLatch(1);
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    when(mockedGcsFs.open((FileInfo) any(), any()))
+        .thenReturn(new BlockingReadChannel(readStartedLatch, interruptLatch));
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the background thread to actually start reading
+    assertTrue("Read should have started", readStartedLatch.await(5, TimeUnit.SECONDS));
+
+    // Cancel one of the child range's data future (simulating a Spark/Parquet timeout)
+    fileRanges.get(0).getData().cancel(true);
+
+    // Verify that the background thread was interrupted
+    assertTrue(
+        "Background thread should have been interrupted for combined range",
+        interruptLatch.await(5, TimeUnit.SECONDS));
+
+    // Verify both child ranges are failed/cancelled
+    assertTrue("First range should be cancelled", fileRanges.get(0).getData().isCancelled());
+    // The second range should also be completed exceptionally because the combined read was
+    // interrupted
+    ExecutionException ee =
+        assertThrows(
+            ExecutionException.class, () -> fileRanges.get(1).getData().get(1, TimeUnit.SECONDS));
+    assertThat(ee.getCause()).isInstanceOf(IOException.class);
+  }
+
   private void verifyRangeContent(List<FileRange> fileRanges) throws Exception {
     for (FileRange range : fileRanges) {
       ByteBuffer result = range.getData().get(1, TimeUnit.MINUTES);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -47,9 +47,12 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
@@ -363,6 +366,25 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         // each time we make progress we reset the retry counter.
         retriesAttempted = 0;
       } catch (IOException ioe) {
+        // Handle thread interruptions (e.g. from cancellation) separately from general
+        // IOExceptions.
+        // We catch InterruptedIOException but exclude its subclass SocketTimeoutException,
+        // which represents a network-level timeout that should still be retried.
+        if (ioe instanceof ClosedByInterruptException
+            || (ioe instanceof InterruptedIOException
+                && !(ioe instanceof SocketTimeoutException))) {
+          logger.atInfo().withCause(ioe).log(
+              "Thread interrupted while reading '%s' at position %d. Stopping further processing.",
+              resourceId, currentPosition);
+          closeContentChannel();
+          // Re-assert interrupt status and percolate as a non-retryable exception.
+          Thread.currentThread().interrupt();
+          throw new IOException(
+              String.format(
+                  "Thread interrupt received while reading '%s' at position %d.",
+                  resourceId, currentPosition),
+              ioe);
+        }
         logger.atFine().log(
             "Closing contentChannel after %s exception for '%s'.", ioe.getMessage(), resourceId);
         closeContentChannel();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -366,17 +366,22 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         // each time we make progress we reset the retry counter.
         retriesAttempted = 0;
       } catch (IOException ioe) {
+        logger.atFine().log(
+            "Closing contentChannel after %s exception for '%s'.", ioe.getMessage(), resourceId);
+        closeContentChannel();
+
         // Handle thread interruptions (e.g. from cancellation) separately from general
         // IOExceptions.
-        // We catch InterruptedIOException but exclude its subclass SocketTimeoutException,
-        // which represents a network-level timeout that should still be retried.
+        // Interruptions are treated as non-retryable events because they indicate the caller has
+        // abandoned the current request (e.g., due to a timeout) and may already be initiating
+        // a new attempt. We catch InterruptedIOException but exclude SocketTimeoutException,
+        // which is a network-level timeout that should still be retried.
         if (ioe instanceof ClosedByInterruptException
             || (ioe instanceof InterruptedIOException
                 && !(ioe instanceof SocketTimeoutException))) {
           logger.atInfo().withCause(ioe).log(
               "Thread interrupted while reading '%s' at position %d. Stopping further processing.",
               resourceId, currentPosition);
-          closeContentChannel();
           // Re-assert interrupt status and percolate as a non-retryable exception.
           Thread.currentThread().interrupt();
           throw new IOException(
@@ -385,9 +390,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                   resourceId, currentPosition),
               ioe);
         }
-        logger.atFine().log(
-            "Closing contentChannel after %s exception for '%s'.", ioe.getMessage(), resourceId);
-        closeContentChannel();
 
         if (buffer.remaining() != remainingBeforeRead) {
           int partialRead = remainingBeforeRead - buffer.remaining();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -36,6 +36,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.cloud.hadoop.util.ResilientOperation;
 import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.annotations.VisibleForTesting;
@@ -47,12 +48,9 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
-import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
@@ -370,15 +368,23 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             "Closing contentChannel after %s exception for '%s'.", ioe.getMessage(), resourceId);
         closeContentChannel();
 
+        if (buffer.remaining() != remainingBeforeRead) {
+          int partialRead = remainingBeforeRead - buffer.remaining();
+          logger.atInfo().log(
+              "Despite exception, had partial read of %d bytes from '%s'; resetting retry count.",
+              partialRead, resourceId);
+          retriesAttempted = 0;
+          totalBytesRead += partialRead;
+          currentPosition += partialRead;
+        }
+
         // Handle thread interruptions (e.g. from cancellation) separately from general
         // IOExceptions.
         // Interruptions are treated as non-retryable events because they indicate the caller has
         // abandoned the current request (e.g., due to a timeout) and may already be initiating
         // a new attempt. We catch InterruptedIOException but exclude SocketTimeoutException,
         // which is a network-level timeout that should still be retried.
-        if (ioe instanceof ClosedByInterruptException
-            || (ioe instanceof InterruptedIOException
-                && !(ioe instanceof SocketTimeoutException))) {
+        if (IoExceptionHelper.isInterrupted(ioe)) {
           logger.atInfo().withCause(ioe).log(
               "Thread interrupted while reading '%s' at position %d. Stopping further processing.",
               resourceId, currentPosition);
@@ -389,16 +395,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                   "Thread interrupt received while reading '%s' at position %d.",
                   resourceId, currentPosition),
               ioe);
-        }
-
-        if (buffer.remaining() != remainingBeforeRead) {
-          int partialRead = remainingBeforeRead - buffer.remaining();
-          logger.atInfo().log(
-              "Despite exception, had partial read of %d bytes from '%s'; resetting retry count.",
-              partialRead, resourceId);
-          retriesAttempted = 0;
-          totalBytesRead += partialRead;
-          currentPosition += partialRead;
         }
 
         // TODO(user): Refactor any reusable logic for retries into a separate RetryHelper
@@ -1035,6 +1031,10 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           break;
         } catch (IOException footerException) {
           GoogleCloudStorageEventBus.postOnException();
+          if (IoExceptionHelper.isInterrupted(footerException)) {
+            Thread.currentThread().interrupt();
+            throw footerException;
+          }
           logger.atInfo().withCause(footerException).log(
               "Failed to prefetch footer (retry #%d/%d) for '%s'",
               retriesCount + 1, maxRetries, resourceId);

--- a/util/src/main/java/com/google/cloud/hadoop/util/IoExceptionHelper.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/IoExceptionHelper.java
@@ -18,8 +18,10 @@ package com.google.cloud.hadoop.util;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedByInterruptException;
 import javax.net.ssl.SSLException;
 
 /**
@@ -77,5 +79,25 @@ public final class IoExceptionHelper {
    */
   public static boolean isReadTimedOut(IOException e) {
     return e instanceof SocketTimeoutException && e.getMessage().equalsIgnoreCase("Read timed out");
+  }
+
+  /**
+   * Determines if a given {@link Throwable} is caused by a thread interruption.
+   *
+   * <p>Recursively checks {@code getCause()} if outer exception isn't an instance of the correct
+   * class.
+   *
+   * @param throwable The {@link Throwable} to check.
+   * @return True if the {@link Throwable} is a result of a thread interruption.
+   */
+  public static boolean isInterrupted(Throwable throwable) {
+    if (throwable instanceof InterruptedException
+        || throwable instanceof ClosedByInterruptException
+        || (throwable instanceof InterruptedIOException
+            && !(throwable instanceof SocketTimeoutException))) {
+      return true;
+    }
+    Throwable cause = throwable.getCause();
+    return cause != null && isInterrupted(cause);
   }
 }

--- a/util/src/test/java/com/google/cloud/hadoop/util/IoExceptionHelperTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/IoExceptionHelperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedByInterruptException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IoExceptionHelperTest {
+
+  @Test
+  public void testIsInterrupted() {
+    assertThat(IoExceptionHelper.isInterrupted(new InterruptedException())).isTrue();
+    assertThat(IoExceptionHelper.isInterrupted(new ClosedByInterruptException())).isTrue();
+    assertThat(IoExceptionHelper.isInterrupted(new InterruptedIOException())).isTrue();
+
+    // SocketTimeoutException should NOT be treated as interrupt
+    assertThat(IoExceptionHelper.isInterrupted(new SocketTimeoutException())).isFalse();
+
+    // Regular IOException should NOT be treated as interrupt
+    assertThat(IoExceptionHelper.isInterrupted(new IOException())).isFalse();
+
+    // Nested interruptions should be detected
+    assertThat(IoExceptionHelper.isInterrupted(new IOException(new InterruptedException())))
+        .isTrue();
+    assertThat(
+            IoExceptionHelper.isInterrupted(new RuntimeException(new ClosedByInterruptException())))
+        .isTrue();
+
+    // Nested non-interruptions
+    assertThat(IoExceptionHelper.isInterrupted(new IOException(new SocketTimeoutException())))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
 This change ensures background worker threads terminate immediately when a vectored read is cancelled by the caller (e.g., Spark/Parquet). It implements cancellation propagation in VectoredIOImpl by interrupting worker futures upon range data cancellation. GoogleCloudStorageReadChannel is updated to catch ClosedByInterruptException and InterruptedIOException, triggering immediate cleanup and preventing redundant retries. These improvements prevent background resource saturation and ensure prompt release of network and thread pool resources. Wildcard imports in VectoredIOImpl were also replaced with explicit
ones.

The following is the follow after this change :

   1. The Trigger: Parquet Timeout
       * Spark/Parquet waits for data using a timed wait (e.g., 30 seconds). If the GCS network call is slow, Parquet's CompletableFuture.get(30, SECONDS) expires and throws a TimeoutException.
       * Immediately after the timeout, Parquet calls range.getData().cancel(true).
       * This signals the system: "I no longer want this data; stop all associated work."

  ---

   2. The Link: VectoredIOImpl Cancellation Propagation
           1. Trigger: The whenComplete block on the range's data future is triggered by the cancellation.
           2. Detection: It detects that the exception is a CancellationException.
           3. Targeting: It identifies the specific executionFuture (the background worker thread) associated with that range.
           4. Action: It calls executionFuture.cancel(true), sending the INTERRUPT signal to the worker thread.

  ---

   3. The Execution: Worker Thread Interruption
       * The background worker thread is typically stuck inside the do...while loop of GoogleCloudStorageReadChannel.read(), waiting for data from the GCS network socket.
           1. Signal: Because executionFuture.cancel(true) was called, the JVM sets the interrupt flag on that worker thread.
           2. Reaction: The low-level Java NIO channel (contentChannel.read()) is interruptible. As soon as it detects the interrupt flag, it immediately stops the network transfer and throws a
              java.nio.channels.ClosedByInterruptException.

  ---

   4. The Recovery: Catching the Interrupt
       * The thread jumps out of the read() call and into the new consolidated catch block in GoogleCloudStorageReadChannel.java:
           1. Detection: It catches the IOException and identifies it as an interruption (while carefully ignoring standard SocketTimeoutException).
           2. Cleanup: It calls closeContentChannel() to release the GCS network connection immediately.
           3. State Preservation: It calls Thread.currentThread().interrupt() to ensure the thread's interrupt status remains set for the parent pool.
           4. Stop Retries: Instead of entering the standard IOException retry logic (which would wait and try again up to 10 times), it throws a new IOException wrapping the interrupt, exiting the loop
              immediately.

  ---

   5. Final Result: Efficient Resource Release
       * The exception bubbles up to the worker thread's top level in VectoredIOImpl, where it is logged.
           * Thread Recovery: The thread is returned to the boundedThreadPool immediately, making it available for new tasks.
           * Bandwidth Savings: The GCS connection is closed instantly, stopping unnecessary data downloads and saving costs.
           * System Stability: The user sees the timeout error as expected, but background "ghost" tasks are eliminated, preventing thread pool saturation and system-wide hangs.


Error StackTrace

<img width="1354" height="388" alt="Screenshot 2026-04-01 at 4 47 52 PM" src="https://github.com/user-attachments/assets/92514f32-3bff-482c-93c6-cd7649dd5f07" />
