### PR TITLE
Upgrade google.api-client-libraries.version to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>${google.api-client-libraries.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client-gson</artifactId>
+        <version>${google.api-client-libraries.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
         <version>${google.cloud.library.bom.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,10 @@
 
     <bigdataoss.version>3.1.16-SNAPSHOT</bigdataoss.version>
 
-    <google.api-client-libraries.version>2.0.0</google.api-client-libraries.version>
-    <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
-    <google.api-storage.version>v1-rev20250312-${google.api-client-libraries.version}</google.api-storage.version>
+    <google.api-client-libraries.version>2.9.0</google.api-client-libraries.version>
+    <google.api-client-libraries-fallback.version>2.0.0</google.api-client-libraries-fallback.version>
+    <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries-fallback.version}</google.api-iamcredentials.version>
+    <google.api-storage.version>v1-rev20250312-${google.api-client-libraries-fallback.version}</google.api-storage.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <!-- Library bom for Java-Storage -->
     <google.cloud.library.bom.version>26.56.0</google.cloud.library.bom.version>


### PR DESCRIPTION
* Update google.api-client-libraries.version to `2.9.0`
* Use fallback `2.0.0` for` google.api-iamcredentials.version`( and storage) as its auto-generated model libraries have not yet been published to Maven Central with the `-2.9.0`([google.api-storage.version/](https://central.sonatype.com/artifact/com.google.apis/google-api-services-storage/versions) [google.api-iamcredentials.version](https://central.sonatype.com/artifact/com.google.apis/google-api-services-iamcredentials/versions))suffix, but the 2.0.0 versions remain fully compatible with the 2.9.0 client