### PR TITLE
Log and drop while receiving the additional bytes from server

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -359,6 +359,11 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                   "Received end of stream result after the channel end; at offset: %d "
                       + "whereas stream was suppose to end at: %d for resource: %s of size: %d",
                   currentPosition, contentChannelEnd, resourceId, objectSize);
+              // Dropping additional bytes.
+              int overshoot = (int) (currentPosition - contentChannelEnd);
+              dst.position(dst.position() - overshoot);
+              currentPosition = contentChannelEnd;
+
               closeContentChannel();
               continue;
             }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -25,13 +25,18 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ErrorTypeExtractor;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.StorageException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import java.io.ByteArrayInputStream;
@@ -39,6 +44,8 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
@@ -55,13 +62,17 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private static final String GZIP_ENCODING = "gzip";
+  private static final String OTEL_DECORATED_READ_CHANNEL = "OtelDecoratedReadChannel";
+  private static final String STORAGE_READ_CHANNEL = "StorageReadChannel";
+  private static final String GRPC_BLOB_READ_CHANNEL = "GrpcBlobReadChannel";
 
-  private final StorageResourceId resourceId;
+  private StorageResourceId resourceId;
   private final GoogleCloudStorageReadOptions readOptions;
   private final GoogleCloudStorageOptions storageOptions;
   private final Storage storage;
   // The size of this object generation, in bytes.
-  private long objectSize;
+  private long objectSize = -1;
+  private boolean metadataInitialized = false;
   private final ErrorTypeExtractor errorExtractor;
   private ContentReadChannel contentReadChannel;
   private boolean gzipEncoded = false;
@@ -73,31 +84,74 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
   public GoogleCloudStorageClientReadChannel(
       Storage storage,
-      GoogleCloudStorageItemInfo itemInfo,
+      StorageResourceId resourceId,
+      @Nullable GoogleCloudStorageItemInfo itemInfo,
       GoogleCloudStorageReadOptions readOptions,
       ErrorTypeExtractor errorExtractor,
       GoogleCloudStorageOptions storageOptions)
       throws IOException {
-    validate(itemInfo);
     this.storage = storage;
     this.errorExtractor = errorExtractor;
-    this.resourceId =
-        new StorageResourceId(
-            itemInfo.getBucketName(), itemInfo.getObjectName(), itemInfo.getContentGeneration());
+    this.resourceId = resourceId;
     this.readOptions = readOptions;
     this.storageOptions = storageOptions;
     this.contentReadChannel = new ContentReadChannel(readOptions, resourceId);
-    initMetadata(itemInfo.getContentEncoding(), itemInfo.getSize());
+    if (itemInfo != null) {
+      validate(itemInfo);
+      initMetadata(
+          itemInfo.getContentEncoding(), itemInfo.getSize(), itemInfo.getContentGeneration());
+    } else {
+      if (readOptions.isFastFailOnNotFoundEnabled()) {
+        fetchMetadata();
+      }
+    }
   }
 
-  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata) throws IOException {
+  private void fetchMetadata() throws IOException {
+    try {
+      BlobId blobId =
+          BlobId.of(
+              resourceId.getBucketName(),
+              resourceId.getObjectName(),
+              resourceId.hasGenerationId() ? resourceId.getGenerationId() : null);
+      Blob blob =
+          storage.get(
+              blobId,
+              Storage.BlobGetOption.fields(
+                  Storage.BlobField.CONTENT_ENCODING,
+                  Storage.BlobField.SIZE,
+                  Storage.BlobField.GENERATION));
+      if (blob == null) {
+        throw new FileNotFoundException(String.format("Item not found: %s", resourceId));
+      }
+      initMetadata(blob.getContentEncoding(), blob.getSize(), blob.getGeneration());
+    } catch (StorageException e) {
+      throw new IOException("Failed to fetch metadata for " + resourceId, e);
+    }
+  }
+
+  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata, long generation)
+      throws IOException {
+    checkState(!metadataInitialized, "Metadata already initialized");
     gzipEncoded = nullToEmpty(encoding).contains(GZIP_ENCODING);
     if (gzipEncoded && !readOptions.isGzipEncodingSupportEnabled()) {
       GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           "Cannot read GZIP encoded files - content encoding support is disabled.");
     }
-    objectSize = gzipEncoded ? Long.MAX_VALUE : sizeFromMetadata;
+    objectSize = gzipEncoded ? -1 : sizeFromMetadata;
+    if (!resourceId.hasGenerationId()) {
+      resourceId =
+          new StorageResourceId(resourceId.getBucketName(), resourceId.getObjectName(), generation);
+    } else {
+      checkState(
+          resourceId.getGenerationId() == generation,
+          "Provided generation (%s) should be equal to fetched generation (%s) for '%s'",
+          resourceId.getGenerationId(),
+          generation,
+          resourceId);
+    }
+    metadataInitialized = true;
   }
 
   @Override
@@ -155,6 +209,10 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
   @Override
   public long size() throws IOException {
+    throwIfNotOpen();
+    if (!metadataInitialized) {
+      fetchMetadata();
+    }
     return objectSize;
   }
 
@@ -195,7 +253,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
     // Size of buffer to allocate for skipping bytes in-place when performing in-place seeks.
     private static final int SKIP_BUFFER_SIZE = 8192;
-    private final BlobId blobId;
 
     // This is the actual current position in `contentChannel` from where read can happen.
     // This remains unchanged of position(long) method call.
@@ -211,13 +268,18 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
     public ContentReadChannel(
         GoogleCloudStorageReadOptions readOptions, StorageResourceId resourceId) {
-      this.blobId =
-          BlobId.of(
-              resourceId.getBucketName(), resourceId.getObjectName(), resourceId.getGenerationId());
       this.fileAccessManager = new FileAccessPatternManager(resourceId, readOptions);
       if (gzipEncoded) {
         fileAccessManager.overrideAccessPattern(false);
       }
+    }
+
+    private BlobId getBlobId() {
+      Long generationId =
+          resourceId.getGenerationId() == StorageResourceId.UNKNOWN_GENERATION_ID
+              ? null
+              : resourceId.getGenerationId();
+      return BlobId.of(resourceId.getBucketName(), resourceId.getObjectName(), generationId);
     }
 
     public int readContent(ByteBuffer dst) throws IOException {
@@ -266,6 +328,8 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                 bytesRead, currentPosition, contentChannelEnd, resourceId, objectSize);
           }
 
+          ensureMetadataInitialized(byteChannel);
+
           if (bytesRead < 0) {
             // Because we don't know decompressed object size for gzip-encoded objects,
             // assume that this is an object end.
@@ -274,24 +338,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               contentChannelEnd = currentPosition;
             }
 
