### PR TITLE
fix : Fix edge case for GCS Overshoot bytes bug in Connector

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -388,6 +388,32 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                   + " after successful read",
               contentChannelCurrentPosition,
               currentPosition);
+
+          // Fail fast if the server sent data past the total object size
+          if (objectSize != -1 && currentPosition > objectSize) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received data beyond the object size; at offset: %d "
+                        + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, objectSize));
+          }
+
+          // Handle the overshoot immediately in the successful read case
+          if (contentChannelEnd >= 0
+              && contentChannelEnd != objectSize
+              && currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received data after the channel end; at offset: %d "
+                    + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, objectSize);
+
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            dst.position(dst.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            contentChannelCurrentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+          }
         } catch (Exception e) {
           GoogleCloudStorageEventBus.postOnException();
           int partialBytes = partiallyReadBytes(remainingBeforeRead, dst);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -347,28 +347,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                           + "at offset: %d where as stream was supposed to end at: %d for resource: "
                           + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
-
-            } else if (currentPosition > objectSize) {
-              GoogleCloudStorageEventBus.postOnException();
-              throw new IOException(
-                  String.format(
-                      "Received end of stream result beyond the object size; at offset: %d "
-                          + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
-                      currentPosition, contentChannelEnd, resourceId, objectSize));
-            } else if (currentPosition > contentChannelEnd) {
-              logger.atWarning().log(
-                  "Received end of stream result after the channel end; at offset: %d "
-                      + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
-                  currentPosition, contentChannelEnd, resourceId, objectSize);
-              // Dropping additional bytes.
-              int overshoot = (int) (currentPosition - contentChannelEnd);
-              dst.position(dst.position() - overshoot);
-              currentPosition = contentChannelEnd;
-              totalBytesRead -= overshoot;
-              contentChannelCurrentPosition -= overshoot;
-
-              closeContentChannel();
-              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -413,6 +391,9 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
             currentPosition = contentChannelEnd;
             contentChannelCurrentPosition = contentChannelEnd;
             totalBytesRead -= overshoot;
+
+            // Close the channel so the next iteration opens a cleanly aligned stream
+            closeContentChannel();
           }
         } catch (Exception e) {
           GoogleCloudStorageEventBus.postOnException();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -376,6 +376,32 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                   + " after successful read",
               contentChannelPosition,
               currentPosition);
+
+          // Fail fast if the server sent data past the total object size
+          if (size != -1 && currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received data beyond the object size; at offset: %d "
+                        + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          }
+
+          // Handle the overshoot immediately in the successful read case
+          if (contentChannelEnd >= 0
+              && contentChannelEnd != size
+              && currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received data after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            contentChannelPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+          }
         }
 
         if (retriesAttempted != 0) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -321,39 +321,16 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             contentChannelEnd = currentPosition;
           }
           // Check that we didn't get a premature End of Stream signal by checking the
-          // number of
-          // bytes read against the stream size. Unfortunately we don't have information
-          // about the
-          // actual size of the data stream when stream compression is used, so we can
-          // only ignore
-          // this case here.
-          if (currentPosition > contentChannelEnd && currentPosition < size) {
-            logger.atWarning().log(
-                "Received end of stream result after the channel end; at offset: %d "
-                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
-                currentPosition, contentChannelEnd, resourceId, size);
-
-            // Dropping additional bytes.
-            int overshoot = (int) (currentPosition - contentChannelEnd);
-            buffer.position(buffer.position() - overshoot);
-            currentPosition = contentChannelEnd;
-            totalBytesRead -= overshoot;
-            contentChannelPosition -= overshoot;
-          } else if (currentPosition < contentChannelEnd && currentPosition < size) {
+          // number of bytes read against the stream size. Unfortunately we don't have information
+          // about the actual size of the data stream when stream compression is used, so we can
+          // only ignore this case here.
+          if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
                     "Received end of stream result before all requestedBytes were received; "
-                        + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                        + "at offset: %d whereas stream was suppose to end at: %d for resource: "
                         + "%s of size: %d",
-                    currentPosition, contentChannelEnd, resourceId, size));
-
-          } else if (currentPosition > size) {
-            GoogleCloudStorageEventBus.postOnException();
-            throw new IOException(
-                String.format(
-                    "Received end of stream result beyond the object size; at offset: %d "
-                        + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                     currentPosition, contentChannelEnd, resourceId, size));
           }
 
@@ -401,6 +378,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             currentPosition = contentChannelEnd;
             contentChannelPosition = contentChannelEnd;
             totalBytesRead -= overshoot;
+
+            // Close the channel so the next iteration opens a cleanly aligned stream
+            closeContentChannel();
           }
         }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -325,6 +325,48 @@ public class GoogleCloudStorageClientReadChannelTest {
   }
 
   @Test
