### PR TITLE
Map Connector configurations to Analytics Core

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.hadoop.fs.gcs;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 
@@ -27,6 +28,23 @@ final class AnalyticsCoreConfigMapper {
   static final String MAX_MERGE_GAP_KEY = "analytics-core.read.vectored.range.merge-gap.max-bytes";
   static final String MAX_MERGE_SIZE_KEY =
       "analytics-core.read.vectored.range.merged-size.max-bytes";
+
+  private static final ImmutableMap<String, String> HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS =
+      ImmutableMap.<String, String>builder()
+          .put(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), PROJECT_ID_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
+              USER_PROJECT_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(),
+              READ_THREAD_COUNT_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(),
+              MAX_MERGE_GAP_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
+              MAX_MERGE_SIZE_KEY)
+          .build();
 
   private AnalyticsCoreConfigMapper() {
     // Utility class
@@ -43,26 +61,9 @@ final class AnalyticsCoreConfigMapper {
     Map<String, String> mappedProperties = config.getValByRegex("^" + prefix.replace(".", "\\."));
 
     // Direct 1:1 mappings from Connector to Analytics Core
-    mapAndRemoveSource(
-        GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(),
-        mappedProperties,
-        prefix + PROJECT_ID_KEY);
-    mapAndRemoveSource(
-        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
-        mappedProperties,
-        prefix + USER_PROJECT_KEY);
-    mapAndRemoveSource(
-        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(),
-        mappedProperties,
-        prefix + READ_THREAD_COUNT_KEY);
-    mapAndRemoveSource(
-        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(),
-        mappedProperties,
-        prefix + MAX_MERGE_GAP_KEY);
-    mapAndRemoveSource(
-        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
-        mappedProperties,
-        prefix + MAX_MERGE_SIZE_KEY);
+    HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS.forEach(
+        (hadoopKey, analyticsKey) ->
+            mapAndRemoveSource(hadoopKey, mappedProperties, prefix + analyticsKey));
 
     return mappedProperties;
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.fs.gcs;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+
+/** Maps GCS Hadoop Connector configurations to GCS Analytics Core configurations. */
+final class AnalyticsCoreConfigMapper {
+
+  private AnalyticsCoreConfigMapper() {
+    // Utility class
+  }
+
+  /**
+   * Maps configurations from Hadoop Configuration to a map suitable for Analytics Core.
+   *
+   * @param config The Hadoop configuration.
+   * @param prefix The prefix used for Analytics Core properties (e.g., "fs.gs.").
+   * @return A map containing the mapped properties.
+   */
+  static Map<String, String> mapConfigs(Configuration config, String prefix) {
+    Map<String, String> properties = config.getValByRegex("^" + prefix.replace(".", "\\."));
+    Map<String, String> mappedProperties = new HashMap<>(properties);
+
+    // Direct 1:1 mappings from Connector to Analytics Core
+    mapAndRemoveSource(
+        config,
+        GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(),
+        mappedProperties,
+        prefix + "project-id");
+    mapAndRemoveSource(
+        config,
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
+        mappedProperties,
+        prefix + "user-project");
+    mapAndRemoveSource(
+        config,
+        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(),
+        mappedProperties,
+        prefix + "analytics-core.read.thread.count");
+    mapAndRemoveSource(
+        config,
+        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(),
+        mappedProperties,
+        prefix + "analytics-core.read.vectored.range.merge-gap.max-bytes");
+    mapAndRemoveSource(
+        config,
+        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
+        mappedProperties,
+        prefix + "analytics-core.read.vectored.range.merged-size.max-bytes");
+
+    return mappedProperties;
+  }
+
+  private static void mapAndRemoveSource(
+      Configuration config, String hadoopKey, Map<String, String> map, String analyticsCoreKey) {
+    String value = config.get(hadoopKey);
+    if (value != null) {
+      map.put(analyticsCoreKey, value);
+      map.remove(hadoopKey);
+    }
+  }
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -52,6 +52,7 @@ final class AnalyticsCoreConfigMapper {
 
   /**
    * Maps configurations from Hadoop Configuration to a map suitable for Analytics Core.
+   * If a configuration flag is not set by the user, Analytics Core defaults will be used.
    *
    * @param config The Hadoop configuration.
    * @param prefix The prefix used for Analytics Core properties (e.g., "fs.gs.").

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -22,6 +22,13 @@ import org.apache.hadoop.conf.Configuration;
 /** Maps GCS Hadoop Connector configurations to GCS Analytics Core configurations. */
 final class AnalyticsCoreConfigMapper {
 
+  static final String PROJECT_ID_KEY = "project-id";
+  static final String USER_PROJECT_KEY = "user-project";
+  static final String READ_THREAD_COUNT_KEY = "analytics-core.read.thread.count";
+  static final String MAX_MERGE_GAP_KEY = "analytics-core.read.vectored.range.merge-gap.max-bytes";
+  static final String MAX_MERGE_SIZE_KEY =
+      "analytics-core.read.vectored.range.merged-size.max-bytes";
+
   private AnalyticsCoreConfigMapper() {
     // Utility class
   }
@@ -42,27 +49,27 @@ final class AnalyticsCoreConfigMapper {
         config,
         GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(),
         mappedProperties,
-        prefix + "project-id");
+        prefix + PROJECT_ID_KEY);
     mapAndRemoveSource(
         config,
         GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
         mappedProperties,
-        prefix + "user-project");
+        prefix + USER_PROJECT_KEY);
     mapAndRemoveSource(
         config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(),
         mappedProperties,
-        prefix + "analytics-core.read.thread.count");
+        prefix + READ_THREAD_COUNT_KEY);
     mapAndRemoveSource(
         config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(),
         mappedProperties,
-        prefix + "analytics-core.read.vectored.range.merge-gap.max-bytes");
+        prefix + MAX_MERGE_GAP_KEY);
     mapAndRemoveSource(
         config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
         mappedProperties,
-        prefix + "analytics-core.read.vectored.range.merged-size.max-bytes");
+        prefix + MAX_MERGE_SIZE_KEY);
 
     return mappedProperties;
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.hadoop.fs.gcs;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 
@@ -41,32 +40,26 @@ final class AnalyticsCoreConfigMapper {
    * @return A map containing the mapped properties.
    */
   static Map<String, String> mapConfigs(Configuration config, String prefix) {
-    Map<String, String> properties = config.getValByRegex("^" + prefix.replace(".", "\\."));
-    Map<String, String> mappedProperties = new HashMap<>(properties);
+    Map<String, String> mappedProperties = config.getValByRegex("^" + prefix.replace(".", "\\."));
 
     // Direct 1:1 mappings from Connector to Analytics Core
     mapAndRemoveSource(
-        config,
         GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(),
         mappedProperties,
         prefix + PROJECT_ID_KEY);
     mapAndRemoveSource(
-        config,
         GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
         mappedProperties,
         prefix + USER_PROJECT_KEY);
     mapAndRemoveSource(
-        config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(),
         mappedProperties,
         prefix + READ_THREAD_COUNT_KEY);
     mapAndRemoveSource(
-        config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(),
         mappedProperties,
         prefix + MAX_MERGE_GAP_KEY);
     mapAndRemoveSource(
-        config,
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
         mappedProperties,
         prefix + MAX_MERGE_SIZE_KEY);
@@ -75,11 +68,10 @@ final class AnalyticsCoreConfigMapper {
   }
 
   private static void mapAndRemoveSource(
-      Configuration config, String hadoopKey, Map<String, String> map, String analyticsCoreKey) {
-    String value = config.get(hadoopKey);
+      String hadoopKey, Map<String, String> map, String analyticsCoreKey) {
+    String value = map.remove(hadoopKey);
     if (value != null) {
       map.put(analyticsCoreKey, value);
-      map.remove(hadoopKey);
     }
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -458,11 +458,11 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
   }
 
   private GcsFileSystem createAnalyticsGcsFs(Configuration config) throws IOException {
-    // TODO(singhaniash): Create a config mapping
     // TODO(singhaniash): Pass correct user agent to AnalyticsCore
-    Map<String, String> properties = config.getValByRegex("^" + GCS_CONFIG_PREFIX + "\\.");
+    Map<String, String> mappedProperties =
+        AnalyticsCoreConfigMapper.mapConfigs(config, GCS_CONFIG_PREFIX + ".");
     GcsFileSystemOptions options =
-        GcsFileSystemOptions.createFromOptions(properties, GCS_CONFIG_PREFIX + ".");
+        GcsFileSystemOptions.createFromOptions(mappedProperties, GCS_CONFIG_PREFIX + ".");
     return new GcsFileSystemImpl(getCredentials(config), options);
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
@@ -29,12 +29,7 @@ public class AnalyticsCoreConfigMapperTest {
 
   @Test
   public void mapConfigs_mapsConnectorPropertiesToAnalyticsCore() {
-    Configuration config = new Configuration();
-    config.set("fs.gs.project.id", "my-project");
-    config.set("fs.gs.requester.pays.project.id", "user-project");
-    config.set("fs.gs.vectored.read.threads", "10");
-    config.set("fs.gs.vectored.read.min.range.seek.size", "1024");
-    config.set("fs.gs.vectored.read.merged.range.max.size", "2048");
+    Configuration config = createTestConfiguration();
 
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
 
@@ -52,20 +47,29 @@ public class AnalyticsCoreConfigMapperTest {
 
   @Test
   public void mapConfigs_removesMappedConnectorPropertiesFromResult() {
-    Configuration config = new Configuration();
-    config.set("fs.gs.project.id", "my-project");
-    config.set("fs.gs.requester.pays.project.id", "user-project");
-    config.set("fs.gs.vectored.read.threads", "10");
-    config.set("fs.gs.vectored.read.min.range.seek.size", "1024");
-    config.set("fs.gs.vectored.read.merged.range.max.size", "2048");
+    Configuration config = createTestConfiguration();
 
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
 
-    assertThat(mapped.containsKey("fs.gs.project.id")).isFalse();
-    assertThat(mapped.containsKey("fs.gs.requester.pays.project.id")).isFalse();
-    assertThat(mapped.containsKey("fs.gs.vectored.read.threads")).isFalse();
-    assertThat(mapped.containsKey("fs.gs.vectored.read.min.range.seek.size")).isFalse();
-    assertThat(mapped.containsKey("fs.gs.vectored.read.merged.range.max.size")).isFalse();
+    assertThat(mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE
+                    .getKey()))
+        .isFalse();
   }
 
   @Test
@@ -95,5 +99,19 @@ public class AnalyticsCoreConfigMapperTest {
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
 
     assertThat(mapped).isEmpty();
+  }
+
+  private Configuration createTestConfiguration() {
+    Configuration config = new Configuration();
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), "my-project");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(), "user-project");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(), "10");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(), "1024");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
+        "2048");
+    return config;
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link AnalyticsCoreConfigMapper}. */
+@RunWith(JUnit4.class)
+public class AnalyticsCoreConfigMapperTest {
+
+  @Test
+  public void mapConfigs_mapsConnectorPropertiesToAnalyticsCore() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.project.id", "my-project");
+    config.set("fs.gs.requester.pays.project.id", "user-project");
+    config.set("fs.gs.vectored.read.threads", "10");
+    config.set("fs.gs.vectored.read.min.range.seek.size", "1024");
+    config.set("fs.gs.vectored.read.merged.range.max.size", "2048");
+
+    Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+
+    assertThat(mapped.get("fs.gs.project-id")).isEqualTo("my-project");
+    assertThat(mapped.get("fs.gs.user-project")).isEqualTo("user-project");
+    assertThat(mapped.get("fs.gs.analytics-core.read.thread.count")).isEqualTo("10");
+    assertThat(mapped.get("fs.gs.analytics-core.read.vectored.range.merge-gap.max-bytes"))
+        .isEqualTo("1024");
+    assertThat(mapped.get("fs.gs.analytics-core.read.vectored.range.merged-size.max-bytes"))
+        .isEqualTo("2048");
+  }
+
+  @Test
+  public void mapConfigs_removesMappedConnectorPropertiesFromResult() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.project.id", "my-project");
+    config.set("fs.gs.requester.pays.project.id", "user-project");
+    config.set("fs.gs.vectored.read.threads", "10");
+    config.set("fs.gs.vectored.read.min.range.seek.size", "1024");
+    config.set("fs.gs.vectored.read.merged.range.max.size", "2048");
+
+    Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+
+    assertThat(mapped.containsKey("fs.gs.project.id")).isFalse();
+    assertThat(mapped.containsKey("fs.gs.requester.pays.project.id")).isFalse();
+    assertThat(mapped.containsKey("fs.gs.vectored.read.threads")).isFalse();
+    assertThat(mapped.containsKey("fs.gs.vectored.read.min.range.seek.size")).isFalse();
+    assertThat(mapped.containsKey("fs.gs.vectored.read.merged.range.max.size")).isFalse();
+  }
+
+  @Test
+  public void mapConfigs_preservesUnmappedPropertiesWithPrefix() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.some.other.prop", "val");
+
+    Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+
+    assertThat(mapped.get("fs.gs.some.other.prop")).isEqualTo("val");
+  }
+
+  @Test
+  public void mapConfigs_returnsEmptyWhenNoMatchingPrefix() {
+    Configuration config = new Configuration();
+    config.set("other.prefix.prop", "val");
+
+    Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    mapped.remove("fs.gs.impl");
+
+    assertThat(mapped).isEmpty();
+  }
+
+  @Test
+  public void mapConfigs_returnsEmptyWhenConfigIsEmpty() {
+    Configuration config = new Configuration();
+
+    Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    mapped.remove("fs.gs.impl");
+
+    assertThat(mapped).isEmpty();
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
@@ -38,12 +38,15 @@ public class AnalyticsCoreConfigMapperTest {
 
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
 
-    assertThat(mapped.get("fs.gs.project-id")).isEqualTo("my-project");
-    assertThat(mapped.get("fs.gs.user-project")).isEqualTo("user-project");
-    assertThat(mapped.get("fs.gs.analytics-core.read.thread.count")).isEqualTo("10");
-    assertThat(mapped.get("fs.gs.analytics-core.read.vectored.range.merge-gap.max-bytes"))
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.PROJECT_ID_KEY))
+        .isEqualTo("my-project");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isEqualTo("user-project");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.READ_THREAD_COUNT_KEY))
+        .isEqualTo("10");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.MAX_MERGE_GAP_KEY))
         .isEqualTo("1024");