-            if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
+            if (currentPosition != contentChannelEnd && currentPosition != objectSize) {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received;"
+                          + "EndOf stream signal received at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
-            } else if (currentPosition > objectSize) {
-              GoogleCloudStorageEventBus.postOnException();
-              throw new IOException(
-                  String.format(
-                      "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
-                      currentPosition, contentChannelEnd, resourceId, objectSize));
-            } else if (currentPosition > contentChannelEnd) {
-              logger.atWarning().log(
-                  "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
-                  currentPosition, contentChannelEnd, resourceId, objectSize);
-              closeContentChannel();
-              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -354,11 +407,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       ReadableByteChannel readableByteChannel =
           getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
 
-      // Logging at warning so that we don't need to change log level.
-      logger.atWarning().log(
-          "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
-          contentChannelCurrentPosition, contentChannelEnd);
-
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)
               <= readOptions.getMinRangeRequestSize()) {
@@ -369,6 +417,47 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
         return serveFooterContent();
       }
       return readableByteChannel;
+    }
+
+    private void ensureMetadataInitialized(ReadableByteChannel readableByteChannel)
+        throws IOException {
+      if (metadataInitialized) {
+        return;
+      }
+
+      if (!initializeMetadataFromChannel(readableByteChannel)) {
+        logger.atInfo().log("Fallback to metadata fetch for '%s'", resourceId);
+        fetchMetadata();
+      }
+    }
+
+    private boolean initializeMetadataFromChannel(ReadableByteChannel readableByteChannel) {
+      if (!(readableByteChannel instanceof ReadChannel)) {
+        return false;
+      }
+
+      try {
+        ApiFuture<BlobInfo> blobInfoFuture =
+            getBlobInfoFromReadChannelFunction((ReadChannel) readableByteChannel);
+        if (!blobInfoFuture.isDone()) {
+          return false;
+        }
+        BlobInfo blobInfo = blobInfoFuture.get();
+        if (blobInfo == null) {
+          return false;
+        }
+
+        objectSize = blobInfo.getSize();
+        initMetadata(blobInfo.getContentEncoding(), objectSize, blobInfo.getGeneration());
+        if (gzipEncoded) {
+          fileAccessManager.overrideAccessPattern(false);
+        }
+        return true;
+      } catch (Exception e) {
+        logger.atWarning().withCause(e).log(
+            "Failed to get metadata from read channel for '%s'", resourceId);
+        return false;
+      }
     }
 
     private void setChannelBoundaries(long bytesToRead) {
@@ -438,18 +527,19 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private long getRangeRequestEnd(long startPosition, long bytesToRead) {
+      long effectiveSize = objectSize == -1 ? Long.MAX_VALUE : objectSize;
       // Always read gzip-encoded files till the end - they do not support range reads.
       if (gzipEncoded) {
-        return objectSize;
+        return effectiveSize;
       }
-      long endPosition = objectSize;
+      long endPosition = effectiveSize;
       if (fileAccessManager.shouldAdaptToRandomAccess()) {
         // opening a channel for whole object doesn't make sense as anyhow it will not be utilized
         // for further reads.
         endPosition = startPosition + max(bytesToRead, readOptions.getMinRangeRequestSize());
       } else {
         if (readOptions.getFadvise() == Fadvise.AUTO_RANDOM) {
-          endPosition = min(startPosition + readOptions.getBlockSize(), objectSize);
+          endPosition = min(startPosition + readOptions.getBlockSize(), effectiveSize);
         }
       }
 
@@ -460,7 +550,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       if (footerContent != null) {
         // If footer is cached open just till footerStart.
         // Remaining content ill be served from cached footer itself.
-        endPosition = min(endPosition, objectSize - footerContent.length);
+        endPosition = min(endPosition, effectiveSize - footerContent.length);
       }
       return endPosition;
     }
@@ -555,6 +645,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private ReadableByteChannel getStorageReadChannel(long seek, long limit) throws IOException {
+      BlobId blobId = getBlobId();
       ReadChannel readChannel = storage.reader(blobId, generateReadOptions(blobId));
       try {
         readChannel.seek(seek);
@@ -589,7 +680,8 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private boolean isFooterRead() {
-      return objectSize - currentPosition <= readOptions.getMinRangeRequestSize();
+      return objectSize != -1
+          && objectSize - currentPosition <= readOptions.getMinRangeRequestSize();
     }
   }
 
@@ -647,6 +739,37 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     if (!isOpen()) {
       GoogleCloudStorageEventBus.postOnException();
       throw new ClosedChannelException();
+    }
+  }
+
+  public static ApiFuture<BlobInfo> getBlobInfoFromReadChannelFunction(ReadChannel readChannel) {
+    // This method relies on the internal implementation details of the Google Cloud Storage client
+    // library (specifically field names and method names). If the underlying library changes,
+    // this reflection logic might break. In that case, we catch the exception and fallback to
+    // explicit metadata fetching, ensuring robustness at the cost of an extra API call.
+    try {
+      ReadChannel targetChannel = readChannel;
+      String channelClassName = targetChannel.getClass().getName();
+      if (channelClassName.endsWith(OTEL_DECORATED_READ_CHANNEL)) {
+        Field readerField = targetChannel.getClass().getDeclaredField("reader");
+        readerField.setAccessible(true);
+        targetChannel = (ReadChannel) readerField.get(targetChannel);
+        channelClassName = targetChannel.getClass().getName();
+      }
+      if (channelClassName.endsWith(STORAGE_READ_CHANNEL)
+          || channelClassName.endsWith(GRPC_BLOB_READ_CHANNEL)) {
+        Method getObjectMethod = targetChannel.getClass().getMethod("getObject");
+        getObjectMethod.setAccessible(true);
+        return (ApiFuture<BlobInfo>) getObjectMethod.invoke(targetChannel);
+      } else {
+        return ApiFutures.immediateFailedFuture(
+            new IllegalArgumentException(
+                "Unsupported ReadChannel implementation: " + channelClassName));
+      }
+    } catch (Exception e) {
+      return ApiFutures.immediateFailedFuture(
+          new IllegalStateException(
+              "Failed to get object info from " + readChannel.getClass().getName(), e));
     }
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -363,6 +363,8 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               int overshoot = (int) (currentPosition - contentChannelEnd);
               dst.position(dst.position() - overshoot);
               currentPosition = contentChannelEnd;
+              totalBytesRead -= overshoot;
+              contentChannelCurrentPosition -= overshoot;
 
               closeContentChannel();
               continue;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -25,18 +25,13 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ErrorTypeExtractor;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobSourceOption;
-import com.google.cloud.storage.StorageException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import java.io.ByteArrayInputStream;
@@ -44,8 +39,6 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
@@ -62,17 +55,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private static final String GZIP_ENCODING = "gzip";
-  private static final String OTEL_DECORATED_READ_CHANNEL = "OtelDecoratedReadChannel";
-  private static final String STORAGE_READ_CHANNEL = "StorageReadChannel";
-  private static final String GRPC_BLOB_READ_CHANNEL = "GrpcBlobReadChannel";
 
-  private StorageResourceId resourceId;
+  private final StorageResourceId resourceId;
   private final GoogleCloudStorageReadOptions readOptions;
   private final GoogleCloudStorageOptions storageOptions;
   private final Storage storage;
   // The size of this object generation, in bytes.
-  private long objectSize = -1;
-  private boolean metadataInitialized = false;
+  private long objectSize;
   private final ErrorTypeExtractor errorExtractor;
   private ContentReadChannel contentReadChannel;
   private boolean gzipEncoded = false;
@@ -84,74 +73,31 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
   public GoogleCloudStorageClientReadChannel(
       Storage storage,
-      StorageResourceId resourceId,
-      @Nullable GoogleCloudStorageItemInfo itemInfo,
+      GoogleCloudStorageItemInfo itemInfo,
       GoogleCloudStorageReadOptions readOptions,
       ErrorTypeExtractor errorExtractor,
       GoogleCloudStorageOptions storageOptions)
       throws IOException {
+    validate(itemInfo);
     this.storage = storage;
     this.errorExtractor = errorExtractor;
-    this.resourceId = resourceId;
+    this.resourceId =
+        new StorageResourceId(
+            itemInfo.getBucketName(), itemInfo.getObjectName(), itemInfo.getContentGeneration());
     this.readOptions = readOptions;
     this.storageOptions = storageOptions;
     this.contentReadChannel = new ContentReadChannel(readOptions, resourceId);
-    if (itemInfo != null) {
-      validate(itemInfo);
-      initMetadata(
-          itemInfo.getContentEncoding(), itemInfo.getSize(), itemInfo.getContentGeneration());
-    } else {
-      if (readOptions.isFastFailOnNotFoundEnabled()) {
-        fetchMetadata();
-      }
-    }
+    initMetadata(itemInfo.getContentEncoding(), itemInfo.getSize());
   }
 
-  private void fetchMetadata() throws IOException {
-    try {
-      BlobId blobId =
-          BlobId.of(
-              resourceId.getBucketName(),
-              resourceId.getObjectName(),
-              resourceId.hasGenerationId() ? resourceId.getGenerationId() : null);
-      Blob blob =
-          storage.get(
-              blobId,
-              Storage.BlobGetOption.fields(
-                  Storage.BlobField.CONTENT_ENCODING,
-                  Storage.BlobField.SIZE,
-                  Storage.BlobField.GENERATION));
-      if (blob == null) {
-        throw new FileNotFoundException(String.format("Item not found: %s", resourceId));
-      }
-      initMetadata(blob.getContentEncoding(), blob.getSize(), blob.getGeneration());
-    } catch (StorageException e) {
-      throw new IOException("Failed to fetch metadata for " + resourceId, e);
-    }
-  }
-
-  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata, long generation)
-      throws IOException {
-    checkState(!metadataInitialized, "Metadata already initialized");
+  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata) throws IOException {
     gzipEncoded = nullToEmpty(encoding).contains(GZIP_ENCODING);
     if (gzipEncoded && !readOptions.isGzipEncodingSupportEnabled()) {
       GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           "Cannot read GZIP encoded files - content encoding support is disabled.");
     }
-    objectSize = gzipEncoded ? -1 : sizeFromMetadata;
-    if (!resourceId.hasGenerationId()) {
-      resourceId =
-          new StorageResourceId(resourceId.getBucketName(), resourceId.getObjectName(), generation);
-    } else {
-      checkState(
-          resourceId.getGenerationId() == generation,
-          "Provided generation (%s) should be equal to fetched generation (%s) for '%s'",
-          resourceId.getGenerationId(),
-          generation,
-          resourceId);
-    }
-    metadataInitialized = true;
+    objectSize = gzipEncoded ? Long.MAX_VALUE : sizeFromMetadata;
   }
 
   @Override
