### PR TITLE
[branch-4.0.x] Backport fast fail features, gRPC bug fixes, and log/drop extra bytes

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+1. Implement fast fail for Bidi Read.
+1. Fast Fail Bug Fix during gRPC Reads.
+1. Log and drop while receiving the additional bytes from server.
+
 ## 4.0.4 - 2026-03-26
 1. Add Integration test for chained Downscoping Interceptors
 1. Enable HNS flag by default

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -302,7 +302,6 @@ default service account impersonation.
     call. If the client code can handle late failures on not-found errors, or
     has independently already ensured that a file exists before calling open(),
     then set this property to false for more efficient reads.
-    Not supported by `STORAGE_CLIENT` (gRPC) when `fs.gs.bidi.enable` is `true`.
 
 *   `fs.gs.inputstream.support.gzip.encoding.enable` (default: `false`)
 

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -558,9 +558,9 @@ better latency and increased bandwidth. Currently supported only for read/write 
 
 ### Hierarchical Namespace (HNS) Configuration
 
-* `fs.gs.hierarchical.namespace.folders.enable` (default: `false`)
+* `fs.gs.hierarchical.namespace.folders.enable` (default: `true`)
 
-    If true, the connector will use native HNS APIs for `rename` and `delete` operations
+    By default, the connector will use native HNS APIs for `rename` and `delete` operations
     on Hierarchical Namespace (HNS) enabled buckets. This includes using the `renameFolder` API for directory renames
     and deleting native folders during `delete` operations.
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
@@ -18,6 +18,8 @@ package com.google.cloud.hadoop.gcsio;
 
 import static com.google.api.client.util.Preconditions.checkArgument;
 import static com.google.api.client.util.Preconditions.checkNotNull;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.Math.max;
 