-    assertThat(mapped.get("fs.gs.analytics-core.read.vectored.range.merged-size.max-bytes"))
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.MAX_MERGE_SIZE_KEY))
         .isEqualTo("2048");
   }
 
@@ -77,21 +80,19 @@ public class AnalyticsCoreConfigMapperTest {
 
   @Test
   public void mapConfigs_returnsEmptyWhenNoMatchingPrefix() {
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
     config.set("other.prefix.prop", "val");
 
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
-    mapped.remove("fs.gs.impl");
 
     assertThat(mapped).isEmpty();
   }
 
   @Test
   public void mapConfigs_returnsEmptyWhenConfigIsEmpty() {
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(false);
 
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
-    mapped.remove("fs.gs.impl");
 
     assertThat(mapped).isEmpty();
   }


### PR DESCRIPTION
This PR introduces the `AnalyticsCoreConfigMapper` class to handle the mapping of Hadoop Connector configurations to Analytics Core configurations. Applicable configs with direct 1:1 mapping, as documented in the [internal doc](https://docs.google.com/document/d/1yRc5Y7NDeXx4aQJYy7s_I4KDpqCdGzAFDkvAGCriksA/edit?tab=t.dp6btvyilmq4#bookmark=id.o300iiy0ehsr), have been implemented.