@@ -209,10 +155,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
   @Override
   public long size() throws IOException {
-    throwIfNotOpen();
-    if (!metadataInitialized) {
-      fetchMetadata();
-    }
     return objectSize;
   }
 
@@ -254,6 +196,8 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     // Size of buffer to allocate for skipping bytes in-place when performing in-place seeks.
     private static final int SKIP_BUFFER_SIZE = 8192;
 
+    private final BlobId blobId;
+
     // This is the actual current position in `contentChannel` from where read can happen.
     // This remains unchanged of position(long) method call.
     private long contentChannelCurrentPosition = -1;
@@ -268,18 +212,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
     public ContentReadChannel(
         GoogleCloudStorageReadOptions readOptions, StorageResourceId resourceId) {
+      this.blobId =
+          BlobId.of(
+              resourceId.getBucketName(), resourceId.getObjectName(), resourceId.getGenerationId());
       this.fileAccessManager = new FileAccessPatternManager(resourceId, readOptions);
       if (gzipEncoded) {
         fileAccessManager.overrideAccessPattern(false);
       }
-    }
-
-    private BlobId getBlobId() {
-      Long generationId =
-          resourceId.getGenerationId() == StorageResourceId.UNKNOWN_GENERATION_ID
-              ? null
-              : resourceId.getGenerationId();
-      return BlobId.of(resourceId.getBucketName(), resourceId.getObjectName(), generationId);
     }
 
     public int readContent(ByteBuffer dst) throws IOException {
@@ -327,8 +266,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                 "Read %d from storage-client's byte channel at position: %d with channel ending at: %d for resourceId: %s of size: %d",
                 bytesRead, currentPosition, contentChannelEnd, resourceId, objectSize);
           }
-
-          ensureMetadataInitialized(byteChannel);
 
           if (bytesRead < 0) {
             // Because we don't know decompressed object size for gzip-encoded objects,
@@ -419,47 +356,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       return readableByteChannel;
     }
 