+  public void read_withOvershoot_handlesBoundaryWithoutCrashing() throws IOException {
+    // Queue READ_CHUNK for the first read, then MORE_THAN_CHANNEL_LENGTH for the second read
+    // to force the underlying channel to overshoot the limit by exactly 1 byte.
+    fakeReadChannel =
+        spy(
+            new FakeReadChannel(
+                CONTENT,
+                ImmutableList.of(REQUEST_TYPE.READ_CHUNK, REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    // Enforce a minimum chunk size of 10 bytes
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setMinRangeRequestSize(10).build();
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
+    readChannel.position(0);
+
+    // First read (Requesting 5 bytes)
+    // The channel is opened with a boundary of 10.
+    // It successfully reads 5 bytes, leaving 5 valid bytes before the boundary.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+
+    // Second read (Requesting 6 bytes)
+    // The FakeReadChannel will return 6 bytes (overshooting the 10-byte limit by 1 byte).
+    // With the immediate correction fix, it detects the 1-byte overshoot right away,
+    // rewinds the buffer, closes the channel, and automatically opens the next stream
+    // to fetch the remaining 1 byte.
+    ByteBuffer buffer2 = ByteBuffer.allocate(6);
+    int bytesRead2 = readChannel.read(buffer2);
+    assertThat(bytesRead2).isEqualTo(6);
+
+    // Third read
+    // We pass a fresh buffer
+    // Previously, the EOF block would trigger the retroactive overshoot logic
+    // and crash with an IllegalArgumentException.
+    // Now, it cleanly reads the next 5 bytes from the properly opened second stream!
+    ByteBuffer buffer3 = ByteBuffer.allocate(5);
+    int bytesRead3 = readChannel.read(buffer3);
+    assertThat(bytesRead3).isEqualTo(5);
+  }
+
+  @Test
   public void fadviseAutoRandom_onSequentialRead_switchToSequential() throws IOException {
     long blockSize = CHUNK_SIZE;
     GoogleCloudStorageReadOptions readOptions =
@@ -999,10 +1041,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     IOException e =
         assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
 
-    assertThat(e)
-        .hasCauseThat()
-        .hasMessageThat()
-        .contains("Received end of stream result beyond the object size;");
+    assertThat(e).hasCauseThat().hasMessageThat().contains("Received data beyond the object size;");
   }
 
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -163,7 +163,7 @@ public class GoogleCloudStorageReadChannelTest {
     MockHttpTransport transport =
         mockTransport(
             // 1st read request response
-            dataRangeResponse(testData2, seekPosition, testData2.length),
+            dataRangeResponse(testData2, seekPosition, testData.length),
             // 2nd read request response
             dataRangeResponse(testData, 0, testData.length));
 
@@ -1005,9 +1005,7 @@ public class GoogleCloudStorageReadChannelTest {
               }
             });
 
-    assertThat(e)
-        .hasMessageThat()
-        .contains("Received end of stream result beyond the object size;");
+    assertThat(e).hasMessageThat().contains("Received data beyond the object size");
   }
 
   @Test
@@ -1058,6 +1056,64 @@ public class GoogleCloudStorageReadChannelTest {
     // limit 20) = 15
     assertThat(bytesRead).isEqualTo(15);
     assertThat(readChannel.position()).isEqualTo(20);
+  }
+
+  @Test
+  public void read_withOvershoot_handlesBoundaryWithoutCrashing() throws Exception {
+    long objectSize = 20L;
+    // Full expected data for the object
+    byte[] testData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+    // The server overshoots the 10-byte limit by sending 12 bytes instead
+    byte[] overshootData = Arrays.copyOfRange(testData, 0, 12);
+    // The subsequent request should start from the correct boundary (offset 10)
+    byte[] restData = Arrays.copyOfRange(testData, 10, 20);
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // Mock the stream returning the 12 overshot bytes
+            dataRangeResponse(overshootData, 0, objectSize),
+            // Mock the second stream fetching the rest of the data from the correct boundary
+            dataRangeResponse(restData, 10, objectSize));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder()
+                    .setFadvise(Fadvise.RANDOM)
+                    .setMinRangeRequestSize(10) // Force requested range to end at 10
+                    .build());
+    readChannel.setMaxRetries(1);
+
+    // First read (Requesting 5 bytes)
+    // The stream is opened with boundary 10. The mock returns 12 bytes.
+    // The channel reads 5 bytes and leaves 7 in the open stream.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+    assertThat(buffer1.array()).isEqualTo(Arrays.copyOfRange(testData, 0, 5));
+
+    // Second read (Requesting 7 bytes)
+    // The channel reads the remaining 7 bytes from the first stream.
+    // The immediate correction logic intercepts the 2-byte overshoot, rewinds the buffer,
+    // closes the channel, and opens the second stream to fetch the remaining 2 bytes.
+    ByteBuffer buffer2 = ByteBuffer.allocate(7);
+    int bytesRead2 = readChannel.read(buffer2);
+    assertThat(bytesRead2).isEqualTo(7);
+    assertThat(buffer2.array()).isEqualTo(Arrays.copyOfRange(testData, 5, 12));
+
+    // Third read (Requesting 5 bytes)
+    // Previously, this caused an IllegalArgumentException crash.
+    // Now, it simply reads the next 5 bytes from the properly opened second stream!
+    ByteBuffer buffer3 = ByteBuffer.allocate(5);
+    int bytesRead3 = readChannel.read(buffer3);
+    assertThat(bytesRead3).isEqualTo(5);
+    assertThat(buffer3.array()).isEqualTo(Arrays.copyOfRange(testData, 12, 17));
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {


### PR DESCRIPTION
Fix edge case for GCS Overshoot bytes bug in Connector
* [1-pager](https://docs.google.com/document/d/17dN6QxM4ciYsOV3AqhMDhcZF0Io2BpKZXEbqaOzWAyo/edit?resourcekey=0-dglHMlLjwGkS5UHEweRQaw&tab=t.0#heading=h.hqppjv18rwc7)