@@ -49,42 +51,54 @@ import javax.annotation.Nullable;
 public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeekableByteChannel {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private static final int EOF = -1;
-  private final StorageResourceId resourceId;
-  private final BlobId blobId;
+  private StorageResourceId resourceId;
+  private BlobId blobId;
   private final ApiFuture<BlobReadSession> sessionFuture;
   private volatile BlobReadSession blobReadSession;
   private final ExecutorService boundedThreadPool;
   private static final String GZIP_ENCODING = "gzip";
-  private long objectSize;
+  private volatile long objectSize = -1;
   private boolean open = true;
+  private volatile boolean metadataInitialized = false;
+
+  private final Storage storage;
+  private final GoogleCloudStorageReadOptions readOptions;
   private boolean gzipEncoded = false;
   private final Duration readTimeout;
   private long position = 0;
-  private final GoogleCloudStorageReadOptions readOptions;
   private byte[] footerContent;
   private ByteBuffer internalBuffer;
   private long bufferStartPosition = -1;
 
   public GoogleCloudStorageBidiReadChannel(
       Storage storage,
-      GoogleCloudStorageItemInfo itemInfo,
+      StorageResourceId resourceId,
+      @Nullable GoogleCloudStorageItemInfo itemInfo,
       GoogleCloudStorageReadOptions readOptions,
       ExecutorService boundedThreadPool)
       throws IOException {
-    validate(itemInfo);
-    // TODO(dhritichopra) Remove grpcReadTimeout if redundant and rename to bidiReadTimeout.
-    this.readTimeout = readOptions.getGrpcReadTimeout();
-    this.resourceId =
-        new StorageResourceId(
-            itemInfo.getBucketName(), itemInfo.getObjectName(), itemInfo.getContentGeneration());
-    this.blobId =
-        BlobId.of(
-            resourceId.getBucketName(), resourceId.getObjectName(), resourceId.getGenerationId());
+    this.storage = storage;
+    this.resourceId = resourceId;
     this.readOptions = readOptions;
+    this.boundedThreadPool = boundedThreadPool;
+    this.readTimeout = readOptions.getGrpcReadTimeout();
+
+    if (itemInfo != null) {
+      validate(itemInfo);
+      initMetadata(
+          itemInfo.getContentEncoding(), itemInfo.getSize(), itemInfo.getContentGeneration());
+    } else if (readOptions.isFastFailOnNotFoundEnabled()) {
+      fetchMetadata();
+    }
+
+    Long generationId =
+        resourceId.getGenerationId() == StorageResourceId.UNKNOWN_GENERATION_ID
+            ? null
+            : resourceId.getGenerationId();
+
+    this.blobId = BlobId.of(resourceId.getBucketName(), resourceId.getObjectName(), generationId);
     this.sessionFuture = storage.blobReadSession(blobId);
     this.blobReadSession = null;
-    this.boundedThreadPool = boundedThreadPool;
-    initMetadata(itemInfo.getContentEncoding(), itemInfo.getSize());
   }
 
   private synchronized BlobReadSession getBlobReadSession() throws IOException {
@@ -107,6 +121,7 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
     if (!dst.hasRemaining()) {
       return 0;
     }
+    ensureMetadataInitialized();
 
     if (position >= objectSize) {
       return EOF;
@@ -172,10 +187,11 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
 
   @Override
   public long size() throws IOException {
-    if (objectSize == -1) {
-      GoogleCloudStorageEventBus.postOnException();
-      throw new IOException("Size of file is not available");
-    }
+    throwIfNotOpen();
+
+    // Lazily fetch the size if it's not available yet
+    ensureMetadataInitialized();
+
     return objectSize;
   }
 
@@ -224,6 +240,8 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
   public void readVectored(List<VectoredIORange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
     logger.atFiner().log("readVectored() called for BlobId=%s", blobId.toString());
+    throwIfNotOpen();
+    ensureMetadataInitialized();
     long vectoredReadStartTime = System.currentTimeMillis();
     BlobReadSession session = getBlobReadSession();
     ranges.forEach(
@@ -294,15 +312,33 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
     }
   }
 
-  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata)
+  protected void initMetadata(@Nullable String encoding, long sizeFromMetadata, long generation)
       throws UnsupportedOperationException {
+    checkState(!metadataInitialized, "Metadata already initialized");
+
     gzipEncoded = nullToEmpty(encoding).contains(GZIP_ENCODING);
     // TODO(dhritichopra) Add Support for GZIP Encoding
     if (gzipEncoded) {
       GoogleCloudStorageEventBus.postOnException();
       throw new UnsupportedOperationException("Gzip Encoded Files are not supported");
     }
+
     objectSize = sizeFromMetadata;
+
+    if (!resourceId.hasGenerationId()) {
+      resourceId =
+          new StorageResourceId(resourceId.getBucketName(), resourceId.getObjectName(), generation);
+      blobId = BlobId.of(resourceId.getBucketName(), resourceId.getObjectName(), generation);
+    } else {
+      checkState(
+          resourceId.getGenerationId() == generation,
+          "Provided generation (%s) should be equal to fetched generation (%s) for '%s'",
+          resourceId.getGenerationId(),
+          generation,
+          resourceId);
+    }
+
+    metadataInitialized = true;
   }
 
   private void validatePosition(long position) throws IOException {
@@ -530,6 +566,89 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
                 ReadProjectionConfigs.asFutureByteString()
                     .withRangeSpec(RangeSpec.of(offset, length)));
     return futureBytes.get(readTimeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  private void ensureMetadataInitialized() throws IOException {
+    // First check (lock-free fast path)
+    if (metadataInitialized) {
+      return;
+    }
+
+    synchronized (this) {
+      // Second check (thread-safe, protects against race conditions)
+      if (metadataInitialized) {
+        return;
+      }
+
+      try {
+        if (this.sessionFuture != null) {
+          // Resolve the ApiFuture to get the actual BlobReadSession object.
+          // We use the configured BidiClientTimeout to prevent the reading thread
+          // from blocking indefinitely if the future hangs.
+          BlobReadSession session =
+              this.sessionFuture.get(readOptions.getBidiClientTimeout(), TimeUnit.SECONDS);
+
+          BlobInfo blobInfo = session.getBlobInfo();
+          if (blobInfo != null) {
+            initMetadata(
+                blobInfo.getContentEncoding(), blobInfo.getSize(), blobInfo.getGeneration());
+            return;
+          }
+        }
+      } catch (InterruptedException e) {
+        GoogleCloudStorageEventBus.postOnException();
+        Thread.currentThread().interrupt();
+        logger.atWarning().withCause(e).log(
+            "Interrupted while waiting for BlobReadSession initialization for '%s'", resourceId);
+        throw new IOException("Thread interrupt received.", e);
+      } catch (ExecutionException e) {
+        GoogleCloudStorageEventBus.postOnException();
+        // If the future failed, the network call failed (e.g. 404 Not Found).
+        // We extract the underlying cause and immediately throw to prevent a redundant fallback
+        // call.
+        Throwable cause = e.getCause();
+        if (cause instanceof StorageException && ((StorageException) cause).getCode() == 404) {
+          throw createFileNotFoundException(
+              resourceId.getBucketName(), resourceId.getObjectName(), new IOException(e));
+        }
+        logger.atWarning().withCause(e).log(
+            "Failed to get metadata from BlobReadSession future for '%s'", resourceId);
+      } catch (TimeoutException e) {
+        GoogleCloudStorageEventBus.postOnException();
+        logger.atWarning().withCause(e).log(
+            "Timeout waiting for BlobReadSession initialization for '%s'", resourceId);
+      }
+
+      // Fallback: If the session didn't have it, or the future failed to resolve, do the explicit
+      // network call
+      logger.atInfo().log("Fallback to explicit metadata fetch for '%s'", resourceId);
+      fetchMetadata();
+    }
+  }
+
+  private void fetchMetadata() throws IOException {
+    try {
+      BlobId metadataBlobId =
+          BlobId.of(
+              resourceId.getBucketName(),
+              resourceId.getObjectName(),
+              resourceId.hasGenerationId() ? resourceId.getGenerationId() : null);
+
+      Blob blob =
+          storage.get(
+              metadataBlobId,
+              Storage.BlobGetOption.fields(
+                  Storage.BlobField.CONTENT_ENCODING,
+                  Storage.BlobField.SIZE,
+                  Storage.BlobField.GENERATION));
+
+      if (blob == null) {
+        throw new FileNotFoundException(String.format("Item not found: %s", resourceId));
+      }
+      initMetadata(blob.getContentEncoding(), blob.getSize(), blob.getGeneration());
+    } catch (StorageException e) {
+      throw new IOException("Failed to fetch metadata for " + resourceId, e);
+    }
   }
 
   private static void validate(GoogleCloudStorageItemInfo itemInfo) throws IOException {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -1309,8 +1309,8 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       GoogleCloudStorageReadOptions readOptions)
       throws IOException {
     GoogleCloudStorageItemInfo gcsItemInfo = itemInfo;
-    if (gcsItemInfo == null
-        && (storageOptions.isBidiEnabled() || readOptions.isFastFailOnNotFoundEnabled())) {
+    // Respect the fastFailOnNotFoundEnabled flag for both Unary and Bidi channels.
+    if (gcsItemInfo == null && readOptions.isFastFailOnNotFoundEnabled()) {
       gcsItemInfo = getItemInfo(resourceId);
     }
     // TODO(dhritichorpa) Microbenchmark the latency of using
@@ -1319,6 +1319,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
     if (storageOptions.isBidiEnabled()) {
       return new GoogleCloudStorageBidiReadChannel(
           storageWrapper.getStorage(),
+          resourceId,
           gcsItemInfo,
           readOptions,
           getBoundedThreadPool(readOptions.getBidiThreadCount()));

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -297,6 +297,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // in the first read. Therefore, loop till we either read the required number of
       // bytes or we reach end-of-stream.
       while (dst.hasRemaining()) {
+
         int remainingBeforeRead = dst.remaining();
         try {
           if (byteChannel == null) {
@@ -404,8 +405,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
       setChannelBoundaries(bytesToRead);
 
+      logger.atFiner().log(
+          "Opening lazy gRPC channel for '%s' from %d to %d",
+          resourceId, contentChannelCurrentPosition, contentChannelEnd);
+
       ReadableByteChannel readableByteChannel =
-          getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
+          initializeMetadataAndValidateChannel(
+              getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd), bytesToRead);
 
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)
@@ -417,6 +423,100 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
         return serveFooterContent();
       }
       return readableByteChannel;
+    }
+
+    private ReadableByteChannel initializeMetadataAndValidateChannel(
+        ReadableByteChannel readableByteChannel, long bytesToRead) throws IOException {
+      try {
+        if (!metadataInitialized) {
+          logger.atFine().log(
+              "Metadata not initialized. Forcing lazy channel connection with 0-byte read for '%s'",
+              resourceId);
+
+          // The 0-byte read triggers the actual ReadObjectRequest over the network
+          readableByteChannel.read(ByteBuffer.allocate(0));
+          // Extract the headers to populate objectSize
+          ensureMetadataInitialized(readableByteChannel);
+
+          logger.atFiner().log(
+              "Metadata extracted! True objectSize is now %d for '%s'", objectSize, resourceId);
+
+          ReadableByteChannel eofChannel = validateEndOfFile(readableByteChannel);
+          if (eofChannel != null) {
+            return eofChannel;
+          }
+
+          ReadableByteChannel gzipChannel = handleGzipDiscovery(readableByteChannel, bytesToRead);
+          if (gzipChannel != null) {
+            return gzipChannel;
+          }
+        }
+
+        if (contentChannelEnd == Long.MAX_VALUE && objectSize != -1) {
+          contentChannelEnd = getRangeRequestEnd(contentChannelCurrentPosition, bytesToRead);
+          logger.atFiner().log(
+              "Recalculated contentChannelEnd to %d for '%s'", contentChannelEnd, resourceId);
+        }
+
+        return readableByteChannel;
+
+      } catch (IOException | RuntimeException e) {
+        logger.atWarning().withCause(e).log(
+            "Exception occurred during metadata initialization for '%s'. Attempting to safely close orphaned channel.",
+            resourceId);
+        try {
+          if (readableByteChannel != null && readableByteChannel.isOpen()) {
+            readableByteChannel.close();
+            logger.atFine().log("Successfully closed orphaned channel for '%s'", resourceId);
+          }
+        } catch (IOException closeException) {
+          logger.atWarning().withCause(closeException).log(
+              "Failed to close orphaned channel for '%s' during cleanup", resourceId);
+          e.addSuppressed(closeException);
+        }
+        // Directly re-throw the exception exactly as it was caught.
+        // This prevents RuntimeExceptions (like NPEs) from being masked as IOExceptions!
+        throw e;
+      }
+    }
+
+    private ReadableByteChannel validateEndOfFile(ReadableByteChannel readableByteChannel)
+        throws IOException {
+      if (objectSize != -1) {
+        if (currentPosition > objectSize) {
+          // We just fetched the metadata and realized the user's initial seek was invalid
+          // Intercept it and throw the standard Invalid Seek error.
+          readableByteChannel.close();
+          GoogleCloudStorageEventBus.postOnException();
+          throw new EOFException(
+              String.format(
+                  "Invalid seek offset: position value (%d) must be between 0 and %d for '%s'",
+                  currentPosition, objectSize, resourceId));
+        } else if (currentPosition == objectSize) {
+          // User seeked exactly to the end of the file. Return a clean EOF.
+          readableByteChannel.close();
+          contentChannelCurrentPosition = currentPosition;
+          contentChannelEnd = currentPosition;
+          return Channels.newChannel(new ByteArrayInputStream(new byte[0]));
+        }
+      }
+      return null;
+    }
+
+    private ReadableByteChannel handleGzipDiscovery(
+        ReadableByteChannel readableByteChannel, long bytesToRead) throws IOException {
+      if (gzipEncoded) {
+        if (currentPosition != 0) {
+          // We guessed the boundary wrong for a GZIP file. Reopen it properly.
+          readableByteChannel.close();
+          // Reset channel boundaries
+          contentChannelCurrentPosition = -1;
+          contentChannelEnd = -1;
+          return openByteChannel(bytesToRead);
+        }
+        contentChannelEnd = objectSize;
+      }
+      return null;
     }
 
     private void ensureMetadataInitialized(ReadableByteChannel readableByteChannel)
@@ -461,7 +561,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private void setChannelBoundaries(long bytesToRead) {
-      contentChannelCurrentPosition = getRangeRequestStart();
+      contentChannelCurrentPosition = getRangeRequestStart(bytesToRead);
       contentChannelEnd = getRangeRequestEnd(contentChannelCurrentPosition, bytesToRead);
       checkState(
           contentChannelEnd >= contentChannelCurrentPosition,
@@ -513,10 +613,25 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       return Channels.newChannel(new ByteArrayInputStream(footerContent, offset, length));
     }
 
-    private long getRangeRequestStart() {
+    private long getRangeRequestStart(long bytesToRead) {
       if (gzipEncoded) {
         return 0;
       }
+
+      // Guess the start boundary if the size is unknown
+      if (objectSize == -1) {
+        if (readOptions.getFadvise() == Fadvise.SEQUENTIAL
+            || bytesToRead >= readOptions.getMinRangeRequestSize()) {
+          return currentPosition;
+        }
+        // Prefetch footer (bytes before 'currentPosition') lazily.
+        // Max prefetch size is (minRangeRequestSize / 2) bytes.
+        if (bytesToRead <= readOptions.getMinRangeRequestSize() / 2) {
+          return Math.max(0, currentPosition - readOptions.getMinRangeRequestSize() / 2);
+        }
+        return Math.max(0, currentPosition - (readOptions.getMinRangeRequestSize() - bytesToRead));
+      }
+
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
           && isFooterRead()
           && !readOptions.isReadExactRequestedBytesEnabled()) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -339,13 +339,36 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               contentChannelEnd = currentPosition;
             }
 
-            if (currentPosition != contentChannelEnd && currentPosition != objectSize) {
+            if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received;"
-                          + "EndOf stream signal received at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received; "
+                          + "at offset: %d where as stream was supposed to end at: %d for resource: "
+                          + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
+
+            } else if (currentPosition > objectSize) {
+              GoogleCloudStorageEventBus.postOnException();
+              throw new IOException(
+                  String.format(
+                      "Received end of stream result beyond the object size; at offset: %d "
+                          + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                      currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > contentChannelEnd) {
+              logger.atWarning().log(
+                  "Received end of stream result after the channel end; at offset: %d "
+                      + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                  currentPosition, contentChannelEnd, resourceId, objectSize);
+              // Dropping additional bytes.
+              int overshoot = (int) (currentPosition - contentChannelEnd);
+              dst.position(dst.position() - overshoot);
+              currentPosition = contentChannelEnd;
+              totalBytesRead -= overshoot;
+              contentChannelCurrentPosition -= overshoot;
+
+              closeContentChannel();
+              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -412,6 +435,10 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       ReadableByteChannel readableByteChannel =
           initializeMetadataAndValidateChannel(
               getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd), bytesToRead);
+
+      logger.atFiner().log(
+          "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
+          contentChannelCurrentPosition, contentChannelEnd);
 
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -324,14 +324,34 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           // actual size of the data stream when stream compression is used, so we can
           // only ignore
           // this case here.
-          if (currentPosition != contentChannelEnd && currentPosition != size) {
+          if (currentPosition > contentChannelEnd && currentPosition < size) {
+            logger.atWarning().log(
+                "Received end of stream result after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+
+            // Dropping additional bytes.
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+            contentChannelPosition -= overshoot;
+          } else if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
-                    "Received end of stream result before all the file data has been received;"
-                        + " totalBytesRead: %d, currentPosition: %d,"
-                        + " contentChannelEnd %d, size: %d, object: '%s'",
-                    totalBytesRead, currentPosition, contentChannelEnd, size, resourceId));
+                    "Received end of stream result before all requestedBytes were received; "
+                        + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                        + "%s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+
+          } else if (currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received end of stream result beyond the object size; at offset: %d "
+                        + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
           }
 
           // If we have reached an end of a contentChannel but not an end of an object
@@ -716,6 +736,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       objectContentStream = openStream(bytesToRead);
     }
     contentChannel = Channels.newChannel(objectContentStream);
+
+    logger.atFiner().log(
+        "Storage ReadChannel opened at, contentChannelPosition: %d, contentChannelEnd: %d",
+        contentChannelPosition, contentChannelEnd);
+
     checkState(
         contentChannelPosition == currentPosition,
         "contentChannelPosition (%s) should be equal to currentPosition (%s) for '%s'",

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
@@ -35,7 +35,9 @@ public class FakeReadChannel implements ReadChannel {
     READ_EXCEPTION,
     PARTIAL_READ,
     NEGATIVE_READ,
-    ZERO_READ
+    ZERO_READ,
+    MORE_THAN_CHANNEL_LENGTH,
+    MORE_THAN_OBJECT_SIZE
   }
 
   private final List<REQUEST_TYPE> orderRequestsList;
@@ -90,14 +92,18 @@ public class FakeReadChannel implements ReadChannel {
   }
 
   private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead) {
-    if (currentPosition >= limit) {
+    return readInternal(dst, startIndex, bytesToRead, false);
+  }
+
+  private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead, boolean ignoreLimit) {
+    if (!ignoreLimit && currentPosition >= limit) {
       return -1;
     }
     long readStart = startIndex;
     long readEnd =
         min(
             min(startIndex + bytesToRead, startIndex + dst.remaining()),
-            min(content.size(), limit));
+            ignoreLimit ? content.size() : min(content.size(), limit));
     ByteString messageData = content.substring(toIntExact(readStart), toIntExact(readEnd));
     for (Byte messageDatum : messageData) {
       dst.put(messageDatum);
@@ -119,11 +125,17 @@ public class FakeReadChannel implements ReadChannel {
       case NEGATIVE_READ:
         bytesRead = -1;
         break;
+      case MORE_THAN_CHANNEL_LENGTH:
+        bytesRead =
+            readInternal(dst, currentPosition, toIntExact(limit - currentPosition + 1), true);
+        break;
+      case MORE_THAN_OBJECT_SIZE:
+        bytesRead = content.size() + 1;
+        break;
       case READ_EXCEPTION:
         throw new IOException("Exception occurred in read");
       case PARTIAL_READ:
         bytesRead = readInternal(dst, currentPosition, dst.remaining() / 2);
-        currentPosition += bytesRead;
         throw new IOException("Partial Read Exception");
       default:
         bytesRead = readInternal(dst, currentPosition, CHUNK_SIZE);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannelTest.java
@@ -21,13 +21,20 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BlobReadSession;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.ZeroCopySupport.DisposableByteString;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import java.io.EOFException;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URISyntaxException;
@@ -78,6 +85,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().build(),
             Executors.newSingleThreadExecutor());
@@ -95,7 +103,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
   // TODO(dhritichopra): Remove test after support for Gzip is added
   @Test
   public void constructor_whenItemIsGzipEncoded_throwsUnsupportedOperationException()
-      throws IOException {
+      throws UnsupportedOperationException {
     Storage storage = mock(Storage.class);
     // Mock session creation to succeed (so the constructor gets to the metadata check)
     when(storage.blobReadSession(any()))
@@ -120,11 +128,349 @@ public class GoogleCloudStorageBidiReadChannelTest {
             () ->
                 new GoogleCloudStorageBidiReadChannel(
                     storage,
-                    gzipItemInfo, // Use the gzip item info
+                    RESOURCE_ID,
+                    gzipItemInfo,
                     GoogleCloudStorageReadOptions.builder().build(),
                     Executors.newSingleThreadExecutor()));
 
     assertThat(e).hasMessageThat().isEqualTo("Gzip Encoded Files are not supported");
+  }
+
+  @Test
+  public void ensureMetadataInitialized_onExecutionException404_throwsFileNotFoundException()
+      throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ApiFuture<BlobReadSession> mockFuture = mock(ApiFuture.class);
+    StorageException notFoundException = new StorageException(404, "Not Found");
+    when(mockFuture.get(anyLong(), any(java.util.concurrent.TimeUnit.class)))
+        .thenThrow(new ExecutionException("Simulated 404", notFoundException));
+    when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockFuture);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    assertThrows(FileNotFoundException.class, channel::size);
+
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void ensureMetadataInitialized_onTimeoutException_usesFallbackGet() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ApiFuture<BlobReadSession> mockFuture = mock(ApiFuture.class);
+    when(mockFuture.get(anyLong(), any(java.util.concurrent.TimeUnit.class)))
+        .thenThrow(new TimeoutException("Simulated Timeout"));
+    when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockFuture);
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(1024L);
+    when(mockBlob.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(mockBlob);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    long size = channel.size();
+
+    assertThat(size).isEqualTo(1024L);
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void ensureMetadataInitialized_onExecutionException500_usesFallbackGet() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ApiFuture<BlobReadSession> mockFuture = mock(ApiFuture.class);
+    StorageException serverErrorException = new StorageException(500, "Internal Server Error");
+    when(mockFuture.get(anyLong(), any(java.util.concurrent.TimeUnit.class)))
+        .thenThrow(new ExecutionException("Simulated 500", serverErrorException));
+    when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockFuture);
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(2048L);
+    when(mockBlob.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(mockBlob);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    long size = channel.size();
+
+    assertThat(size).isEqualTo(2048L);
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void lazyMetadataFetch_whenFastFailFalse_usesSessionMetadata() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    BlobInfo mockBlobInfo = mock(BlobInfo.class);
+    when(mockBlobInfo.getSize()).thenReturn(2048L);
+    when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlobInfo.getGeneration()).thenReturn(1L);
+    when(mockSession.getBlobInfo()).thenReturn(mockBlobInfo);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    verify(mockStorage, times(0)).get(any(BlobId.class));
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+
+    long size = channel.size();
+
+    assertThat(size).isEqualTo(2048L);
+    verify(mockSession, times(1)).getBlobInfo();
+    verify(mockStorage, times(0)).get(any(BlobId.class));
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void lazyMetadataFetch_whenSessionFutureThrowsException_usesFallbackGet()
+      throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ApiFuture<BlobReadSession> mockSessionFuture =
+        ApiFutures.immediateFailedFuture(
+            new java.util.concurrent.ExecutionException(
+                "Simulated Bidi Handshake Failure", new Exception()));
+    when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockSessionFuture);
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(8192L);
+    when(mockBlob.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(mockBlob);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+
+    // Trigger lazy initialization (this will catch the ExecutionException and trigger fallback)
+    long size = channel.size();
+
+    // Verify fallback worked
+    assertThat(size).isEqualTo(8192L);
+
+    // Verify storage.get() WAS called exactly once as the fallback mechanism
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void lazyMetadataFetch_whenSessionReturnsNull_usesFallbackGet() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    when(mockSession.getBlobInfo()).thenReturn(null);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(4096L);
+    when(mockBlob.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(mockBlob);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+
+    // Trigger the lazy initialization
+    long size = channel.size();
+
+    assertThat(size).isEqualTo(4096L);
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void fetchMetadata_whenBlobIsNull_throwsFileNotFoundException() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    when(mockSession.getBlobInfo()).thenReturn(null);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(null);
+
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    FileNotFoundException e = assertThrows(FileNotFoundException.class, channel::size);
+    assertThat(e).hasMessageThat().contains("Item not found: " + RESOURCE_ID);
+  }
+
+  @Test
+  public void fetchMetadata_whenStorageException_throwsIOException() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    when(mockSession.getBlobInfo()).thenReturn(null);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class)))
+        .thenThrow(new StorageException(500, "Simulated Server Error"));
+
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    IOException e = assertThrows(IOException.class, channel::size);
+    assertThat(e).hasMessageThat().contains("Failed to fetch metadata for " + RESOURCE_ID);
+    assertThat(e).hasCauseThat().isInstanceOf(StorageException.class);
+  }
+
+  @Test
+  public void initMetadata_withoutGenerationId_updatesResourceId() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    StorageResourceId noGenId = new StorageResourceId("test-bucket", "test-object");
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, noGenId, null, readOptions, Executors.newSingleThreadExecutor());
+
+    channel.initMetadata("text/plain", 1024L, 999L);
+
+    assertThat(channel.size()).isEqualTo(1024L);
+  }
+
+  @Test
+  public void initMetadata_withMismatchedGenerationId_throwsIllegalStateException()
+      throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    StorageResourceId withGenId = new StorageResourceId("test-bucket", "test-object", 123L);
+
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, withGenId, null, readOptions, Executors.newSingleThreadExecutor());
+
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              channel.initMetadata("text/plain", 1024L, 999L);
+            });
+
+    assertThat(e).hasMessageThat().contains("should be equal to fetched generation");
+  }
+
+  @Test
+  public void lazyMetadataFetch_triggeredByRead_usesSessionMetadata() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    BlobInfo mockBlobInfo = mock(BlobInfo.class);
+    when(mockBlobInfo.getSize()).thenReturn(5L);
+    when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlobInfo.getGeneration()).thenReturn(1L);
+    when(mockSession.getBlobInfo()).thenReturn(mockBlobInfo);
+    DisposableByteString mockDisposable = mock(DisposableByteString.class);
+    ByteString mockByteString = ByteString.copyFromUtf8("hello");
+    when(mockDisposable.byteString()).thenReturn(mockByteString);
+    ApiFuture<DisposableByteString> mockReadFuture = ApiFutures.immediateFuture(mockDisposable);
+    when(mockSession.readAs(any())).thenReturn(mockReadFuture);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    ByteBuffer buffer = ByteBuffer.allocate(5);
+    int bytesRead = channel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(5);
+    verify(mockSession, times(1)).getBlobInfo();
+    verify(mockSession, times(1)).readAs(any());
+    verify(mockStorage, times(0)).get(any(BlobId.class));
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void lazyMetadataFetch_triggeredByReadVectored_usesSessionMetadata() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    BlobInfo mockBlobInfo = mock(BlobInfo.class);
+    when(mockBlobInfo.getSize()).thenReturn(2048L);
+    when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlobInfo.getGeneration()).thenReturn(1L);
+    when(mockSession.getBlobInfo()).thenReturn(mockBlobInfo);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    channel.readVectored(ImmutableList.of(), ByteBuffer::allocate);
+
+    verify(mockSession, times(1)).getBlobInfo();
+    verify(mockStorage, times(0)).get(any(BlobId.class));
+    verify(mockStorage, times(0)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+  }
+
+  @Test
+  public void ensureMetadataInitialized_onInterruptedException_restoresInterruptFlag()
+      throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ApiFuture<BlobReadSession> mockFuture = mock(ApiFuture.class);
+    when(mockFuture.get(anyLong(), any(java.util.concurrent.TimeUnit.class)))
+        .thenThrow(new InterruptedException("Simulated Interrupt"));
+    when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockFuture);
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    IOException thrown = assertThrows(IOException.class, channel::size);
+    assertThat(thrown).hasMessageThat().contains("Thread interrupt received.");
+    assertThat(thrown).hasCauseThat().isInstanceOf(InterruptedException.class);
+    assertThat(Thread.currentThread().isInterrupted()).isTrue();
+
+    // Clear the interrupt flag so it doesn't affect other tests!
+    Thread.interrupted();
+  }
+
+  @Test
+  public void eagerMetadataFetch_whenFastFailTrue_callsGetImmediately() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(true).build();
+    Storage mockStorage = mock(Storage.class);
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(8192L);
+    when(mockBlob.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption.class))).thenReturn(mockBlob);
+    BlobReadSession mockSession = mock(BlobReadSession.class);
+    when(mockStorage.blobReadSession(any(BlobId.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockSession));
+    GoogleCloudStorageBidiReadChannel channel =
+        new GoogleCloudStorageBidiReadChannel(
+            mockStorage, RESOURCE_ID, null, readOptions, Executors.newSingleThreadExecutor());
+
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
+
+    long size = channel.size();
+
+    assertThat(size).isEqualTo(8192L);
+    verify(mockStorage, times(1)).get(any(BlobId.class), any(Storage.BlobGetOption.class));
   }
 
   @Test
