### PR TITLE
Log requested byte range in high latency logs

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -94,7 +94,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.fadvise", Fadvise.AUTO);
           put("fs.gs.inputstream.fast.fail.on.not.found.enable", true);
           put("fs.gs.inputstream.inplace.seek.limit", 8 * 1024 * 1024L);
-          put("fs.gs.inputstream.latency.logging.threshold.ms", 1000L);
+          put("fs.gs.inputstream.latency.logging.threshold.ms", 10000L);
           put("fs.gs.inputstream.min.range.request.size", 2 * 1024 * 1024L);
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.lazy.init.enable", false);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -61,7 +61,7 @@ public abstract class GoogleCloudStorageReadOptions {
         .setReadExactRequestedBytesEnabled(false)
         .setBidiThreadCount(16)
         .setBidiClientTimeout(30)
-        .setLatencyLoggingThreshold(1000L);
+        .setLatencyLoggingThreshold(10000L);
   }
 
   public abstract Builder toBuilder();

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
@@ -30,14 +30,14 @@ public class GcsReadDurationTrackerStream extends FilterInputStream {
   private static final String UPLOAD_ID_HEADER = "x-guploader-uploadid";
 
   private final URI streamPath;
-  private final Object responseHeaders;
+  private final HttpHeaders responseHeaders;
   private final long latencyLoggingThresholdMs;
   private long cumulativeTransferDurationMs;
 
   public GcsReadDurationTrackerStream(
       InputStream delegate,
       URI streamPath,
-      Object responseHeaders,
+      HttpHeaders responseHeaders,
       long latencyLoggingThresholdMs) {
     super(delegate);
     this.streamPath = streamPath;
@@ -73,13 +73,15 @@ public class GcsReadDurationTrackerStream extends FilterInputStream {
     } finally {
       boolean latencyThresholdBreached = cumulativeTransferDurationMs > latencyLoggingThresholdMs;
       if (latencyThresholdBreached) {
-        String uploadId =
-            responseHeaders instanceof HttpHeaders
-                ? ((HttpHeaders) responseHeaders).getFirstHeaderStringValue(UPLOAD_ID_HEADER)
-                : String.valueOf(responseHeaders);
+        String uploadId = null;
+        String range = null;
+        if (responseHeaders != null) {
+          uploadId = responseHeaders.getFirstHeaderStringValue(UPLOAD_ID_HEADER);
+          range = responseHeaders.getContentRange();
+        }
         logger.atInfo().atMostEvery(10, TimeUnit.SECONDS).log(
-            "Detected high latency for %s. durationMs=%d; upload_id=%s",
-            streamPath, cumulativeTransferDurationMs, uploadId);
+            "Detected high latency for %s. durationMs=%d; upload_id=%s; range=%s",
+            streamPath, cumulativeTransferDurationMs, uploadId, range);
       }
       GoogleCloudStorageEventBus.postReadMetricEvent(
           GcsReadMetricEvent.ofDataTransfer(


### PR DESCRIPTION
- Increase the logging threshold to 10 seconds
- Log bytesRanges