### PR TITLE
Parameterize the existing Integration Tests for read path

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreChannelAdapter.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreChannelAdapter.java
@@ -118,7 +118,7 @@ class AnalyticsCoreChannelAdapter implements SeekableByteChannel {
     checkOpen();
     List<GcsObjectRange> validRanges = new ArrayList<>();
     for (GcsObjectRange range : ranges) {
-      if (range.getOffset() + range.getLength() > size) {
+      if (size >= 0 && range.getOffset() + range.getLength() > size) {
         range
             .getByteBufferFuture()
             .completeExceptionally(new IOException("Range extends beyond file size: " + range));

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreChannelAdapter.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreChannelAdapter.java
@@ -19,11 +19,13 @@ package com.google.cloud.hadoop.fs.gcs;
 import com.google.cloud.gcs.analyticscore.client.GcsObjectRange;
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
 
@@ -71,12 +73,12 @@ class AnalyticsCoreChannelAdapter implements SeekableByteChannel {
     checkOpen();
     if (newPosition < 0) {
       GoogleCloudStorageEventBus.postOnException();
-      throw new java.io.EOFException(
+      throw new EOFException(
           "Invalid seek offset: position value (" + newPosition + ") must be >= 0");
     }
     if (size >= 0 && newPosition >= size) {
       GoogleCloudStorageEventBus.postOnException();
-      throw new java.io.EOFException(
+      throw new EOFException(
           "Invalid seek offset: position value ("
               + newPosition
               + ") must be between 0 and "
@@ -114,7 +116,19 @@ class AnalyticsCoreChannelAdapter implements SeekableByteChannel {
   public void readVectored(List<GcsObjectRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
     checkOpen();
-    inputStream.readVectored(ranges, allocate);
+    List<GcsObjectRange> validRanges = new ArrayList<>();
+    for (GcsObjectRange range : ranges) {
+      if (range.getOffset() + range.getLength() > size) {
+        range
+            .getByteBufferFuture()
+            .completeExceptionally(new IOException("Range extends beyond file size: " + range));
+      } else {
+        validRanges.add(range);
+      }
+    }
+    if (!validRanges.isEmpty()) {
+      inputStream.readVectored(validRanges, allocate);
+    }
   }
 
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -32,6 +32,7 @@ import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
 import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
 import com.google.cloud.hadoop.gcsio.ReadVectoredSeekableByteChannel;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.VectoredIORange;
@@ -223,6 +224,7 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
           streamStatistics,
           STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
           () -> {
+            long startTimeNs = System.nanoTime();
             if (channel instanceof ReadVectoredSeekableByteChannel) {
               ReadVectoredSeekableByteChannel readVectoredSeekableByteChannelChannel =
                   (ReadVectoredSeekableByteChannel) channel;
@@ -242,15 +244,24 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
                                   .build())
                       .collect(Collectors.toList()),
                   allocate);
+              vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
             } else if (channel instanceof AnalyticsCoreChannelAdapter) {
-              AnalyticsCoreChannelAdapter analyticsCoreChannelAdapterChannel =
-                  (AnalyticsCoreChannelAdapter) channel;
+              AnalyticsCoreChannelAdapter adapterChannel = (AnalyticsCoreChannelAdapter) channel;
               ranges.forEach(
                   range -> {
                     CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
                     range.setData(result);
+                    result.whenComplete(
+                        (buf, ex) -> {
+                          if (ex == null) {
+                            int length = range.getLength();
+                            streamStatistics.bytesRead(length);
+                            storageStatistics.streamReadBytes(length);
+                          }
+                        });
                   });
-              analyticsCoreChannelAdapterChannel.readVectored(
+
+              List<GcsObjectRange> gcsRanges =
                   ranges.stream()
                       .map(
                           range ->
@@ -259,10 +270,15 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
                                   .setOffset(range.getOffset())
                                   .setByteBufferFuture(range.getData())
                                   .build())
-                      .collect(Collectors.toList()),
-                  allocate);
+                      .collect(Collectors.toList());
+
+              adapterChannel.readVectored(gcsRanges, allocate);
+
+              storageStatistics.incrementGcsTotalRequestCount();
+              storageStatistics.incrementCounter(
+                  GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
+              vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
             } else {
-              long startTimeNs = System.nanoTime();
               vectoredIOSupplier
                   .get()
                   .readVectored(
@@ -319,6 +335,11 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             // the underlying channel.
             int numRead = channel.read(ByteBuffer.wrap(buf, offset, length));
             if (numRead > 0) {
+              if (channel instanceof AnalyticsCoreChannelAdapter) {
+                storageStatistics.incrementGcsTotalRequestCount();
+                storageStatistics.incrementCounter(
+                    GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
+              }
               // -1 means we actually read 0 bytes, but requested at least one byte.
               totalBytesRead += numRead;
               statistics.incrementReadOps(1);
@@ -354,6 +375,9 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             long startTimeNs = System.nanoTime();
             checkNotClosed();
             ((AnalyticsCoreChannelAdapter) channel).readFully(position, buffer, offset, length);
+            storageStatistics.incrementGcsTotalRequestCount();
+            storageStatistics.incrementCounter(
+                GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
             totalBytesRead += length;
             statistics.incrementReadOps(1);
             streamStats.updateReadStreamStats(length, startTimeNs);

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -48,6 +48,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -56,6 +57,7 @@ import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileRange;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.statistics.DurationTracker;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
@@ -94,7 +96,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
 
   private final GhfsStreamStats streamStats;
   private final GhfsStreamStats seekStreamStats;
-  private final GhfsStreamStats vectoredReadStats;
   private final ConcurrentHashMap<String, Long> rangeReadThreadStats;
 
   // Statistic tracker of the Input stream
@@ -202,9 +203,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
         new GhfsStreamStats(storageStatistics, GhfsStatistic.STREAM_READ_OPERATIONS, gcsPath);
     this.seekStreamStats =
         new GhfsStreamStats(storageStatistics, GhfsStatistic.STREAM_READ_SEEK_OPERATIONS, gcsPath);
-    this.vectoredReadStats =
-        new GhfsStreamStats(
-            storageStatistics, GhfsStatistic.STREAM_READ_VECTORED_OPERATIONS, gcsPath);
     this.rangeReadThreadStats = new ConcurrentHashMap<>();
 
     this.traceFactory = ghfs.getTraceFactory();
@@ -221,17 +219,41 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
   @Override
   public void readVectored(List<? extends FileRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
+    if (ranges.isEmpty()) {
+      return;
+    }
+    long startTimeNs = System.nanoTime();
+    DurationTracker tracker =
+        streamStatistics.trackDuration(STREAM_READ_VECTORED_OPERATIONS.getSymbol(), 1);
     try {
-      trackDuration(
-          streamStatistics,
-          STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
-          () -> readVectoredRouted(ranges, allocate));
+      readVectoredRouted(ranges, allocate);
     } catch (IOException e) {
+      tracker.failed();
+      tracker.close();
       if (IoExceptionHelper.isInterrupted(e)) {
         Thread.currentThread().interrupt();
       }
       throw e;
     }
+
+    CompletableFuture<?>[] futures =
+        ranges.stream().map(FileRange::getData).toArray(CompletableFuture[]::new);
+    CompletableFuture.allOf(futures)
+        .whenComplete(
+            (v, ex) -> {
+              if (ex != null) {
+                tracker.failed();
+              }
+              tracker.close();
+              long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs);
+              storageStatistics.updateStats(
+                  GhfsStatistic.STREAM_READ_VECTORED_OPERATIONS,
+                  elapsedMs,
+                  elapsedMs,
+                  elapsedMs,
+                  1,
+                  gcsPath);
+            });
   }
 
   private Void readVectoredRouted(
@@ -252,7 +274,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
       List<? extends FileRange> ranges,
       IntFunction<ByteBuffer> allocate)
       throws IOException {
-    long startTimeNs = System.nanoTime();
     ranges.forEach(range -> range.setData(new CompletableFuture<>()));
     List<VectoredIORange> vectoredIORanges =
         ranges.stream()
@@ -265,7 +286,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
                         .build())
             .collect(Collectors.toList());
     vectoredChannel.readVectored(vectoredIORanges, allocate);
-    vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
   }
 
   private void readVectoredViaAnalyticsCore(
@@ -273,7 +293,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
       List<? extends FileRange> ranges,
       IntFunction<ByteBuffer> allocate)
       throws IOException {
-    long startTimeNs = System.nanoTime();
     ranges.forEach(
         range -> {
           CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
@@ -298,20 +317,19 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
                         .build())
             .collect(Collectors.toList());
     analyticsChannel.readVectored(gcsObjectRanges, allocate);
+    // Update metrics manually as Analytics Core bypasses the standard GCS event
+    // bus.
     storageStatistics.incrementGcsTotalRequestCount();
     storageStatistics.incrementCounter(GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
-    vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
   }
 
   private void readVectoredDefault(
       List<? extends FileRange> ranges, IntFunction<ByteBuffer> allocate) throws IOException {
-    long startTimeNs = System.nanoTime();
     vectoredIOSupplier
         .get()
         .readVectored(
             ranges, allocate, gcsFs, fileInfo, gcsPath, streamStatistics, rangeReadThreadStats);
     statistics.incrementReadOps(1);
-    vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
   }
 
   @Override
@@ -348,6 +366,8 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             int numRead = channel.read(ByteBuffer.wrap(buf, offset, length));
             if (numRead > 0) {
               if (channel instanceof GcsAnalyticsCoreInputStreamWrapper) {
+                // Update metrics manually as Analytics Core bypasses the standard GCS event
+                // bus.
                 storageStatistics.incrementGcsTotalRequestCount();
                 storageStatistics.incrementCounter(
                     GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
@@ -390,6 +410,8 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             checkNotClosed();
             ((GcsAnalyticsCoreInputStreamWrapper) channel)
                 .readFully(position, buffer, offset, length);
+            // Update metrics manually as Analytics Core bypasses the standard GCS event
+            // bus.
             storageStatistics.incrementGcsTotalRequestCount();
             storageStatistics.incrementCounter(
                 GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST, 1);
@@ -472,7 +494,6 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
               rangeReadThreadStats.clear();
               streamStats.close();
               seekStreamStats.close();
-              vectoredReadStats.close();
             }
           }
           return null;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreInputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreInputStreamWrapperTest.java
@@ -18,6 +18,9 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -147,6 +150,75 @@ public class GcsAnalyticsCoreInputStreamWrapperTest {
     adapter.readVectored(ranges, allocate);
 
     verify(mockInputStream).readVectored(ranges, allocate);
+  }
+
+  @Test
+  public void readVectored_withSomeInvalidRanges_completesInvalidExceptionallyAndDelegatesValid()
+      throws IOException {
+    CompletableFuture<ByteBuffer> validFuture = new CompletableFuture<>();
+    GcsObjectRange validRange =
+        GcsObjectRange.builder()
+            .setOffset(0)
+            .setLength(100)
+            .setByteBufferFuture(validFuture)
+            .build();
+
+    CompletableFuture<ByteBuffer> invalidFuture = new CompletableFuture<>();
+    GcsObjectRange invalidRange =
+        GcsObjectRange.builder()
+            .setOffset(950)
+            .setLength(100)
+            .setByteBufferFuture(invalidFuture)
+            .build(); // 950 + 100 = 1050 > size (1000)
+
+    List<GcsObjectRange> ranges = Arrays.asList(validRange, invalidRange);
+    IntFunction<ByteBuffer> allocate = ByteBuffer::allocate;
+
+    adapter.readVectored(ranges, allocate);
+
+    // Verify valid range is delegated
+    verify(mockInputStream).readVectored(Arrays.asList(validRange), allocate);
+
+    // Verify invalid range is completed exceptionally
+    assertThat(invalidFuture.isCompletedExceptionally()).isTrue();
+    java.util.concurrent.ExecutionException exception =
+        assertThrows(java.util.concurrent.ExecutionException.class, invalidFuture::get);
+    assertThat(exception.getCause()).isInstanceOf(IOException.class);
+    assertThat(exception.getCause().getMessage()).contains("Range extends beyond file size");
+
+    // Verify valid range is NOT completed exceptionally
+    assertThat(validFuture.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  public void readVectored_withAllInvalidRanges_doesNotDelegateToInputStream() throws IOException {
+    CompletableFuture<ByteBuffer> invalidFuture1 = new CompletableFuture<>();
+    GcsObjectRange invalidRange1 =
+        GcsObjectRange.builder()
+            .setOffset(1001)
+            .setLength(10)
+            .setByteBufferFuture(invalidFuture1)
+            .build();
+
+    CompletableFuture<ByteBuffer> invalidFuture2 = new CompletableFuture<>();
+    GcsObjectRange invalidRange2 =
+        GcsObjectRange.builder()
+            .setOffset(950)
+            .setLength(100)
+            .setByteBufferFuture(invalidFuture2)
+            .build();
+
+    List<GcsObjectRange> ranges = Arrays.asList(invalidRange1, invalidRange2);
+    IntFunction<ByteBuffer> allocate = ByteBuffer::allocate;
+
+    adapter.readVectored(ranges, allocate);
+
+    // Verify mockInputStream.readVectored was never called
+    verify(mockInputStream, never()).readVectored(anyList(), any());
+
+    // Verify both are completed exceptionally
+    assertThat(invalidFuture1.isCompletedExceptionally()).isTrue();
+    assertThat(invalidFuture2.isCompletedExceptionally()).isTrue();
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
@@ -347,6 +347,13 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
 
     in.readVectored(fileRanges, ByteBuffer::allocate);
     assertThat(expected).isEqualTo(rangeReq1.getData().get(10, TimeUnit.SECONDS).array());
+
+    long startWait = System.currentTimeMillis();
+    while (globalStorageStatistics.getLong(STREAM_READ_VECTORED_OPERATIONS.getSymbol()) < 1
+        && System.currentTimeMillis() - startWait < 5000) {
+      Thread.sleep(100);
+    }
+
     in.close();
 
     IOStatistics ioStats = in.getIOStatistics();
@@ -437,6 +444,12 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     try (GoogleHadoopFSInputStream ignore = in) {
       in.readVectored(fileRanges, ByteBuffer::allocate);
       validateVectoredReadResult(fileRanges, path);
+    }
+
+    long startWait = System.currentTimeMillis();
+    while (stats.getLong(STREAM_READ_VECTORED_OPERATIONS.getSymbol()) < 1
+        && System.currentTimeMillis() - startWait < 5000) {
+      Thread.sleep(100);
     }
 
     TestUtils.verifyCounter(stats, STREAM_READ_VECTORED_OPERATIONS, 1);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileRange;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.statistics.IOStatistics;
@@ -51,10 +52,23 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class GoogleHadoopFSInputStreamIntegrationTest {
+
+  @Parameterized.Parameter public boolean analyticsCoreEnabled;
+
+  @Parameterized.Parameters(name = "analyticsCoreEnabled={0}")
+  public static Iterable<Boolean> getAnalyticsCoreEnabled() {
+    return List.of(true, false);
+  }
+
+  private Configuration getParameterizedConfig() {
+    Configuration config = GoogleHadoopFileSystemIntegrationHelper.getTestConfig();
+    config.setBoolean("fs.gs.analytics.core.enable", analyticsCoreEnabled);
+    return config;
+  }
 
   private static GoogleCloudStorageFileSystemIntegrationHelper gcsFsIHelper;
 
@@ -95,8 +109,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "seek_illegalArgument");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -112,8 +125,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_singleBytes");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -137,8 +149,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_singleBytes");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -163,8 +174,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_mergedRange");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     // overriding the default values with lower limit to test out on smaller content size.
     VectoredReadOptions vectoredReadOptions =
@@ -204,8 +214,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_rangeRequestBeyondFile");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "verify vectored read ranges are getting"; // length = 40
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -242,8 +251,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
   public void testAvailable() throws Exception {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "testAvailable");
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -261,8 +269,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_after_closed");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -279,8 +286,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "seek_illegalArgument");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     String testContent = "test content";
     gcsFsIHelper.writeTextFile(path, testContent);
@@ -324,8 +330,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "seek_illegalArgument");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
 
     GhfsGlobalStorageStatistics globalStorageStatistics = ghfs.getGlobalGcsStorageStatistics();
     GhfsThreadLocalStatistics ghfsThreadLocalStatistics =
@@ -376,8 +381,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "seek_illegalArgument");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
     GhfsGlobalStorageStatistics stats = TestUtils.getStorageStatistics();
 
     String testContent = "test content";
@@ -424,8 +428,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "read_mergedRange");
 
     GoogleHadoopFileSystem ghfs =
-        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
-            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, getParameterizedConfig());
     GhfsGlobalStorageStatistics stats = TestUtils.getStorageStatistics();
 
     // overriding the default values with lower limit to test out on smaller content size.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/TestUtils.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/TestUtils.java
@@ -32,7 +32,7 @@ class TestUtils {
 
     Long minValue = ioStatistics.minimums().get(minKey);
     Long maxValue = ioStatistics.maximums().get(maxKey);
-    long meanValue = Double.valueOf(ioStatistics.meanStatistics().get(meanKey).mean()).longValue();
+    long meanValue = Math.round(ioStatistics.meanStatistics().get(meanKey).mean());
 
     assertThat(minValue).isLessThan(maxValue + 1);
     assertThat(minValue).isLessThan(meanValue + 1);
@@ -44,7 +44,7 @@ class TestUtils {
     String symbol = statistic;
     long minValue = stats.getMin(symbol);
     long maxValue = stats.getMax(symbol);
-    long meanValue = Double.valueOf(stats.getMean(symbol)).longValue();
+    long meanValue = Math.round(stats.getMean(symbol));
 
     assertThat(stats.getLong(symbol)).isEqualTo(expected);
     assertThat(minValue).isLessThan(maxValue + 1);


### PR DESCRIPTION
This PR parameterizes `GoogleHadoopFSInputStreamIntegrationTest` to verify the read path with Analytics Core both enabled and disabled. It also introduces manual metric updates and range validation to ensure consistency.