@@ -192,6 +538,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel bidiReadChannel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().build(),
             Executors.newSingleThreadExecutor());
@@ -212,6 +559,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel bidiReadChannel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().build(),
             Executors.newSingleThreadExecutor());
@@ -236,6 +584,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel bidiReadChannel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder()
                 .setGrpcReadTimeout(java.time.Duration.ofNanos(1))
@@ -357,11 +706,22 @@ public class GoogleCloudStorageBidiReadChannelTest {
   }
 
   @Test
-  public void initMetadata_unsupportedOperationException() throws IOException {
-    GoogleCloudStorageBidiReadChannel bidiReadChannel = getMockedBidiReadChannel();
+  public void initMetadata_whenGzipNotSupported_throwsUnsupportedOperationException()
+      throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder()
+            .setFastFailOnNotFoundEnabled(false)
+            .setGzipEncodingSupportEnabled(false)
+            .build();
 
-    assertThrows(
-        UnsupportedOperationException.class, () -> bidiReadChannel.initMetadata("gzip", 10));
+    GoogleCloudStorageBidiReadChannel bidiReadChannel = getMockedBidiReadChannel(null, readOptions);
+
+    UnsupportedOperationException thrown =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> bidiReadChannel.initMetadata("gzip", 10L, 1L));
+
+    assertThat(thrown).hasMessageThat().contains("Gzip Encoded Files are not supported");
   }
 
   @Test