-    private void ensureMetadataInitialized(ReadableByteChannel readableByteChannel)
-        throws IOException {
-      if (metadataInitialized) {
-        return;
-      }
-
-      if (!initializeMetadataFromChannel(readableByteChannel)) {
-        logger.atInfo().log("Fallback to metadata fetch for '%s'", resourceId);
-        fetchMetadata();
-      }
-    }
-
-    private boolean initializeMetadataFromChannel(ReadableByteChannel readableByteChannel) {
-      if (!(readableByteChannel instanceof ReadChannel)) {
-        return false;
-      }
-
-      try {
-        ApiFuture<BlobInfo> blobInfoFuture =
-            getBlobInfoFromReadChannelFunction((ReadChannel) readableByteChannel);
-        if (!blobInfoFuture.isDone()) {
-          return false;
-        }
-        BlobInfo blobInfo = blobInfoFuture.get();
-        if (blobInfo == null) {
-          return false;
-        }
-
-        objectSize = blobInfo.getSize();
-        initMetadata(blobInfo.getContentEncoding(), objectSize, blobInfo.getGeneration());
-        if (gzipEncoded) {
-          fileAccessManager.overrideAccessPattern(false);
-        }
-        return true;
-      } catch (Exception e) {
-        logger.atWarning().withCause(e).log(
-            "Failed to get metadata from read channel for '%s'", resourceId);
-        return false;
-      }
-    }
-
     private void setChannelBoundaries(long bytesToRead) {
       contentChannelCurrentPosition = getRangeRequestStart();
       contentChannelEnd = getRangeRequestEnd(contentChannelCurrentPosition, bytesToRead);
@@ -527,19 +423,18 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private long getRangeRequestEnd(long startPosition, long bytesToRead) {
-      long effectiveSize = objectSize == -1 ? Long.MAX_VALUE : objectSize;
       // Always read gzip-encoded files till the end - they do not support range reads.
       if (gzipEncoded) {
-        return effectiveSize;
+        return objectSize;
       }
-      long endPosition = effectiveSize;
+      long endPosition = objectSize;
       if (fileAccessManager.shouldAdaptToRandomAccess()) {
         // opening a channel for whole object doesn't make sense as anyhow it will not be utilized
         // for further reads.
         endPosition = startPosition + max(bytesToRead, readOptions.getMinRangeRequestSize());
       } else {
         if (readOptions.getFadvise() == Fadvise.AUTO_RANDOM) {
-          endPosition = min(startPosition + readOptions.getBlockSize(), effectiveSize);
+          endPosition = min(startPosition + readOptions.getBlockSize(), objectSize);
         }
       }
 
@@ -550,7 +445,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       if (footerContent != null) {
         // If footer is cached open just till footerStart.
         // Remaining content ill be served from cached footer itself.
-        endPosition = min(endPosition, effectiveSize - footerContent.length);
+        endPosition = min(endPosition, objectSize - footerContent.length);
       }
       return endPosition;
     }
@@ -645,7 +540,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private ReadableByteChannel getStorageReadChannel(long seek, long limit) throws IOException {
-      BlobId blobId = getBlobId();
       ReadChannel readChannel = storage.reader(blobId, generateReadOptions(blobId));
       try {
         readChannel.seek(seek);
@@ -680,8 +574,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private boolean isFooterRead() {
-      return objectSize != -1
-          && objectSize - currentPosition <= readOptions.getMinRangeRequestSize();
+      return objectSize - currentPosition <= readOptions.getMinRangeRequestSize();
     }
   }
 
@@ -739,37 +632,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     if (!isOpen()) {
       GoogleCloudStorageEventBus.postOnException();
       throw new ClosedChannelException();
-    }
-  }
-
-  public static ApiFuture<BlobInfo> getBlobInfoFromReadChannelFunction(ReadChannel readChannel) {
-    // This method relies on the internal implementation details of the Google Cloud Storage client
-    // library (specifically field names and method names). If the underlying library changes,
-    // this reflection logic might break. In that case, we catch the exception and fallback to
-    // explicit metadata fetching, ensuring robustness at the cost of an extra API call.
-    try {
-      ReadChannel targetChannel = readChannel;
-      String channelClassName = targetChannel.getClass().getName();
-      if (channelClassName.endsWith(OTEL_DECORATED_READ_CHANNEL)) {
-        Field readerField = targetChannel.getClass().getDeclaredField("reader");
-        readerField.setAccessible(true);
-        targetChannel = (ReadChannel) readerField.get(targetChannel);
-        channelClassName = targetChannel.getClass().getName();
-      }
-      if (channelClassName.endsWith(STORAGE_READ_CHANNEL)
-          || channelClassName.endsWith(GRPC_BLOB_READ_CHANNEL)) {
-        Method getObjectMethod = targetChannel.getClass().getMethod("getObject");
-        getObjectMethod.setAccessible(true);
-        return (ApiFuture<BlobInfo>) getObjectMethod.invoke(targetChannel);
-      } else {
-        return ApiFutures.immediateFailedFuture(
-            new IllegalArgumentException(
-                "Unsupported ReadChannel implementation: " + channelClassName));
-      }
-    } catch (Exception e) {
-      return ApiFutures.immediateFailedFuture(
-          new IllegalStateException(
-              "Failed to get object info from " + readChannel.getClass().getName(), e));
     }
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -195,7 +195,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
     // Size of buffer to allocate for skipping bytes in-place when performing in-place seeks.
     private static final int SKIP_BUFFER_SIZE = 8192;
-
     private final BlobId blobId;
 
     // This is the actual current position in `contentChannel` from where read can happen.
@@ -236,7 +235,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // in the first read. Therefore, loop till we either read the required number of
       // bytes or we reach end-of-stream.
       while (dst.hasRemaining()) {
-        final int remainingBeforeRead = dst.remaining();
+        int remainingBeforeRead = dst.remaining();
         try {
           if (byteChannel == null) {
             byteChannel = openByteChannel(dst.remaining());
@@ -276,7 +275,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
             }
 
             if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
-
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -342,17 +342,22 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received; "
+                          + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                          + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
+
             } else if (currentPosition > objectSize) {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result beyond the object size; at offset: %d "
+                          + "whereas stream was suppose to end at: %d for resource: %s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
             } else if (currentPosition > contentChannelEnd) {
               logger.atWarning().log(
-                  "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                  "Received end of stream result after the channel end; at offset: %d "
+                      + "whereas stream was suppose to end at: %d for resource: %s of size: %d",
                   currentPosition, contentChannelEnd, resourceId, objectSize);
               closeContentChannel();
               continue;
@@ -418,8 +423,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       ReadableByteChannel readableByteChannel =
           getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
 
-      // Logging at warning so that we don't need to change log level.
-      logger.atWarning().log(
+      logger.atFiner().log(
           "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
           contentChannelCurrentPosition, contentChannelEnd);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -338,13 +338,24 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               contentChannelEnd = currentPosition;
             }
 
-            if (currentPosition != contentChannelEnd && currentPosition != objectSize) {
+            if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received;"
-                          + "EndOf stream signal received at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > objectSize) {
+              GoogleCloudStorageEventBus.postOnException();
+              throw new IOException(
+                  String.format(
+                      "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > contentChannelEnd) {
+              logger.atWarning().log(
+                  "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                  currentPosition, contentChannelEnd, resourceId, objectSize);
+              closeContentChannel();
+              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -406,6 +417,11 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
       ReadableByteChannel readableByteChannel =
           getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
+
+      // Logging at warning so that we don't need to change log level.
+      logger.atWarning().log(
+          "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
+          contentChannelCurrentPosition, contentChannelEnd);
 
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -343,7 +343,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               throw new IOException(
                   String.format(
                       "Received end of stream result before all requestedBytes were received; "
-                          + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                          + "at offset: %d where as stream was supposed to end at: %d for resource: "
                           + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
 
@@ -352,12 +352,12 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               throw new IOException(
                   String.format(
                       "Received end of stream result beyond the object size; at offset: %d "
-                          + "whereas stream was suppose to end at: %d for resource: %s of size: %d",
+                          + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
             } else if (currentPosition > contentChannelEnd) {
               logger.atWarning().log(
                   "Received end of stream result after the channel end; at offset: %d "
-                      + "whereas stream was suppose to end at: %d for resource: %s of size: %d",
+                      + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
                   currentPosition, contentChannelEnd, resourceId, objectSize);
               // Dropping additional bytes.
               int overshoot = (int) (currentPosition - contentChannelEnd);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -195,6 +195,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
     // Size of buffer to allocate for skipping bytes in-place when performing in-place seeks.
     private static final int SKIP_BUFFER_SIZE = 8192;
+
     private final BlobId blobId;
 
     // This is the actual current position in `contentChannel` from where read can happen.
@@ -235,7 +236,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // in the first read. Therefore, loop till we either read the required number of
       // bytes or we reach end-of-stream.
       while (dst.hasRemaining()) {
-        int remainingBeforeRead = dst.remaining();
+        final int remainingBeforeRead = dst.remaining();
         try {
           if (byteChannel == null) {
             byteChannel = openByteChannel(dst.remaining());
@@ -274,13 +275,25 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               contentChannelEnd = currentPosition;
             }
 
-            if (currentPosition != contentChannelEnd && currentPosition != objectSize) {
+            if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
+
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received;"
-                          + "EndOf stream signal received at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > objectSize) {
+              GoogleCloudStorageEventBus.postOnException();
+              throw new IOException(
+                  String.format(
+                      "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > contentChannelEnd) {
+              logger.atWarning().log(
+                  "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                  currentPosition, contentChannelEnd, resourceId, objectSize);
+              closeContentChannel();
+              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -342,6 +355,11 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
       ReadableByteChannel readableByteChannel =
           getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
+
+      // Logging at warning so that we don't need to change log level.
+      logger.atWarning().log(
+          "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
+          contentChannelCurrentPosition, contentChannelEnd);
 
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -346,6 +346,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                 "Received end of stream result after the channel end; at offset: %d "
                     + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                 currentPosition, contentChannelEnd, resourceId, size);
+
+            // Dropping additional bytes.
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+
             closeContentChannel();
             continue;
           }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -328,7 +328,19 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           // actual size of the data stream when stream compression is used, so we can
           // only ignore
           // this case here.
-          if (currentPosition < contentChannelEnd && currentPosition < size) {
+          if (currentPosition > contentChannelEnd && currentPosition < size) {
+            logger.atWarning().log(
+                "Received end of stream result after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+
+            // Dropping additional bytes.
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+            contentChannelPosition -= overshoot;
+          } else if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
@@ -344,21 +356,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                     "Received end of stream result beyond the object size; at offset: %d "
                         + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                     currentPosition, contentChannelEnd, resourceId, size));
-          } else if (currentPosition > contentChannelEnd) {
-            logger.atWarning().log(
-                "Received end of stream result after the channel end; at offset: %d "
-                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
-                currentPosition, contentChannelEnd, resourceId, size);
-
-            // Dropping additional bytes.
-            int overshoot = (int) (currentPosition - contentChannelEnd);
-            buffer.position(buffer.position() - overshoot);
-            currentPosition = contentChannelEnd;
-            totalBytesRead -= overshoot;
-            contentChannelPosition -= overshoot;
-
-            closeContentChannel();
-            continue;
           }
 
           // If we have reached an end of a contentChannel but not an end of an object

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -297,7 +297,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     // in the first read. Therefore, loop till we either read the required number of
     // bytes or we reach end-of-stream.
     do {
-      int remainingBeforeRead = buffer.remaining();
+      final int remainingBeforeRead = buffer.remaining();
       performLazySeek(remainingBeforeRead);
       checkState(
           contentChannelPosition == currentPosition,
@@ -325,14 +325,24 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           // actual size of the data stream when stream compression is used, so we can
           // only ignore
           // this case here.
-          if (currentPosition != contentChannelEnd && currentPosition != size) {
+          if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
-                    "Received end of stream result before all the file data has been received;"
-                        + " totalBytesRead: %d, currentPosition: %d,"
-                        + " contentChannelEnd %d, size: %d, object: '%s'",
-                    totalBytesRead, currentPosition, contentChannelEnd, size, resourceId));
+                    "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          } else if (currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          } else if (currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+            closeContentChannel();
+            continue;
           }
 
           // If we have reached an end of a contentChannel but not an end of an object
@@ -736,6 +746,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       objectContentStream = openStream(bytesToRead);
     }
     contentChannel = Channels.newChannel(objectContentStream);
+
+    // Logging at warning so that we don't need to change log level.
+    logger.atWarning().log(
+        "Storage ReadChannel opened at, contentChannelPosition: %d, contentChannelEnd: %d",
+        contentChannelPosition, contentChannelEnd);
+
     checkState(
         contentChannelPosition == currentPosition,
         "contentChannelPosition (%s) should be equal to currentPosition (%s) for '%s'",

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -297,7 +297,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     // in the first read. Therefore, loop till we either read the required number of
     // bytes or we reach end-of-stream.
     do {
-      final int remainingBeforeRead = buffer.remaining();
+      int remainingBeforeRead = buffer.remaining();
       performLazySeek(remainingBeforeRead);
       checkState(
           contentChannelPosition == currentPosition,
@@ -329,17 +329,22 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
-                    "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    "Received end of stream result before all requestedBytes were received; "
+                        + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                        + "%s of size: %d",
                     currentPosition, contentChannelEnd, resourceId, size));
+
           } else if (currentPosition > size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
-                    "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    "Received end of stream result beyond the object size; at offset: %d "
+                        + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                     currentPosition, contentChannelEnd, resourceId, size));
           } else if (currentPosition > contentChannelEnd) {
             logger.atWarning().log(
-                "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                "Received end of stream result after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                 currentPosition, contentChannelEnd, resourceId, size);
             closeContentChannel();
             continue;
@@ -747,8 +752,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     }
     contentChannel = Channels.newChannel(objectContentStream);
 
-    // Logging at warning so that we don't need to change log level.
-    logger.atWarning().log(
+    logger.atFiner().log(
         "Storage ReadChannel opened at, contentChannelPosition: %d, contentChannelEnd: %d",
         contentChannelPosition, contentChannelEnd);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -351,6 +351,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             int overshoot = (int) (currentPosition - contentChannelEnd);
             buffer.position(buffer.position() - overshoot);
             currentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+            contentChannelPosition -= overshoot;
 
             closeContentChannel();
             continue;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -296,7 +296,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     // in the first read. Therefore, loop till we either read the required number of
     // bytes or we reach end-of-stream.
     do {
-      int remainingBeforeRead = buffer.remaining();
+      final int remainingBeforeRead = buffer.remaining();
       performLazySeek(remainingBeforeRead);
       checkState(
           contentChannelPosition == currentPosition,
@@ -324,14 +324,24 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           // actual size of the data stream when stream compression is used, so we can
           // only ignore
           // this case here.
-          if (currentPosition != contentChannelEnd && currentPosition != size) {
+          if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
-                    "Received end of stream result before all the file data has been received;"
-                        + " totalBytesRead: %d, currentPosition: %d,"
-                        + " contentChannelEnd %d, size: %d, object: '%s'",
-                    totalBytesRead, currentPosition, contentChannelEnd, size, resourceId));
+                    "Received end of stream result before all requestedBytes were received; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          } else if (currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received end of stream result beyond the object size; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          } else if (currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received end of stream result after the channel end; at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+            closeContentChannel();
+            continue;
           }
 
           // If we have reached an end of a contentChannel but not an end of an object
@@ -716,6 +726,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       objectContentStream = openStream(bytesToRead);
     }
     contentChannel = Channels.newChannel(objectContentStream);
+
+    // Logging at warning so that we don't need to change log level.
+    logger.atWarning().log(
+        "Storage ReadChannel opened at, contentChannelPosition: %d, contentChannelEnd: %d",
+        contentChannelPosition, contentChannelEnd);
+
     checkState(
         contentChannelPosition == currentPosition,
         "contentChannelPosition (%s) should be equal to currentPosition (%s) for '%s'",

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
@@ -35,7 +35,9 @@ public class FakeReadChannel implements ReadChannel {
     READ_EXCEPTION,
     PARTIAL_READ,
     NEGATIVE_READ,
-    ZERO_READ
+    ZERO_READ,
+    MORE_THAN_CHANNEL_LENGTH,
+    MORE_THAN_OBJECT_SIZE
   }
 
   private final List<REQUEST_TYPE> orderRequestsList;
@@ -118,6 +120,12 @@ public class FakeReadChannel implements ReadChannel {
         break;
       case NEGATIVE_READ:
         bytesRead = -1;
+        break;
+      case MORE_THAN_CHANNEL_LENGTH:
+        bytesRead = toIntExact(limit + 1);
+        break;
+      case MORE_THAN_OBJECT_SIZE:
+        bytesRead = content.size() + 1;
         break;
       case READ_EXCEPTION:
         throw new IOException("Exception occurred in read");

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
@@ -92,14 +92,18 @@ public class FakeReadChannel implements ReadChannel {
   }
 
   private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead) {
-    if (currentPosition >= limit) {
+    return readInternal(dst, startIndex, bytesToRead, false);
+  }
+
+  private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead, boolean ignoreLimit) {
+    if (!ignoreLimit && currentPosition >= limit) {
       return -1;
     }
     long readStart = startIndex;
     long readEnd =
         min(
             min(startIndex + bytesToRead, startIndex + dst.remaining()),
-            min(content.size(), limit));
+            ignoreLimit ? content.size() : min(content.size(), limit));
     ByteString messageData = content.substring(toIntExact(readStart), toIntExact(readEnd));
     for (Byte messageDatum : messageData) {
       dst.put(messageDatum);
@@ -122,8 +126,8 @@ public class FakeReadChannel implements ReadChannel {
         bytesRead = -1;
         break;
       case MORE_THAN_CHANNEL_LENGTH:
-        bytesRead = readInternal(dst, currentPosition, toIntExact(limit - currentPosition + 1));
-        currentPosition = limit + 1;
+        bytesRead =
+            readInternal(dst, currentPosition, toIntExact(limit - currentPosition + 1), true);
         break;
       case MORE_THAN_OBJECT_SIZE:
         bytesRead = content.size() + 1;
@@ -132,7 +136,6 @@ public class FakeReadChannel implements ReadChannel {
         throw new IOException("Exception occurred in read");
       case PARTIAL_READ:
         bytesRead = readInternal(dst, currentPosition, dst.remaining() / 2);
-        currentPosition += bytesRead;
         throw new IOException("Partial Read Exception");
       default:
         bytesRead = readInternal(dst, currentPosition, CHUNK_SIZE);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
@@ -122,7 +122,8 @@ public class FakeReadChannel implements ReadChannel {
         bytesRead = -1;
         break;
       case MORE_THAN_CHANNEL_LENGTH:
-        bytesRead = toIntExact(limit + 1);
+        bytesRead = readInternal(dst, currentPosition, toIntExact(limit - currentPosition + 1));
+        currentPosition = limit + 1;
         break;
       case MORE_THAN_OBJECT_SIZE:
         bytesRead = content.size() + 1;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -626,39 +626,6 @@ public class GoogleCloudStorageClientReadChannelTest {
   }
 
   @Test
-  public void readBeyondChannelLength() throws IOException {
-    int bufferSize = 100;
-    fakeReadChannel =
-        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
-    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
-    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
-
-    int startPosition = 0;
-    readChannel.position(startPosition);
-
-    assertThat(readChannel.read(ByteBuffer.allocate(bufferSize)))
-        .isEqualTo(bufferSize + CHUNK_SIZE + 1);
-  }
-
-  @Test
-  public void readBeyondObjectSize() throws IOException {
-    fakeReadChannel =
-        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_OBJECT_SIZE)));
-    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
-    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
-
-    int startPosition = 0;
-    readChannel.position(startPosition);
-    IOException e =
-        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
-
-    assertThat(e)
-        .hasCauseThat()
-        .hasMessageThat()
-        .contains("Received end of stream result beyond the object size;");
-  }
-
-  @Test
   public void lazyMetadataFetch_whenFastFailFalse_usesFallback() throws IOException {
     // Setup with fastFailOnNotFound = false and null itemInfo
     GoogleCloudStorageReadOptions readOptions =
@@ -868,6 +835,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
     return new GoogleCloudStorageClientReadChannel(
         mockedStorage,
+        objectInfo.getResourceId(),
         objectInfo,
         readOptions,
         GrpcErrorTypeExtractor.INSTANCE,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -653,6 +653,7 @@ public class GoogleCloudStorageClientReadChannelTest {
         assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
 
     assertThat(e)
+        .hasCauseThat()
         .hasMessageThat()
         .contains("Received end of stream result beyond the object size;");
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -789,12 +789,13 @@ public class GoogleCloudStorageClientReadChannelTest {
 
   @Test
   public void readBeyondChannelLength() throws IOException {
-    // Queue MORE_THAN_CHANNEL_LENGTH for the first read, then NORMAL for the continuation read
+    // Queue READ_CHUNK for the first read, then MORE_THAN_CHANNEL_LENGTH for the second read
+    // so it overshoots the channel limit.
     fakeReadChannel =
         spy(
             new FakeReadChannel(
                 CONTENT,
-                ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH, REQUEST_TYPE.READ_CHUNK)));
+                ImmutableList.of(REQUEST_TYPE.READ_CHUNK, REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
     when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
 
     // Enforce a chunk size so that contentChannelEnd is smaller than the full object size
@@ -803,14 +804,22 @@ public class GoogleCloudStorageClientReadChannelTest {
 
     readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
 
-    int startPosition = 0;
-    readChannel.position(startPosition);
+    readChannel.position(0);
 
-    // We expect it to drop the overshoot, fetch the remaining chunks, and succeed
-    ByteBuffer buffer = ByteBuffer.allocate(100);
-    int bytesRead = readChannel.read(buffer);
+    // 1. First read of 5 bytes. This will open the channel with limit = max(5, 10) = 10.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
 
-    assertThat(bytesRead).isGreaterThan(0);
+    // 2. Second read of 10 bytes. The channel limit is still 10.
+    // The FakeReadChannel will return 10 - 5 + 1 = 6 bytes, so currentPosition becomes 11.
+    // Since 11 > 10, it will hit the overshoot block in GoogleCloudStorageClientReadChannel.
+    ByteBuffer buffer2 = ByteBuffer.allocate(10);
+    int bytesRead2 = readChannel.read(buffer2);
+
+    // TODO(animgupt): Check if we should change returned bytes as well.
+    assertThat(bytesRead2).isEqualTo(11);
+    assertThat(readChannel.position()).isEqualTo(15);
   }
 
   // @Ignore

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -821,7 +821,6 @@ public class GoogleCloudStorageClientReadChannelTest {
     assertThat(readChannel.position()).isEqualTo(15);
   }
 
-  // @Ignore
   @Test
   public void readBeyondObjectSize() throws IOException {
     fakeReadChannel =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -787,6 +787,38 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
   }
 
+  @Test
+  public void readBeyondChannelLength() throws IOException {
+    int bufferSize = 100;
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+
+    assertThat(readChannel.read(ByteBuffer.allocate(bufferSize)))
+        .isEqualTo(bufferSize + CHUNK_SIZE + 1);
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_OBJECT_SIZE)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+    IOException e =
+        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {
     assertThat(buffer.position()).isEqualTo(length);
     assertByteArrayEquals(
@@ -802,10 +834,6 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
     return new GoogleCloudStorageClientReadChannel(
         mockedStorage,
-        new StorageResourceId(
-            objectInfo.getBucketName(),
-            objectInfo.getObjectName(),
-            objectInfo.getContentGeneration()),
         objectInfo,
         readOptions,
         GrpcErrorTypeExtractor.INSTANCE,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -798,8 +798,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     int startPosition = 0;
     readChannel.position(startPosition);
 
-    assertThat(readChannel.read(ByteBuffer.allocate(bufferSize)))
-        .isEqualTo(bufferSize + CHUNK_SIZE + 1);
+    assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(100)));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -789,18 +789,31 @@ public class GoogleCloudStorageClientReadChannelTest {
 
   @Test
   public void readBeyondChannelLength() throws IOException {
-    int bufferSize = 100;
+    // Queue MORE_THAN_CHANNEL_LENGTH for the first read, then NORMAL for the continuation read
     fakeReadChannel =
-        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+        spy(
+            new FakeReadChannel(
+                CONTENT,
+                ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH, REQUEST_TYPE.READ_CHUNK)));
     when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
-    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    // Enforce a chunk size so that contentChannelEnd is smaller than the full object size
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setMinRangeRequestSize(10).build();
+
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
 
     int startPosition = 0;
     readChannel.position(startPosition);
 
-    assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(100)));
+    // We expect it to drop the overshoot, fetch the remaining chunks, and succeed
+    ByteBuffer buffer = ByteBuffer.allocate(100);
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isGreaterThan(0);
   }
 
+  // @Ignore
   @Test
   public void readBeyondObjectSize() throws IOException {
     fakeReadChannel =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -815,6 +815,7 @@ public class GoogleCloudStorageClientReadChannelTest {
         assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
 
     assertThat(e)
+        .hasCauseThat()
         .hasMessageThat()
         .contains("Received end of stream result beyond the object size;");
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -817,8 +817,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     ByteBuffer buffer2 = ByteBuffer.allocate(10);
     int bytesRead2 = readChannel.read(buffer2);
 
-    // TODO(animgupt): Check if we should change returned bytes as well.
-    assertThat(bytesRead2).isEqualTo(11);
+    assertThat(bytesRead2).isEqualTo(10);
     assertThat(readChannel.position()).isEqualTo(15);
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -625,6 +625,38 @@ public class GoogleCloudStorageClientReadChannelTest {
     assertThat(limitValue.getAllValues().get(1)).isEqualTo(startPosition + 1);
   }
 
+  @Test
+  public void readBeyondChannelLength() throws IOException {
+    int bufferSize = 100;
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+
+    assertThat(readChannel.read(ByteBuffer.allocate(bufferSize)))
+        .isEqualTo(bufferSize + CHUNK_SIZE + 1);
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_OBJECT_SIZE)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+    IOException e =
+        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {
     assertThat(buffer.position()).isEqualTo(length);
     assertByteArrayEquals(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -981,9 +981,11 @@ public class GoogleCloudStorageReadChannelTest {
 
   @Test
   public void readBeyondChannelLength() throws Exception {
-    long objectSize = 20L;
-    long contentChannelEnd = 10L;
-    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+    long objectSize = 200L;
+    // First response overshoots the 10 byte limit by 2 bytes
+    byte[] overshootData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+    // Second response provides the rest of the object size
+    byte[] restData = {0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
 
     MockHttpTransport transport =
         mockTransport(
@@ -993,8 +995,11 @@ public class GoogleCloudStorageReadChannelTest {
                     .setName(OBJECT_NAME)
                     .setSize(BigInteger.valueOf(objectSize))
                     .setGeneration(1L)),
-            inputStreamResponse(
-                CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
+            // 1. Mock first read returning 12 bytes
+            dataRangeResponse(overshootData, 0, objectSize),
+            // 2. Mock the second read for the remaining bytes
+            dataRangeResponse(restData, 12, objectSize));
+
     GoogleCloudStorage gcs = mockedGcsImpl(transport);
 
     GoogleCloudStorageReadChannel readChannel =
@@ -1002,12 +1007,26 @@ public class GoogleCloudStorageReadChannelTest {
             gcs.open(
                 new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
                 GoogleCloudStorageReadOptions.builder()
-                    .setMinRangeRequestSize((int) contentChannelEnd)
                     .setFadvise(Fadvise.RANDOM)
+                    .setMinRangeRequestSize(10) // Force requested range to be 10
                     .build());
 
-    readChannel.setMaxRetries(0);
-    assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(100)));
+    readChannel.setMaxRetries(1);
+
+    // First read of 5 bytes
+    ByteBuffer buffer = ByteBuffer.allocate(30);
+    buffer.limit(5);
+    int bytesRead = readChannel.read(buffer);
+    assertThat(bytesRead).isEqualTo(5);
+
+    // Second read to trigger overshoot and then EOF
+    buffer.limit(20);
+    bytesRead = readChannel.read(buffer);
+
+    // total read should be 7 (remaining in overshootData) + 8 (from second mock to fill buffer
+    // limit 20) = 15
+    assertThat(bytesRead).isEqualTo(17);
+    assertThat(readChannel.position()).isEqualTo(20);
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -1007,12 +1007,7 @@ public class GoogleCloudStorageReadChannelTest {
                     .build());
 
     readChannel.setMaxRetries(0);
-
-    readChannel.read(ByteBuffer.allocate((int) contentChannelEnd));
-
-    readChannel.read(ByteBuffer.allocate(2));
-
-    assertThrows(Exception.class, () -> readChannel.read(ByteBuffer.allocate(1)));
+    assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(100)));
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -1025,7 +1025,7 @@ public class GoogleCloudStorageReadChannelTest {
 
     // total read should be 7 (remaining in overshootData) + 8 (from second mock to fill buffer
     // limit 20) = 15
-    assertThat(bytesRead).isEqualTo(17);
+    assertThat(bytesRead).isEqualTo(15);
     assertThat(readChannel.position()).isEqualTo(20);
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -949,7 +949,9 @@ public class GoogleCloudStorageReadChannelTest {
                     .setName(OBJECT_NAME)
                     .setSize(BigInteger.valueOf(objectSize))
                     .setGeneration(1L)),
-            inputStreamResponse(CONTENT_LENGTH, objectSize, new ByteArrayInputStream(testData)));
+            // Ensure content-length accommodates the over-read
+            inputStreamResponse(
+                CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
     GoogleCloudStorage gcs = mockedGcsImpl(transport);
 
     GoogleCloudStorageReadChannel readChannel =
@@ -962,7 +964,15 @@ public class GoogleCloudStorageReadChannelTest {
 
     IOException e =
         assertThrows(
-            IOException.class, () -> readChannel.read(ByteBuffer.allocate(testData.length)));
+            IOException.class,
+            () -> {
+              ByteBuffer buffer = ByteBuffer.allocate(testData.length + 1);
+              while (buffer.hasRemaining()) {
+                if (readChannel.read(buffer) < 0) {
+                  break;
+                }
+              }
+            });
 
     assertThat(e)
         .hasMessageThat()
@@ -970,7 +980,7 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
-  public void readBeyondChannelLength() throws IOException {
+  public void readBeyondChannelLength() throws Exception {
     long objectSize = 20L;
     long contentChannelEnd = 10L;
     byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
@@ -984,7 +994,7 @@ public class GoogleCloudStorageReadChannelTest {
                     .setSize(BigInteger.valueOf(objectSize))
                     .setGeneration(1L)),
             inputStreamResponse(
-                CONTENT_LENGTH, contentChannelEnd, new ByteArrayInputStream(testData)));
+                CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
     GoogleCloudStorage gcs = mockedGcsImpl(transport);
 
     GoogleCloudStorageReadChannel readChannel =
@@ -998,7 +1008,11 @@ public class GoogleCloudStorageReadChannelTest {
 
     readChannel.setMaxRetries(0);
 
-    assertThrows(Exception.class, () -> readChannel.read(ByteBuffer.allocate(testData.length)));
+    readChannel.read(ByteBuffer.allocate((int) contentChannelEnd));
+
+    readChannel.read(ByteBuffer.allocate(2));
+
+    assertThrows(Exception.class, () -> readChannel.read(ByteBuffer.allocate(1)));
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -48,6 +48,7 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -933,6 +934,71 @@ public class GoogleCloudStorageReadChannelTest {
         .isEqualTo(
             "Unexpected end of stream trying to skip 10 bytes to seek to position 10,"
                 + " size: 9223372036854775807 for 'gs://foo-bucket/bar-object'");
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    long objectSize = 10L;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            inputStreamResponse(CONTENT_LENGTH, objectSize, new ByteArrayInputStream(testData)));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder().setFadvise(Fadvise.SEQUENTIAL).build());
+
+    readChannel.setMaxRetries(0);
+
+    IOException e =
+        assertThrows(
+            IOException.class, () -> readChannel.read(ByteBuffer.allocate(testData.length)));
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
+  @Test
+  public void readBeyondChannelLength() throws IOException {
+    long objectSize = 20L;
+    long contentChannelEnd = 10L;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            inputStreamResponse(
+                CONTENT_LENGTH, contentChannelEnd, new ByteArrayInputStream(testData)));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder()
+                    .setMinRangeRequestSize((int) contentChannelEnd)
+                    .setFadvise(Fadvise.RANDOM)
+                    .build());
+
+    readChannel.setMaxRetries(0);
+
+    assertThrows(Exception.class, () -> readChannel.read(ByteBuffer.allocate(testData.length)));
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {


### PR DESCRIPTION
As discussed in the [internal doc](http://shortn/_mfCylknbNH), in a very rare cases GCS can send more bytes than requested. Even though it should not be a fatal error from the client perspective, connector still throws error. This PR fixes the same scenario by adding warning log instead of throwing an exception as well as dropping the additional bytes. It also corrects the current log messages as they were slightly misleading. The fix is applied to both JSON and gRPC path. BiDi readchannel is not applicable here as it can move in both directions and we haven't observed this issue for BiDi.