### PR TITLE
Backport 3.1.x: chore: Migrate gsutil usage to gcloud storage (#1646)

### DIFF
--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -133,7 +133,7 @@ the installation.
 
 *   If the test issued a message related to authorization, make sure that you
     have access to Cloud Storage using
-    [gsutil](https://cloud.google.com/storage/docs/gsutil) (`gsutil ls -b
+    [gsutil](https://cloud.google.com/storage/docs/gsutil) (`gcloud storage ls -b
     gs://<some-bucket>`), and that the credentials in your configuration are
     correct.
 

--- a/gcs/README.md
+++ b/gcs/README.md
@@ -60,7 +60,7 @@ There are multiple ways to access data stored in Google Cloud Storage:
     or `fs -ls /dir/file`
 *   the
     [Cloud Platform Console Cloud Storage browser](https://cloud.google.com/storage/docs/gettingstarted-console)
-*   [`gsutil cp`](https://cloud.google.com/storage/docs/gsutil/commands/cp)
-*   [`gsutil rsync`](https://cloud.google.com/storage/docs/gsutil/commands/rsync)
+*   [`gcloud storage cp`](https://docs.cloud.google.com/sdk/gcloud/reference/storage/cp)
+*   [`gcloud storage rsync`](https://cloud.google.com/sdk/gcloud/reference/storage/rsync)
 *   The
     [Cloud Storage JSON API](https://cloud.google.com/storage/docs/json_api/v1/)


### PR DESCRIPTION
Original PR : https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1646