@@ -383,6 +743,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel bidiReadChannel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().build(),
             Executors.newSingleThreadExecutor());
@@ -421,7 +782,11 @@ public class GoogleCloudStorageBidiReadChannelTest {
 
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
-            storage, DEFAULT_ITEM_INFO, readOptions, Executors.newSingleThreadExecutor());
+            storage,
+            RESOURCE_ID,
+            DEFAULT_ITEM_INFO,
+            readOptions,
+            Executors.newSingleThreadExecutor());
 
     // Verify footer is not initially cached
     assertNull("Footer should be null initially", getPrivateField(channel, "footerContent"));
@@ -461,6 +826,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(10).build(),
             Executors.newSingleThreadExecutor());
@@ -482,6 +848,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(10).build(),
             Executors.newSingleThreadExecutor());
@@ -501,6 +868,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(10).build(),
             Executors.newSingleThreadExecutor());
@@ -810,6 +1178,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     GoogleCloudStorageBidiReadChannel channel =
         new GoogleCloudStorageBidiReadChannel(
             storage,
+            RESOURCE_ID,
             DEFAULT_ITEM_INFO,
             GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(10).build(),
             Executors.newSingleThreadExecutor());
@@ -835,7 +1204,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     when(storage.blobReadSession(any(), ArgumentMatchers.any(BlobSourceOption.class)))
         .thenReturn(ApiFutures.immediateFuture(new FakeBlobReadSession()));
     return new GoogleCloudStorageBidiReadChannel(
-        storage, itemInfo, readOptions, Executors.newSingleThreadExecutor());
+        storage, RESOURCE_ID, itemInfo, readOptions, Executors.newSingleThreadExecutor());
   }
 
   private GoogleCloudStorageBidiReadChannel getMockedBidiReadChannel(
@@ -872,7 +1241,7 @@ public class GoogleCloudStorageBidiReadChannelTest {
     when(storage.blobReadSession(any()))
         .thenReturn(ApiFutures.immediateFuture(new FakeBlobReadSession()));
     return new GoogleCloudStorageBidiReadChannel(
-        storage, DEFAULT_ITEM_INFO, readOptions, Executors.newSingleThreadExecutor());
+        storage, RESOURCE_ID, DEFAULT_ITEM_INFO, readOptions, Executors.newSingleThreadExecutor());
   }
 
   private Object getPrivateField(Object obj, String fieldName) throws Exception {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -33,7 +33,9 @@ import com.google.cloud.hadoop.gcsio.FakeReadChannel.REQUEST_TYPE;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
 import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.common.collect.ImmutableList;
@@ -645,7 +647,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     verify(mockedStorage, times(0)).get(any(com.google.cloud.storage.BlobId.class));
 
     // Mock storage.get for the fallback/lazy fetch
-    com.google.cloud.storage.Blob mockBlob = mock(com.google.cloud.storage.Blob.class);
+    Blob mockBlob = mock(Blob.class);
     when(mockBlob.getSize()).thenReturn((long) OBJECT_SIZE);
     when(mockBlob.getContentEncoding()).thenReturn("text/plain");
     when(mockedStorage.get(any(com.google.cloud.storage.BlobId.class), any())).thenReturn(mockBlob);
@@ -770,6 +772,170 @@ public class GoogleCloudStorageClientReadChannelTest {
     buffer.clear();
     bytesRead = readChannel.read(buffer);
     assertThat(bytesRead).isEqualTo(10);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_emptyObject_returnsEofCleanly() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder()
+            .setFastFailOnNotFoundEnabled(false)
+            .setGzipEncodingSupportEnabled(true)
+            .build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(0L);
+    when(mockBlob.getContentEncoding()).thenReturn(null);
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(ByteString.EMPTY, mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(0);
+    assertThat(readChannel.size()).isEqualTo(0L);
+  }
+
+  @Test
+  public void testRead_whenLazyInitFails_closesOrphanedChannel() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ReadChannel mockReadChannel = mock(ReadChannel.class);
+    when(mockStorage.reader(any(), any())).thenReturn(mockReadChannel);
+    when(mockReadChannel.isOpen()).thenReturn(true);
+    when(mockReadChannel.read(any(ByteBuffer.class)))
+        .thenThrow(new IOException("Simulated Connection Error"));
+    GoogleCloudStorageClientReadChannel channel =
+        new GoogleCloudStorageClientReadChannel(
+            mockStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> channel.read(ByteBuffer.allocate(10)));
+
+    assertThat(thrown).hasMessageThat().contains("Error reading");
+    assertThat(thrown).hasCauseThat().hasMessageThat().contains("Simulated Connection Error");
+    verify(mockReadChannel, times(1)).close();
+  }
+
+  @Test
+  public void testLazyMetadataFetch_normalForwardRead_fetchesMetadataMidFlight() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+    BlobInfo mockBlobInfo = mock(BlobInfo.class);
+    when(mockBlobInfo.getSize()).thenReturn((long) OBJECT_SIZE);
+    when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlobInfo.getGeneration()).thenReturn(1L);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(CONTENT, mockBlobInfo);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Read from the beginning (offset 0)
+    int readBytes = 100;
+    ByteBuffer buffer = ByteBuffer.allocate(readBytes);
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(readBytes);
+    assertThat(readChannel.size()).isEqualTo(OBJECT_SIZE);
+
+    buffer.flip();
+    byte[] expectedContent = CONTENT.substring(0, readBytes).toByteArray();
+    assertThat(buffer.array()).isEqualTo(expectedContent);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_gzipEncoded_recoversFromBadGuess() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder()
+            .setFastFailOnNotFoundEnabled(false)
+            .setGzipEncodingSupportEnabled(true)
+            .build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn((long) OBJECT_SIZE);
+    when(mockBlob.getContentEncoding()).thenReturn("gzip");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(CONTENT, mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Seek to a random offset (simulating a bad guess before GZIP is discovered)
+    readChannel.position(100);
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(10);
+    assertThat(readChannel.size()).isEqualTo(-1L);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_seekPastEof_throwsEofException() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(10L);
+    when(mockBlob.getContentEncoding()).thenReturn(null);
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel =
+        new MockStorageReadChannel(ByteString.copyFromUtf8("0123456789"), mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Seek to position 15 (which is > objectSize 10)
+    // Because fast fail is disabled, the connector doesn't know this is out of bounds yet.
+    readChannel.position(15);
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+
+    // Once read() is called, the lazy fetch retrieves the actual size (10L).
+    // validateEndOfFile will realize position (15) > objectSize (10) and throw an EOFException.
+    IOException thrown = assertThrows(IOException.class, () -> readChannel.read(buffer));
+
+    assertThat(thrown).hasCauseThat().isInstanceOf(EOFException.class);
+
+    assertThat(thrown)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Invalid seek offset: position value (15) must be between 0 and 10");
+
+    assertThat(readChannel.size()).isEqualTo(10L);
   }
 
   // A fake ReadChannel that mimics StorageReadChannel by having a getObject method

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -953,6 +953,58 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
   }
 
