### PR TITLE
Capture BYTES_READ Metrics In Case Of Exception

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -31,6 +31,7 @@ import com.google.cloud.hadoop.gcsio.ReadVectoredSeekableByteChannel;
 import com.google.cloud.hadoop.gcsio.VectoredIORange;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
 import java.net.URI;
@@ -137,7 +138,8 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
     return new GoogleHadoopFSInputStream(ghfs, fileInfo.getPath(), fileInfo, channel, statistics);
   }
 
-  private GoogleHadoopFSInputStream(
+  @VisibleForTesting
+  GoogleHadoopFSInputStream(
       GoogleHadoopFileSystem ghfs,
       URI gcsPath,
       FileInfo fileInfo,
@@ -246,13 +248,15 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             throw new IndexOutOfBoundsException();
           }
           int response = 0;
+          ByteBuffer buffer = ByteBuffer.wrap(buf, offset, length);
           try {
             // TODO(user): Wrap this in a while-loop if we ever introduce a non-blocking mode for
             // the underlying channel.
-            int numRead = channel.read(ByteBuffer.wrap(buf, offset, length));
+            int numRead = channel.read(buffer);
             if (numRead > 0) {
               // -1 means we actually read 0 bytes, but requested at least one byte.
               totalBytesRead += numRead;
+              statistics.incrementBytesRead(numRead);
               statistics.incrementReadOps(1);
               streamStats.updateReadStreamStats(numRead, startTimeNs);
             }
@@ -261,6 +265,13 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             response = numRead;
           } catch (IOException e) {
             streamStatistics.readException();
+            int bytesReadBeforeException = buffer.position() - offset;
+            if (bytesReadBeforeException > 0) {
+              totalBytesRead += bytesReadBeforeException;
+              statistics.incrementBytesRead(bytesReadBeforeException);
+              streamStatistics.bytesRead(bytesReadBeforeException);
+              streamStats.updateReadStreamStats(bytesReadBeforeException, startTimeNs);
+            }
             throw e;
           }
           streamStatistics.bytesRead(max(response, 0));

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.statistics.DurationTracker;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for GoogleHadoopFSInputStream class. */
+@RunWith(JUnit4.class)
+public class GoogleHadoopFSInputStreamTest {
+
+  @Mock private GoogleHadoopFileSystem mockGhfs;
+  @Mock private GoogleCloudStorageFileSystem mockGcsFs;
+  @Mock private GhfsGlobalStorageStatistics mockStorageStatistics;
+  @Mock private GhfsInstrumentation mockInstrumentation;
+  @Mock private GhfsInputStreamStatistics mockStreamStatistics;
+
+  private GoogleHadoopFSInputStream inputStream;
+  private SeekableByteChannel mockChannel;
+  private FileSystem.Statistics hadoopStatistics;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+
+    hadoopStatistics = new FileSystem.Statistics("gs");
+    mockChannel = mock(SeekableByteChannel.class);
+
+    when(mockGhfs.getGcsFs()).thenReturn(mockGcsFs);
+    when(mockGhfs.getGlobalGcsStorageStatistics()).thenReturn(mockStorageStatistics);
+    when(mockGhfs.getInstrumentation()).thenReturn(mockInstrumentation);
+    when(mockInstrumentation.newInputStreamStatistics(any())).thenReturn(mockStreamStatistics);
+    when(mockStreamStatistics.trackDuration(anyString(), anyLong()))
+        .thenReturn(new StubDurationTracker());
+    when(mockStreamStatistics.trackDuration(anyString())).thenReturn(new StubDurationTracker());
+
+    inputStream =
+        new GoogleHadoopFSInputStream(
+            mockGhfs,
+            URI.create("gs://test-bucket/test-file"),
+            null,
+            mockChannel,
+            hadoopStatistics);
+  }
+
+  @Test
+  public void read_partialReadBeforeException_updatesStatistics() throws IOException {
+    // Verify that data read before an exception occurs is correctly recorded in statistics.
+    byte[] buffer = new byte[10];
+    int offset = 0;
+    int length = 10;
+
+    // Mock channel to read 5 bytes then throw IOException
+    when(mockChannel.read(any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer bb = invocation.getArgument(0);
+              bb.put(new byte[5]);
+              throw new IOException("Simulated partial read failure");
+            });
+
+    assertThrows(IOException.class, () -> inputStream.read(buffer, offset, length));
+
+    // Verify that the 5 bytes read before the exception were recorded
+    assertThat(hadoopStatistics.getBytesRead()).isEqualTo(5);
+  }
+
+  private static class StubDurationTracker implements DurationTracker {
+    @Override
+    public void failed() {}
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
**PR Summary: Capture BYTES_READ Metrics In Case Of Exception**

**Overview**
This PR improves the accuracy of GCS connector metrics by ensuring that bytes read are captured even when a read operation terminates with an IOException. Previously, partial reads followed by an exception would result in those bytes being omitted from the BYTES_READ statistics.

  **Key Changes**

  **1. GoogleHadoopFSInputStream.java**
   - Partial Read Tracking: Updated the read(byte[] buf, int offset, int length) method to track the number of bytes successfully written to the buffer before an IOException occurs.
   - Metric Updates in Catch Block: In the event of an IOException, the code now calculates the bytes read using the ByteBuffer position and updates the following statistics:
       - totalBytesRead
       - statistics.incrementBytesRead() (Hadoop FileSystem.Statistics)
       - streamStatistics.bytesRead()
       - streamStats.updateReadStreamStats()
   - Visibility Change: Updated the GoogleHadoopFSInputStream constructor from private to package-private and added @VisibleForTesting to facilitate unit testing.

  **2. GoogleHadoopFSInputStreamTest.java (New)**
   - New Unit Tests: Introduced a new test suite for GoogleHadoopFSInputStream.
   - Validation of Partial Reads: Added read_partialReadBeforeException_updatesStatistics, which mocks a partial read followed by a failure and verifies that the FileSystem.Statistics correctly reflects the
     partial data transferred.

  **Verification Results**
   - Unit Tests: The new test case read_partialReadBeforeException_updatesStatistics passed, confirming that metrics are now correctly captured during exception scenarios.