+  @Test
+  public void readBeyondChannelLength() throws IOException {
+    // Queue READ_CHUNK for the first read, then MORE_THAN_CHANNEL_LENGTH for the second read
+    // so it overshoots the channel limit.
+    fakeReadChannel =
+        spy(
+            new FakeReadChannel(
+                CONTENT,
+                ImmutableList.of(REQUEST_TYPE.READ_CHUNK, REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+
+    // Enforce a chunk size so that contentChannelEnd is smaller than the full object size
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setMinRangeRequestSize(10).build();
+
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
+
+    readChannel.position(0);
+
+    // 1. First read of 5 bytes. This will open the channel with limit = max(5, 10) = 10.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+
+    // 2. Second read of 10 bytes. The channel limit is still 10.
+    // The FakeReadChannel will return 10 - 5 + 1 = 6 bytes, so currentPosition becomes 11.
+    // Since 11 > 10, it will hit the overshoot block in GoogleCloudStorageClientReadChannel.
+    ByteBuffer buffer2 = ByteBuffer.allocate(10);
+    int bytesRead2 = readChannel.read(buffer2);
+
+    assertThat(bytesRead2).isEqualTo(10);
+    assertThat(readChannel.position()).isEqualTo(15);
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_OBJECT_SIZE)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+    IOException e =
+        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
+
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {
     assertThat(buffer.position()).isEqualTo(length);
     assertByteArrayEquals(
@@ -968,10 +1020,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
     return new GoogleCloudStorageClientReadChannel(
         mockedStorage,
-        new StorageResourceId(
-            objectInfo.getBucketName(),
-            objectInfo.getObjectName(),
-            objectInfo.getContentGeneration()),
+        objectInfo.getResourceId(),
         objectInfo,
         readOptions,
         GrpcErrorTypeExtractor.INSTANCE,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -48,6 +48,7 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -933,6 +934,99 @@ public class GoogleCloudStorageReadChannelTest {
         .isEqualTo(
             "Unexpected end of stream trying to skip 10 bytes to seek to position 10,"
                 + " size: 9223372036854775807 for 'gs://foo-bucket/bar-object'");
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    long objectSize = 10L;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // Ensure content-length accommodates the over-read
+            inputStreamResponse(
+                CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder().setFadvise(Fadvise.SEQUENTIAL).build());
+
+    readChannel.setMaxRetries(0);
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> {
+              ByteBuffer buffer = ByteBuffer.allocate(testData.length + 1);
+              while (buffer.hasRemaining()) {
+                if (readChannel.read(buffer) < 0) {
+                  break;
+                }
+              }
+            });
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
+  @Test
+  public void readBeyondChannelLength() throws Exception {
+    long objectSize = 200L;
+    // First response overshoots the 10 byte limit by 2 bytes
+    byte[] overshootData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+    // Second response provides the rest of the object size
+    byte[] restData = {0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // 1. Mock first read returning 12 bytes
+            dataRangeResponse(overshootData, 0, objectSize),
+            // 2. Mock the second read for the remaining bytes
+            dataRangeResponse(restData, 12, objectSize));
+
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder()
+                    .setFadvise(Fadvise.RANDOM)
+                    .setMinRangeRequestSize(10) // Force requested range to be 10
+                    .build());
+
+    readChannel.setMaxRetries(1);
+
+    // First read of 5 bytes
+    ByteBuffer buffer = ByteBuffer.allocate(30);
+    buffer.limit(5);
+    int bytesRead = readChannel.read(buffer);
+    assertThat(bytesRead).isEqualTo(5);
+
+    // Second read to trigger overshoot and then EOF
+    buffer.limit(20);
+    bytesRead = readChannel.read(buffer);
+
+    // total read should be 7 (remaining in overshootData) + 8 (from second mock to fill buffer
+    // limit 20) = 15
+    assertThat(bytesRead).isEqualTo(15);
+    assertThat(readChannel.position()).isEqualTo(20);
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -36,6 +36,8 @@ import com.google.gson.Gson;
 import com.google.storage.v2.BucketName;
 import io.grpc.Status;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -207,6 +209,63 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
 
     Map<String, Object> writeObjectCloseStatusRecord = assertingHandler.getLogRecordAtIndex(3);
     verifyCloseStatus(writeObjectCloseStatusRecord, "ReadObject", Status.OK);
+  }
+
+  @Test
+  public void testGrpcReadLogs_fastFailDisabled_perfectFooterCache() throws Exception {
+    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());
+    int partitionsCount = 1;
+    // Write a 2MB file to simulate a Parquet block
+    byte[] partition =
+        writeObject(helperGcs, resourceId, /* partitionSize= */ 2 * 1024 * 1024, partitionsCount);
+    GoogleCloudStorageOptions storageOption =
+        GCS_TRACE_OPTIONS.toBuilder().setBidiEnabled(false).build();
+    GoogleCloudStorage gcsImpl = getGCSClientImpl(storageOption);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    assertingHandler.flush();
+
+    // Execute Parquet-style suffix read
+    try (SeekableByteChannel channel = gcsImpl.open(resourceId, readOptions)) {
+      // Read last 8 bytes (triggers the 1MB backward guess + 0-byte metadata fetch)
+      channel.position(partition.length - 8);
+      ByteBuffer magicBuffer = ByteBuffer.allocate(8);
+      channel.read(magicBuffer);
+      // Seek backward by 64KB and read (should be satisfied entirely from RAM)
+      channel.position(partition.length - 65536);
+      ByteBuffer footerBuffer = ByteBuffer.allocate(65536);
+      channel.read(footerBuffer);
+    }
+
+    // A single gRPC network stream generates exactly 3 logs (request, response, onClose)
+    // We expect exactly 1 stream to be opened, therefore we expect 3 logs!
+    assertingHandler.assertLogCount(3);
+    List<Map<String, Object>> allLogs = assertingHandler.getAllLogRecords();
+    long getObjectCount =
+        allLogs.stream()
+            .filter(
+                log ->
+                    "GetObject"
+                        .equals(
+                            String.valueOf(
+                                log.get(GoogleCloudStorageTracingFields.RPC_METHOD.name))))
+            .count();
+    long readObjectCount =
+        allLogs.stream()
+            .filter(
+                log -> {
+                  String method =
+                      String.valueOf(log.get(GoogleCloudStorageTracingFields.RPC_METHOD.name));
+                  String streamOp = String.valueOf(log.get("streamOperation"));
+                  // ONLY count when the stream is initially opened ("request"),
+                  // and ignore "response" and "onClose".
+                  return method != null
+                      && method.contains("ReadObject")
+                      && "request".equals(streamOp);
+                })
+            .count();
+    assertThat(getObjectCount).isEqualTo(0);
+    assertThat(readObjectCount).isEqualTo(1);
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -149,6 +150,32 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
 
     Map<String, Object> writeObjectCloseStatusRecord = assertingHandler.getLogRecordAtIndex(6);
     verifyCloseStatus(writeObjectCloseStatusRecord, "WriteObject", Status.OK);
+  }
+
+  @Test
+  public void testBidiReadLogs_fastFailDisabled_noGetObject() throws Exception {
+    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());
+    int partitionsCount = 1;
+    byte[] partition =
+        writeObject(helperGcs, resourceId, /* partitionSize= */ 2 * 1024 * 1024, partitionsCount);
+    assertingHandler.flush();
+    GoogleCloudStorageOptions storageOption =
+        GCS_TRACE_OPTIONS.toBuilder().setBidiEnabled(true).build();
+    GoogleCloudStorage gcsImpl = getGCSClientImpl(storageOption);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    assertObjectContent(gcsImpl, resourceId, readOptions, partition, partitionsCount);
+
+    // Verify number of calls
+    assertingHandler.assertLogCount(1);
+
+    // Verify that no GetObject call was made
+    List<String> rpcMethods =
+        assertingHandler.getAllLogRecords().stream()
+            .map(log -> String.valueOf(log.get(GoogleCloudStorageTracingFields.RPC_METHOD.name)))
+            .collect(Collectors.toList());
+    assertThat(rpcMethods).doesNotContain("GetObject");
+    assertThat(rpcMethods.stream().anyMatch(method -> method.contains("ReadObject"))).isTrue();
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -57,6 +57,7 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -165,6 +166,64 @@ public class GoogleCloudStorageImplTest {
       assertThat(trackingGcs.getAllRequestStrings())
           .containsExactly(getObjectRequestString(resourceId, filelds, testStorageClientImpl));
     }
+    trackingGcs.delegate.close();
+  }
+
+  /**
+   * Verifies that Bidi channels with fast-fail disabled load metadata lazily from the session,
+   * avoiding an explicit 'GetObject' network call.
+   */
+  @Test
+  public void open_bidi_lazyInit_whenFastFailOnNotFound_isFalse() throws IOException {
+    if (!testStorageClientImpl) {
+      return;
+    }
+
+    int expectedSize = 5 * 1024 * 1024;
+    StorageResourceId resourceId = new StorageResourceId(testBucket, name.getMethodName());
+    writeObject(helperGcs, resourceId, /* partitionSize= */ expectedSize, /* partitionsCount= */ 1);
+    GoogleCloudStorageOptions bidiOptions = GCS_OPTIONS.toBuilder().setBidiEnabled(true).build();
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(bidiOptions);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+
+    try (SeekableByteChannel readChannel = trackingGcs.delegate.open(resourceId, readOptions)) {
+      // Calling size() triggers ensureMetadataInitialized().
+      // In Bidi, it resolves the session future and gets the BlobInfo locally for free!
+      assertThat(readChannel.size()).isEqualTo(expectedSize);
+    }
+    assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
+        .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
+    assertThat(trackingGcs.getAllRequestStrings()).doesNotContain("rpcMethod:GetObject");
+
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void open_bidi_lazyInit_whenFileNotFound_throwsExceptionWithoutFallback()
+      throws Exception {
+    if (!testStorageClientImpl) {
+      return;
+    }
+    StorageResourceId resourceId = new StorageResourceId(testBucket, "non-existent-file-123.txt");
+    GoogleCloudStorageOptions bidiOptions = GCS_OPTIONS.toBuilder().setBidiEnabled(true).build();
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(bidiOptions);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    try (SeekableByteChannel readChannel = trackingGcs.delegate.open(resourceId, readOptions)) {
+      // Trigger lazy initialization.
+      // The sessionFuture.get() will throw an ExecutionException(StorageException: 404).
+      // catch block intercepts and throws a FileNotFoundException.
+      FileNotFoundException thrown =
+          assertThrows(FileNotFoundException.class, () -> readChannel.size());
+      assertThat(thrown).hasMessageThat().contains("Item not found");
+    }
+    // Verify that the fallback fetchMetadata() was bypassed.
+    // If the code fell through to the fallback, we would see a "GetObject" RPC in the logs.
+    assertThat(trackingGcs.getAllRequestStrings()).doesNotContain("rpcMethod:GetObject");
+
     trackingGcs.delegate.close();
   }
 


### PR DESCRIPTION
Original PR
* [Bidi Fast fail](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1682)
* [grpc Fast Fail](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1685)
* [Log and drop additional bytes](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1694)
* [HNS doc update](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1686) 