### PR TITLE
[Backport 4.0.x] Port VectorIO and Logging Enhancement Commits from master branch

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
@@ -129,6 +129,21 @@ public enum GhfsStatistic {
       "Discarded read bytes during readVectored operation",
       TYPE_COUNTER),
 
+  STREAM_READ_VECTORED_THREAD_WAIT_DURATION(
+      "stream_readVectored_thread_wait_duration",
+      "Tracks how long a read task waits in the thread pool queue before execution starts",
+      TYPE_DURATION),
+
+  STREAM_READ_CONNECTION_DURATION(
+      "stream_read_connection_duration",
+      "Captures the time taken to establish a connection and receive the initial response from GCS",
+      TYPE_DURATION),
+
+  STREAM_READ_DATA_TRANSFER_DURATION(
+      "stream_read_data_transfer_duration",
+      "Measures the duration of the actual data transfer after the connection is established",
+      TYPE_DURATION),
+
   STREAM_READ_VECTORED_READ_RANGE_DURATION(
       "stream_readVectored_range_duration", "Latency of individual FileRange", TYPE_DURATION),
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
@@ -81,6 +81,13 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
     }
   }
 
+  void increment(String s, long count) {
+    Metric m = Metric.getMetricByName(s);
+    if (m != null) {
+      m.increment(count);
+    }
+  }
+
   @Override
   public Iterator<LongStatistic> getLongStatistics() {
     return this.metrics.entrySet().stream()
@@ -114,12 +121,24 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
     STREAM_READ_VECTORED_COUNT("readVectoredCount"),
     STREAM_READ_VECTORED_RANGE_COUNT("readVectoredRangeCount");
 
+    private static final Map<String, Metric> BY_LABEL = new HashMap<>();
+
+    static {
+      for (Metric e : values()) {
+        BY_LABEL.put(e.metricName, e);
+      }
+    }
+
     private final String metricName;
     private final ThreadLocalValue metricValue;
 
     Metric(String metricName) {
       this.metricName = metricName;
       this.metricValue = new ThreadLocalValue();
+    }
+
+    public static Metric getMetricByName(String label) {
+      return BY_LABEL.get(label);
     }
 
     void reset() {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageEventSubscriber.java
@@ -25,6 +25,7 @@ import com.google.cloud.hadoop.util.GCSChecksumFailureEvent;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent.EventType;
 import com.google.cloud.hadoop.util.GcsJsonApiEvent.RequestType;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
 import com.google.cloud.hadoop.util.GcsRequestExecutionEvent;
 import com.google.cloud.hadoop.util.IGcsJsonApiEvent;
 import com.google.common.annotations.VisibleForTesting;
@@ -62,6 +63,7 @@ public class GoogleCloudStorageEventSubscriber {
       logger.atFiner().log("Subscriber class invoked for first time");
       INSTANCE = new GoogleCloudStorageEventSubscriber(storageStatistics);
     }
+    GoogleCloudStorageEventSubscriber.storageStatistics = storageStatistics;
     return INSTANCE;
   }
 
@@ -96,6 +98,10 @@ public class GoogleCloudStorageEventSubscriber {
       storageStatistics.incrementCounter(GoogleCloudStorageStatistics.GCS_API_TIME, duration);
 
       RequestType requestType = (RequestType) event.getProperty(GcsJsonApiEvent.REQUEST_TYPE);
+      if (requestType == RequestType.GET_MEDIA) {
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_CONNECTION_DURATION, duration, eventContext);
+      }
       if (requestToGcsStatMap.containsKey(requestType)) {
         updateMetric(requestToGcsStatMap.get(requestType), duration, eventContext);
       } else if (requestToGhfsStatMap.containsKey(requestType)) {
@@ -112,6 +118,28 @@ public class GoogleCloudStorageEventSubscriber {
           GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, backOffTime);
     } else if (eventType == EventType.EXCEPTION) {
       storageStatistics.incrementGcsExceptionCount();
+    }
+  }
+
+  @Subscribe
+  private void subscriberOnGcsReadMetricEvent(@Nonnull GcsReadMetricEvent event) {
+    switch (event.getType()) {
+      case CONNECTION:
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_CONNECTION_DURATION,
+            event.getDurationMs(),
+            event.getStreamPath());
+        break;
+      case DATA_TRANSFER:
+        storageStatistics.updateStats(
+            GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION,
+            event.getDurationMs(),
+            event.getStreamPath());
+        if (event.isLatencyThresholdBreached()) {
+          storageStatistics.incrementCounter(
+              GoogleCloudStorageStatistics.GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT, 1);
+        }
+        break;
     }
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -39,6 +39,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -86,6 +87,7 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
   private final GhfsStreamStats streamStats;
   private final GhfsStreamStats seekStreamStats;
   private final GhfsStreamStats vectoredReadStats;
+  private final ConcurrentHashMap<String, Long> rangeReadThreadStats;
 
   // Statistic tracker of the Input stream
   private final GhfsInputStreamStatistics streamStatistics;
@@ -158,6 +160,7 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
     this.vectoredReadStats =
         new GhfsStreamStats(
             storageStatistics, GhfsStatistic.STREAM_READ_VECTORED_OPERATIONS, gcsPath);
+    this.rangeReadThreadStats = new ConcurrentHashMap<>();
 
     this.traceFactory = ghfs.getTraceFactory();
     this.vectoredIOSupplier = ghfs.getVectoredIOSupplier();
@@ -200,7 +203,14 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             long startTimeNs = System.nanoTime();
             vectoredIOSupplier
                 .get()
-                .readVectored(ranges, allocate, gcsFs, fileInfo, gcsPath, streamStatistics);
+                .readVectored(
+                    ranges,
+                    allocate,
+                    gcsFs,
+                    fileInfo,
+                    gcsPath,
+                    streamStatistics,
+                    rangeReadThreadStats);
             statistics.incrementReadOps(1);
             vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
           }
@@ -316,6 +326,8 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
               }
             } finally {
               statistics.incrementBytesRead(streamStatistics.getBytesRead());
+              mergeRangeReadThreadStats();
+              rangeReadThreadStats.clear();
               streamStats.close();
               seekStreamStats.close();
               vectoredReadStats.close();
@@ -327,6 +339,17 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
     if (!isClosed) {
       streamStatistics.close();
     }
+  }
+
+  /**
+   * Merges the range read stats collected in readVectored call to threadLocal stats of main thread.
+   */
+  private void mergeRangeReadThreadStats() {
+    GhfsThreadLocalStatistics tlStats = storageStatistics.getThreadLocalStatistics();
+    rangeReadThreadStats.forEach(
+        (key, value) -> {
+          tlStats.increment(key, value);
+        });
   }
 
   /**

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -31,6 +31,7 @@ import com.google.cloud.hadoop.gcsio.ReadVectoredSeekableByteChannel;
 import com.google.cloud.hadoop.gcsio.VectoredIORange;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
 import java.net.URI;
@@ -176,46 +177,53 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
   @Override
   public void readVectored(List<? extends FileRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
-    trackDuration(
-        streamStatistics,
-        STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
-        () -> {
-          if (channel instanceof ReadVectoredSeekableByteChannel) {
-            ReadVectoredSeekableByteChannel readVectoredSeekableByteChannelChannel =
-                (ReadVectoredSeekableByteChannel) channel;
-            ranges.forEach(
-                range -> {
-                  CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
-                  range.setData(result);
-                });
-            readVectoredSeekableByteChannelChannel.readVectored(
-                ranges.stream()
-                    .map(
-                        range ->
-                            VectoredIORange.builder()
-                                .setLength(range.getLength())
-                                .setOffset(range.getOffset())
-                                .setData(range.getData())
-                                .build())
-                    .collect(Collectors.toList()),
-                allocate);
-          } else {
-            long startTimeNs = System.nanoTime();
-            vectoredIOSupplier
-                .get()
-                .readVectored(
-                    ranges,
-                    allocate,
-                    gcsFs,
-                    fileInfo,
-                    gcsPath,
-                    streamStatistics,
-                    rangeReadThreadStats);
-            statistics.incrementReadOps(1);
-            vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
-          }
-          return null;
-        });
+    try {
+      trackDuration(
+          streamStatistics,
+          STREAM_READ_VECTORED_OPERATIONS.getSymbol(),
+          () -> {
+            if (channel instanceof ReadVectoredSeekableByteChannel) {
+              ReadVectoredSeekableByteChannel readVectoredSeekableByteChannelChannel =
+                  (ReadVectoredSeekableByteChannel) channel;
+              ranges.forEach(
+                  range -> {
+                    CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
+                    range.setData(result);
+                  });
+              readVectoredSeekableByteChannelChannel.readVectored(
+                  ranges.stream()
+                      .map(
+                          range ->
+                              VectoredIORange.builder()
+                                  .setLength(range.getLength())
+                                  .setOffset(range.getOffset())
+                                  .setData(range.getData())
+                                  .build())
+                      .collect(Collectors.toList()),
+                  allocate);
+            } else {
+              long startTimeNs = System.nanoTime();
+              vectoredIOSupplier
+                  .get()
+                  .readVectored(
+                      ranges,
+                      allocate,
+                      gcsFs,
+                      fileInfo,
+                      gcsPath,
+                      streamStatistics,
+                      rangeReadThreadStats);
+              statistics.incrementReadOps(1);
+              vectoredReadStats.updateVectoredReadStreamStats(startTimeNs);
+            }
+            return null;
+          });
+    } catch (IOException e) {
+      if (IoExceptionHelper.isInterrupted(e)) {
+        Thread.currentThread().interrupt();
+      }
+      throw e;
+    }
   }
 
   @Override
@@ -260,6 +268,9 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
             storageStatistics.streamReadOperationInComplete(length, Math.max(numRead, 0));
             response = numRead;
           } catch (IOException e) {
+            if (IoExceptionHelper.isInterrupted(e)) {
+              Thread.currentThread().interrupt();
+            }
             streamStatistics.readException();
             throw e;
           }
@@ -290,6 +301,11 @@ class GoogleHadoopFSInputStream extends FSInputStream implements IOStatisticsSou
           }
           try {
             channel.position(pos);
+          } catch (IOException e) {
+            if (IoExceptionHelper.isInterrupted(e)) {
+              Thread.currentThread().interrupt();
+            }
+            throw e;
           } catch (IllegalArgumentException e) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(e);

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -640,10 +640,22 @@ public class GoogleHadoopFileSystemConfiguration {
   }
 
   static VectoredReadOptions.Builder getVectoredReadOptionBuilder(Configuration config) {
+    int readThreads = GCS_VECTORED_READ_THREADS.get(config, config::getInt);
+    if (config.get(GCS_VECTORED_READ_THREADS.getKey()) == null) {
+      int availableCores = Runtime.getRuntime().availableProcessors();
+
+      // Multiplier of 2x for a safe balance of high throughput and stability
+      int calculatedThreads = availableCores * 2;
+
+      // Floor of 16: Hides network latency on small containers
+      // Ceiling of 128: Prevents connection/memory thrashing on massive VMs.
+      readThreads = Math.max(16, Math.min(128, calculatedThreads));
+    }
+    logger.atInfo().log("Using %d threads for vectored reads", readThreads);
     return VectoredReadOptions.builder()
         .setMinSeekVectoredReadSize(GCS_VECTORED_READ_RANGE_MIN_SEEK.get(config, config::getInt))
         .setMergeRangeMaxSize(GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.get(config, config::getInt))
-        .setReadThreads(GCS_VECTORED_READ_THREADS.get(config, config::getInt));
+        .setReadThreads(readThreads);
   }
 
   @VisibleForTesting

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -380,6 +380,16 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.inputstream.min.range.request.size",
           GoogleCloudStorageReadOptions.DEFAULT.getMinRangeRequestSize());
 
+  /**
+   * Threshold for data transfer latency, if the transfer takes longer than this threshold, then a
+   * high latency warning will be logged.
+   */
+  public static final HadoopConfigurationProperty<Long>
+      GCS_INPUT_STREAM_LATENCY_LOGGING_THRESHOLD_MS =
+          new HadoopConfigurationProperty<>(
+              "fs.gs.inputstream.latency.logging.threshold.ms",
+              GoogleCloudStorageReadOptions.DEFAULT.getLatencyLoggingThreshold());
+
   /** Minimum distance that will be seeked without merging the ranges together. */
   public static final HadoopConfigurationProperty<Integer> GCS_VECTORED_READ_RANGE_MIN_SEEK =
       new HadoopConfigurationProperty<>(
@@ -749,6 +759,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setFadviseRequestTrackCount(GCS_FADVISE_REQUEST_TRACK_COUNT.get(config, config::getInt))
         .setBidiThreadCount(GCS_BIDI_THREAD_COUNT.get(config, config::getInt))
         .setBidiClientTimeout(GCS_BIDI_CLIENT_INITIALIZATION_TIMEOUT.get(config, config::getInt))
+        .setLatencyLoggingThreshold(
+            GCS_INPUT_STREAM_LATENCY_LOGGING_THRESHOLD_MS.get(config, config::getLong))
         .build();
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.fs.VectoredReadUtils.validateRangeRequest;
 import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -37,9 +38,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -143,19 +146,21 @@ public class VectoredIOImpl implements Closeable {
         // case when ranges are not merged
         for (FileRange sortedRange : sortedRanges) {
           long startTimer = System.currentTimeMillis();
-          boundedThreadPool.submit(
-              () -> {
-                logger.atFiner().log("Submitting range %s for execution.", sortedRange);
-                // Reset thread stats as a new task is being submitted to this thread.
-                // all required stats must be collected before task is finished.
-                resetThreadLocalStats();
-                readSingleRange(sortedRange, allocate, channelProvider);
-                long endTimer = System.currentTimeMillis();
-                storageStatistics.updateStats(
-                    GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                    endTimer - startTimer,
-                    channelProvider.gcsPath);
-              });
+          Future<?> executionFuture =
+              boundedThreadPool.submit(
+                  () -> {
+                    logger.atFiner().log("Submitting range %s for execution.", sortedRange);
+                    // Reset thread stats as a new task is being submitted to this thread.
+                    // all required stats must be collected before task is finished.
+                    resetThreadLocalStats();
+                    readSingleRange(sortedRange, allocate, channelProvider);
+                    long endTimer = System.currentTimeMillis();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
+                        endTimer - startTimer,
+                        channelProvider.gcsPath);
+                  });
+          addCancellationListener(sortedRange, executionFuture);
         }
       } else {
         List<CombinedFileRange> combinedFileRanges = getCombinedFileRange(sortedRanges);
@@ -165,23 +170,52 @@ public class VectoredIOImpl implements Closeable {
           CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
           combinedFileRange.setData(result);
           long startTimer = System.currentTimeMillis();
-          boundedThreadPool.submit(
-              () -> {
-                logger.atFiner().log(
-                    "Submitting combinedRange %s for execution.", combinedFileRange);
+          Future<?> executionFuture =
+              boundedThreadPool.submit(
+                  () -> {
+                    logger.atFiner().log(
+                        "Submitting combinedRange %s for execution.", combinedFileRange);
 
-                // Reset thread stats as a new task is being submitted to this thread.
-                // all required stats must be collected before task is finished.
-                resetThreadLocalStats();
-                readCombinedRange(combinedFileRange, allocate, channelProvider);
-                long endTimer = System.currentTimeMillis();
-                storageStatistics.updateStats(
-                    GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                    endTimer - startTimer,
-                    channelProvider.gcsPath);
-              });
+                    // Reset thread stats as a new task is being submitted to this thread.
+                    // all required stats must be collected before task is finished.
+                    resetThreadLocalStats();
+                    readCombinedRange(combinedFileRange, allocate, channelProvider);
+                    long endTimer = System.currentTimeMillis();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
+                        endTimer - startTimer,
+                        channelProvider.gcsPath);
+                  });
+          addCancellationListener(combinedFileRange, executionFuture);
         }
       }
+    }
+
+    /**
+     * Adds a listener to the range's data future that will interrupt the background execution
+     * thread if the future is cancelled. This prevents background "zombie" threads from continuing
+     * to read data after a timeout or explicit cancellation by the caller.
+     *
+     * @param range the file range being read.
+     * @param executionFuture the future representing the background thread execution.
+     */
+    private void addCancellationListener(FileRange range, Future<?> executionFuture) {
+      if (range instanceof CombinedFileRange) {
+        for (FileRange child : ((CombinedFileRange) range).getUnderlying()) {
+          addCancellationListener(child, executionFuture);
+        }
+      }
+      range
+          .getData()
+          .whenComplete(
+              (res, ex) -> {
+                if (ex instanceof CancellationException) {
+                  logger.atWarning().log(
+                      "Cancelling execution future for range %s due to CancellationException",
+                      range);
+                  executionFuture.cancel(true);
+                }
+              });
     }
 
     private void updateRangeSizeCounters(int incomingRangeSize, int combinedRangeSize) {
@@ -293,6 +327,9 @@ public class VectoredIOImpl implements Closeable {
         }
         combinedFileRange.getData().complete(readContent);
       } catch (Exception e) {
+        if (IoExceptionHelper.isInterrupted(e)) {
+          Thread.currentThread().interrupt();
+        }
         logger.atWarning().withCause(e).log(
             "Exception while reading combinedFileRange:%s for path: %s",
             combinedFileRange, channelProvider.gcsPath);
@@ -346,6 +383,9 @@ public class VectoredIOImpl implements Closeable {
             "Read single range completed from range: %s, path: %s", range, channelProvider.gcsPath);
         range.getData().complete(dst);
       } catch (Exception e) {
+        if (IoExceptionHelper.isInterrupted(e)) {
+          Thread.currentThread().interrupt();
+        }
         logger.atWarning().withCause(e).log(
             "Exception while reading range:%s for path: %s", range, channelProvider.gcsPath);
         captureAndResetThreadLocalStats();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -145,19 +145,25 @@ public class VectoredIOImpl implements Closeable {
         updateRangeSizeCounters(sortedRanges.size(), sortedRanges.size());
         // case when ranges are not merged
         for (FileRange sortedRange : sortedRanges) {
-          long startTimer = System.currentTimeMillis();
+          long submissionTime = System.currentTimeMillis();
           Future<?> executionFuture =
               boundedThreadPool.submit(
                   () -> {
+                    long startTime = System.currentTimeMillis();
+                    long queueWaitTime = startTime - submissionTime;
                     logger.atFiner().log("Submitting range %s for execution.", sortedRange);
                     // Reset thread stats as a new task is being submitted to this thread.
                     // all required stats must be collected before task is finished.
                     resetThreadLocalStats();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION,
+                        queueWaitTime,
+                        channelProvider.gcsPath);
                     readSingleRange(sortedRange, allocate, channelProvider);
                     long endTimer = System.currentTimeMillis();
                     storageStatistics.updateStats(
                         GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                        endTimer - startTimer,
+                        endTimer - submissionTime,
                         channelProvider.gcsPath);
                   });
           addCancellationListener(sortedRange, executionFuture);
@@ -169,21 +175,27 @@ public class VectoredIOImpl implements Closeable {
         for (CombinedFileRange combinedFileRange : combinedFileRanges) {
           CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
           combinedFileRange.setData(result);
-          long startTimer = System.currentTimeMillis();
+          long submissionTime = System.currentTimeMillis();
           Future<?> executionFuture =
               boundedThreadPool.submit(
                   () -> {
+                    long startTime = System.currentTimeMillis();
+                    long queueWaitTime = startTime - submissionTime;
                     logger.atFiner().log(
                         "Submitting combinedRange %s for execution.", combinedFileRange);
 
                     // Reset thread stats as a new task is being submitted to this thread.
                     // all required stats must be collected before task is finished.
                     resetThreadLocalStats();
+                    storageStatistics.updateStats(
+                        GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION,
+                        queueWaitTime,
+                        channelProvider.gcsPath);
                     readCombinedRange(combinedFileRange, allocate, channelProvider);
                     long endTimer = System.currentTimeMillis();
                     storageStatistics.updateStats(
                         GhfsStatistic.STREAM_READ_VECTORED_READ_RANGE_DURATION,
-                        endTimer - startTimer,
+                        endTimer - submissionTime,
                         channelProvider.gcsPath);
                   });
           addCancellationListener(combinedFileRange, executionFuture);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Map.entry;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
 import java.util.*;
@@ -39,7 +40,6 @@ public class GhfsThreadLocalStatisticsTest {
   private static final String HADOOP_API_COUNT = "hadoopApiCount";
   private static final String HADOOP_API_TIME = "hadoopApiTime";
   private static final String STREAM_READ_VECTORED_COUNT = "readVectoredCount";
-
   private static final String STREAM_READ_VECTORED_RANGE_COUNT = "readVectoredRangeCount";
 
   private static Map<GoogleCloudStorageStatistics, String> typeToNameMapping =
@@ -59,15 +59,15 @@ public class GhfsThreadLocalStatisticsTest {
   private Map<String, Long> getInitMetrics() {
     Map<String, Long> result =
         new HashMap<>(
-            Map.of(
-                BACKOFF_COUNT, 0L,
-                BACKOFF_TIME, 0L,
-                HADOOP_API_COUNT, 0L,
-                HADOOP_API_TIME, 0L,
-                GCS_API_COUNT, 0L,
-                GCS_API_TIME, 0L,
-                STREAM_READ_VECTORED_COUNT, 0L,
-                STREAM_READ_VECTORED_RANGE_COUNT, 0L));
+            Map.ofEntries(
+                entry(BACKOFF_COUNT, 0L),
+                entry(BACKOFF_TIME, 0L),
+                entry(HADOOP_API_COUNT, 0L),
+                entry(HADOOP_API_TIME, 0L),
+                entry(GCS_API_COUNT, 0L),
+                entry(GCS_API_TIME, 0L),
+                entry(STREAM_READ_VECTORED_COUNT, 0L),
+                entry(STREAM_READ_VECTORED_RANGE_COUNT, 0L)));
 
     return result;
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.fs.statistics.StoreStatisticNames.SUFFIX_FAILURE
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationHelper;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.URI;
@@ -316,6 +317,58 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
 
     TestUtils.verifyDurationMetric(
         ghfs.getInstrumentation().getIOStatistics(), STREAM_READ_OPERATIONS.getSymbol(), 2);
+  }
+
+  @Test
+  public void fs_operation_threadLocalMetric_tests() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "seek_illegalArgument");
+
+    GoogleHadoopFileSystem ghfs =
+        GoogleHadoopFileSystemIntegrationHelper.createGhfs(
+            path, GoogleHadoopFileSystemIntegrationHelper.getTestConfig());
+
+    GhfsGlobalStorageStatistics globalStorageStatistics = ghfs.getGlobalGcsStorageStatistics();
+    GhfsThreadLocalStatistics ghfsThreadLocalStatistics =
+        globalStorageStatistics.getThreadLocalStatistics();
+
+    String testContent = "test content";
+    gcsFsIHelper.writeTextFile(path, testContent);
+
+    globalStorageStatistics.reset();
+    ghfsThreadLocalStatistics.reset();
+
+    byte[] expected = Arrays.copyOf(testContent.getBytes(StandardCharsets.UTF_8), 10);
+    GoogleHadoopFSInputStream in = createGhfsInputStream(ghfs, path);
+    List<FileRange> fileRanges = new ArrayList<>();
+    FileRange rangeReq1 = FileRange.createFileRange(0, 10);
+    fileRanges.add(rangeReq1);
+
+    in.seek(0);
+    assertThat(in.read(new byte[1], 0, 1)).isEqualTo(1);
+
+    in.readVectored(fileRanges, ByteBuffer::allocate);
+    assertThat(expected).isEqualTo(rangeReq1.getData().get(10, TimeUnit.SECONDS).array());
+    in.close();
+
+    IOStatistics ioStats = in.getIOStatistics();
+    TestUtils.verifyDurationMetric(ioStats, STREAM_READ_OPERATIONS.getSymbol(), 1);
+    TestUtils.verifyDurationMetric(ioStats, STREAM_READ_VECTORED_OPERATIONS.getSymbol(), 1);
+
+    assertThat(ghfsThreadLocalStatistics.getLong("gcsApiCount")).isEqualTo(3);
+
+    assertThat(globalStorageStatistics.getLong(STREAM_READ_OPERATIONS.getSymbol())).isEqualTo(1);
+    assertThat(
+            globalStorageStatistics.getLong(
+                GoogleCloudStorageStatistics.GCS_GET_MEDIA_REQUEST.getSymbol()))
+        .isEqualTo(2);
+    assertThat(
+            globalStorageStatistics.getLong(
+                GoogleCloudStorageStatistics.GCS_METADATA_REQUEST.getSymbol()))
+        .isEqualTo(1);
+    assertThat(
+            globalStorageStatistics.getLong(
+                GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT.getSymbol()))
+        .isEqualTo(3);
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -93,7 +93,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.fadvise", Fadvise.AUTO);
           put("fs.gs.inputstream.fast.fail.on.not.found.enable", true);
           put("fs.gs.inputstream.inplace.seek.limit", 8 * 1024 * 1024L);
-          put("fs.gs.inputstream.latency.logging.threshold.ms", 1000L);
+          put("fs.gs.inputstream.latency.logging.threshold.ms", 10000L);
           put("fs.gs.inputstream.min.range.request.size", 2 * 1024 * 1024L);
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.lazy.init.enable", false);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -93,6 +93,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.fadvise", Fadvise.AUTO);
           put("fs.gs.inputstream.fast.fail.on.not.found.enable", true);
           put("fs.gs.inputstream.inplace.seek.limit", 8 * 1024 * 1024L);
+          put("fs.gs.inputstream.latency.logging.threshold.ms", 1000L);
           put("fs.gs.inputstream.min.range.request.size", 2 * 1024 * 1024L);
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.lazy.init.enable", false);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
@@ -49,7 +49,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -63,7 +62,10 @@ public class GoogleHadoopFileSystemNewIntegrationTest {
   private static HadoopFileSystemIntegrationHelper ghfsIHelper;
   private static String testBucketName;
 
-  @Rule public TestName name = new TestName();
+  @Rule
+  public GoogleHadoopFileSystemTestBase.SanitizedTestName name =
+      new GoogleHadoopFileSystemTestBase.SanitizedTestName();
+
   private TrackingHttpRequestInitializer gcsRequestsTracker;
 
   @Parameterized.Parameter public ClientType storageClientType;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -83,15 +83,16 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     return newConfig;
   }
 
-  @Rule
-  public TestName name =
-      new TestName() {
-        // With parametrization method name will get [index] appended in their name.
-        @Override
-        public String getMethodName() {
-          return super.getMethodName().replaceAll("[\\[,\\],\\s+]", "");
-        }
-      };
+  /** TestName rule that sanitizes method names for use in GCS paths. */
+  public static class SanitizedTestName extends TestName {
+    @Override
+    public String getMethodName() {
+      // With parametrization method name will get [index] appended in their name.
+      return super.getMethodName().replaceAll("[\\[,\\],\\s+]", "");
+    }
+  }
+
+  @Rule public SanitizedTestName name = new SanitizedTestName();
 
   // -----------------------------------------------------------------------------------------
   // Tests that vary according to the GHFS variant, but which we want to make sure get tested.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -37,11 +37,13 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
@@ -490,6 +492,85 @@ public class VectoredIOImplTest {
         .isEqualTo(1);
   }
 
+  @Test
+  public void testZombieThreadPrevention() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    fileRanges.add(FileRange.createFileRange(0, 10));
+
+    CountDownLatch readStartedLatch = new CountDownLatch(1);
+    CountDownLatch interruptLatch = new CountDownLatch(1);
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    when(mockedGcsFs.open((FileInfo) any(), any()))
+        .thenReturn(new BlockingReadChannel(readStartedLatch, interruptLatch));
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the background thread to actually start reading
+    assertTrue("Read should have started", readStartedLatch.await(5, TimeUnit.SECONDS));
+
+    // Cancel the range's data future (simulating a Spark/Parquet timeout)
+    fileRanges.get(0).getData().cancel(true);
+
+    // Verify that the background thread was interrupted
+    assertTrue(
+        "Background thread should have been interrupted",
+        interruptLatch.await(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testCombinedRangeZombieThreadPrevention() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    // These two ranges will be merged based on default options
+    fileRanges.add(FileRange.createFileRange(0, 10));
+    fileRanges.add(FileRange.createFileRange(15, 10));
+
+    CountDownLatch readStartedLatch = new CountDownLatch(1);
+    CountDownLatch interruptLatch = new CountDownLatch(1);
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    when(mockedGcsFs.open((FileInfo) any(), any()))
+        .thenReturn(new BlockingReadChannel(readStartedLatch, interruptLatch));
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the background thread to actually start reading
+    assertTrue("Read should have started", readStartedLatch.await(5, TimeUnit.SECONDS));
+
+    // Cancel one of the child range's data future (simulating a Spark/Parquet timeout)
+    fileRanges.get(0).getData().cancel(true);
+
+    // Verify that the background thread was interrupted
+    assertTrue(
+        "Background thread should have been interrupted for combined range",
+        interruptLatch.await(5, TimeUnit.SECONDS));
+
+    // Verify both child ranges are failed/cancelled
+    assertTrue("First range should be cancelled", fileRanges.get(0).getData().isCancelled());
+    // The second range should also be completed exceptionally because the combined read was
+    // interrupted
+    ExecutionException ee =
+        assertThrows(
+            ExecutionException.class, () -> fileRanges.get(1).getData().get(1, TimeUnit.SECONDS));
+    assertThat(ee.getCause()).isInstanceOf(IOException.class);
+  }
+
   private void verifyRangeContent(List<FileRange> fileRanges) throws Exception {
     for (FileRange range : fileRanges) {
       ByteBuffer result = range.getData().get(1, TimeUnit.MINUTES);
@@ -549,6 +630,30 @@ public class VectoredIOImplTest {
     @Override
     public void close() {
       isOpen = false;
+    }
+  }
+
+  private class BlockingReadChannel extends MockedReadChannel {
+    private final CountDownLatch startLatch;
+    private final CountDownLatch interruptLatch;
+
+    public BlockingReadChannel(CountDownLatch startLatch, CountDownLatch interruptLatch) {
+      this.startLatch = startLatch;
+      this.interruptLatch = interruptLatch;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+      startLatch.countDown();
+      try {
+        // Simulating a long-running/blocked read that waits for an interrupt
+        Thread.sleep(10000);
+      } catch (InterruptedException e) {
+        interruptLatch.countDown();
+        Thread.currentThread().interrupt();
+        throw new ClosedByInterruptException();
+      }
+      return 0;
     }
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,7 +34,10 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -84,6 +88,8 @@ public class VectoredIOImplTest {
 
   @Before
   public void before() throws Exception {
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventSubscriber.reset();
     this.ghfs = createInMemoryGoogleHadoopFileSystem();
     // Write a file which will be used across test case to validate the ranges reads
     this.path = new Path(ghfs.getUri().resolve(OBJECT_NAME));
@@ -98,6 +104,8 @@ public class VectoredIOImplTest {
     this.gcsFs = spy(ghfs.getGcsFs());
     this.statistics = new FileSystem.Statistics(ghfs.getScheme());
     this.ghfsStorageStatistics = new GhfsGlobalStorageStatistics();
+    GoogleCloudStorageEventBus.register(
+        GoogleCloudStorageEventSubscriber.getInstance(ghfsStorageStatistics));
     this.vectoredIO = new VectoredIOImpl(vectoredReadOptions, ghfsStorageStatistics);
     this.streamStatistics = ghfs.getInstrumentation().newInputStreamStatistics(statistics);
     this.rangeReadThreadStats = new ConcurrentHashMap<>();
@@ -109,6 +117,8 @@ public class VectoredIOImplTest {
       vectoredIO.close();
     }
     ghfsStorageStatistics.reset();
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventSubscriber.reset();
     streamStatistics.close();
     rangeReadThreadStats = null;
   }
@@ -659,5 +669,76 @@ public class VectoredIOImplTest {
 
   private void verifyGcsFsOpenCalls(int callCount) throws IOException {
     verify(gcsFs, times(callCount)).open((FileInfo) any(), any());
+  }
+
+  @Test
+  public void testVectoredIOMetricsWithReadChannel() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    // valid range
+    fileRanges.add(FileRange.createFileRange(/* offset */ 0, /* length */ 10));
+
+    GoogleCloudStorageFileSystem mockedGcsFs = mock(GoogleCloudStorageFileSystem.class);
+    when(mockedGcsFs.getOptions()).thenReturn(GoogleCloudStorageFileSystemOptions.DEFAULT);
+
+    GoogleCloudStorageReadChannel mockedChannel = mock(GoogleCloudStorageReadChannel.class);
+
+    when(mockedChannel.read(any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              int length = buffer.remaining();
+              buffer.position(buffer.position() + length);
+              return length;
+            });
+    when(mockedChannel.isOpen()).thenReturn(true);
+    when(mockedChannel.position(org.mockito.ArgumentMatchers.anyLong())).thenReturn(mockedChannel);
+
+    doAnswer(
+            invocation -> {
+              GoogleCloudStorageEventBus.postReadMetricEvent(
+                  GcsReadMetricEvent.ofConnection(100L, fileInfo.getPath()));
+              GoogleCloudStorageEventBus.postReadMetricEvent(
+                  GcsReadMetricEvent.ofDataTransfer(200L, fileInfo.getPath(), false));
+              return null;
+            })
+        .when(mockedChannel)
+        .close();
+
+    when(mockedGcsFs.open((FileInfo) any(), any())).thenReturn(mockedChannel);
+
+    vectoredIO.readVectored(
+        fileRanges,
+        allocate,
+        mockedGcsFs,
+        fileInfo,
+        fileInfo.getPath(),
+        streamStatistics,
+        rangeReadThreadStats);
+
+    // Wait for the asynchronous tasks to complete
+    for (FileRange range : fileRanges) {
+      range.getData().get(1, TimeUnit.MINUTES);
+    }
+
+    long connectionTime = 0;
+    long dataTransferTime = 0;
+    for (int i = 0; i < 100; i++) {
+      connectionTime =
+          ghfsStorageStatistics.getMax(GhfsStatistic.STREAM_READ_CONNECTION_DURATION.getSymbol());
+      dataTransferTime =
+          ghfsStorageStatistics.getMax(
+              GhfsStatistic.STREAM_READ_DATA_TRANSFER_DURATION.getSymbol());
+      if (connectionTime == 100L && dataTransferTime == 200L) {
+        break;
+      }
+      Thread.sleep(50);
+    }
+
+    assertThat(connectionTime).isEqualTo(100L);
+    assertThat(dataTransferTime).isEqualTo(200L);
+    assertThat(
+            ghfsStorageStatistics.getMax(
+                GhfsStatistic.STREAM_READ_VECTORED_THREAD_WAIT_DURATION.getSymbol()))
+        .isAtLeast(0L);
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -35,6 +35,8 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
+import com.google.cloud.hadoop.util.GcsReadDurationTrackerStream;
+import com.google.cloud.hadoop.util.GcsReadMetricEvent;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.cloud.hadoop.util.ResilientOperation;
@@ -48,6 +50,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
@@ -893,7 +896,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
   }
 
   /**
-   * Opens the underlying stream, sets its position to the {@link #currentPosition}.
+   * Opens an {@link InputStream} to the GCS object at the current position, wrapped with
+   * performance tracking.
    *
    * <p>If the file encoding in GCS is gzip (and therefore the HTTP client will decompress it), the
    * entire file is always requested, and we seek to the position requested. If the file encoding is
@@ -901,6 +905,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
    *
    * @param bytesToRead number of bytes to read from new stream. Ignored if {@link
    *     GoogleCloudStorageReadOptions#getFadvise()} is equal to {@link Fadvise#SEQUENTIAL}.
+   * @return an {@link InputStream} to the object content, typically a {@link
+   *     GcsReadDurationTrackerStream}.
    * @throws IOException on IO error
    */
   protected InputStream openStream(long bytesToRead) throws IOException {
@@ -987,8 +993,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
 
     Storage.Objects.Get getObject = createDataRequest(rangeHeader);
     HttpResponse response;
+    long startTime = System.currentTimeMillis();
     try {
       response = getObject.executeMedia();
+      GoogleCloudStorageEventBus.postReadMetricEvent(
+          GcsReadMetricEvent.ofConnection(
+              System.currentTimeMillis() - startTime, URI.create(resourceId.toString())));
       // TODO(b/110832992): validate response range header against expected/request range
     } catch (IOException e) {
       if (!metadataInitialized && errorExtractor.rangeNotSatisfiable(e) && currentPosition == 0) {
@@ -1108,7 +1118,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           currentPosition,
           resourceId);
 
-      return contentStream;
+      return new GcsReadDurationTrackerStream(
+          contentStream,
+          URI.create(resourceId.toString()),
+          response.getHeaders(),
+          readOptions.getLatencyLoggingThreshold());
     } catch (IOException e) {
       GoogleCloudStorageEventBus.postOnException();
       try {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -36,6 +36,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
+import com.google.cloud.hadoop.util.IoExceptionHelper;
 import com.google.cloud.hadoop.util.ResilientOperation;
 import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.annotations.VisibleForTesting;
@@ -395,6 +396,25 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           retriesAttempted = 0;
           totalBytesRead += partialRead;
           currentPosition += partialRead;
+        }
+
+        // Handle thread interruptions (e.g. from cancellation) separately from general
+        // IOExceptions.
+        // Interruptions are treated as non-retryable events because they indicate the caller has
+        // abandoned the current request (e.g., due to a timeout) and may already be initiating
+        // a new attempt. We catch InterruptedIOException but exclude SocketTimeoutException,
+        // which is a network-level timeout that should still be retried.
+        if (IoExceptionHelper.isInterrupted(ioe)) {
+          logger.atInfo().withCause(ioe).log(
+              "Thread interrupted while reading '%s' at position %d. Stopping further processing.",
+              resourceId, currentPosition);
+          // Re-assert interrupt status and percolate as a non-retryable exception.
+          Thread.currentThread().interrupt();
+          throw new IOException(
+              String.format(
+                  "Thread interrupt received while reading '%s' at position %d.",
+                  resourceId, currentPosition),
+              ioe);
         }
 
         // TODO(user): Refactor any reusable logic for retries into a separate RetryHelper
@@ -1036,6 +1056,10 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           break;
         } catch (IOException footerException) {
           GoogleCloudStorageEventBus.postOnException();
+          if (IoExceptionHelper.isInterrupted(footerException)) {
+            Thread.currentThread().interrupt();
+            throw footerException;
+          }
           logger.atInfo().withCause(footerException).log(
               "Failed to prefetch footer (retry #%d/%d) for '%s'",
               retriesCount + 1, maxRetries, resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -60,7 +60,8 @@ public abstract class GoogleCloudStorageReadOptions {
         .setFadviseRequestTrackCount(3)
         .setReadExactRequestedBytesEnabled(false)
         .setBidiThreadCount(16)
-        .setBidiClientTimeout(30);
+        .setBidiClientTimeout(30)
+        .setLatencyLoggingThreshold(1000L);
   }
 
   public abstract Builder toBuilder();
@@ -119,6 +120,9 @@ public abstract class GoogleCloudStorageReadOptions {
 
   /** See {@link Builder#setBidiClientTimeout(int)}. */
   public abstract int getBidiClientTimeout();
+
+  /** See {@link Builder#setLatencyLoggingThreshold(long)}. */
+  public abstract long getLatencyLoggingThreshold();
 
   /** Mutable builder for GoogleCloudStorageReadOptions. */
   @AutoValue.Builder
@@ -233,6 +237,12 @@ public abstract class GoogleCloudStorageReadOptions {
 
     /** Sets the total amount of time, we would wait for bidi client initialization. */
     public abstract Builder setBidiClientTimeout(int bidiClientTimeout);
+
+    /**
+     * Sets the threshold for data transfer latency, if the transfer takes longer than this
+     * threshold, then a high latency warning will be logged.
+     */
+    public abstract Builder setLatencyLoggingThreshold(long latencyLoggingThresholdMillis);
 
     abstract GoogleCloudStorageReadOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -61,7 +61,7 @@ public abstract class GoogleCloudStorageReadOptions {
         .setReadExactRequestedBytesEnabled(false)
         .setBidiThreadCount(16)
         .setBidiClientTimeout(30)
-        .setLatencyLoggingThreshold(1000L);
+        .setLatencyLoggingThreshold(10000L);
   }
 
   public abstract Builder toBuilder();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
@@ -115,6 +115,11 @@ public enum GoogleCloudStorageStatistics {
   GCS_API_TIME(
       "gcs_api_time", "Tracks the amount of time spend while calling GCS APIs.", TYPE_COUNTER),
 
+  GCS_READ_DATA_TRANSFER_LATENCY_BREACHED_COUNT(
+      "gcs_read_data_transfer_latency_breached_count",
+      "Counts the number of times the read data transfer latency threshold was breached.",
+      TYPE_COUNTER),
+
   GCS_METADATA_REQUEST(
       "gcs_metadata_request", "Tracks GCS GET metadata API calls.", TYPE_DURATION_TOTAL),
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.common.flogger.GoogleLogger;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+/** A decorator for {@link InputStream} that tracks the data transfer duration. */
+public class GcsReadDurationTrackerStream extends FilterInputStream {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final String UPLOAD_ID_HEADER = "x-guploader-uploadid";
+
+  private final URI streamPath;
+  private final Object responseHeaders;
+  private final long latencyLoggingThresholdMs;
+  private long cumulativeTransferDurationMs;
+
+  public GcsReadDurationTrackerStream(
+      InputStream delegate,
+      URI streamPath,
+      Object responseHeaders,
+      long latencyLoggingThresholdMs) {
+    super(delegate);
+    this.streamPath = streamPath;
+    this.responseHeaders = responseHeaders;
+    this.latencyLoggingThresholdMs = latencyLoggingThresholdMs;
+    this.cumulativeTransferDurationMs = 0;
+  }
+
+  @Override
+  public int read() throws IOException {
+    long startTime = System.currentTimeMillis();
+    try {
+      return super.read();
+    } finally {
+      cumulativeTransferDurationMs += System.currentTimeMillis() - startTime;
+    }
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    long startTime = System.currentTimeMillis();
+    try {
+      return super.read(b, off, len);
+    } finally {
+      cumulativeTransferDurationMs += System.currentTimeMillis() - startTime;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      boolean latencyThresholdBreached = cumulativeTransferDurationMs > latencyLoggingThresholdMs;
+      if (latencyThresholdBreached) {
+        String uploadId =
+            responseHeaders instanceof HttpHeaders
+                ? ((HttpHeaders) responseHeaders).getFirstHeaderStringValue(UPLOAD_ID_HEADER)
+                : String.valueOf(responseHeaders);
+        logger.atInfo().atMostEvery(10, TimeUnit.SECONDS).log(
+            "Detected high latency for %s. durationMs=%d; upload_id=%s",
+            streamPath, cumulativeTransferDurationMs, uploadId);
+      }
+      GoogleCloudStorageEventBus.postReadMetricEvent(
+          GcsReadMetricEvent.ofDataTransfer(
+              cumulativeTransferDurationMs, streamPath, latencyThresholdBreached));
+    }
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStream.java
@@ -30,14 +30,14 @@ public class GcsReadDurationTrackerStream extends FilterInputStream {
   private static final String UPLOAD_ID_HEADER = "x-guploader-uploadid";
 
   private final URI streamPath;
-  private final Object responseHeaders;
+  private final HttpHeaders responseHeaders;
   private final long latencyLoggingThresholdMs;
   private long cumulativeTransferDurationMs;
 
   public GcsReadDurationTrackerStream(
       InputStream delegate,
       URI streamPath,
-      Object responseHeaders,
+      HttpHeaders responseHeaders,
       long latencyLoggingThresholdMs) {
     super(delegate);
     this.streamPath = streamPath;
@@ -73,13 +73,15 @@ public class GcsReadDurationTrackerStream extends FilterInputStream {
     } finally {
       boolean latencyThresholdBreached = cumulativeTransferDurationMs > latencyLoggingThresholdMs;
       if (latencyThresholdBreached) {
-        String uploadId =
-            responseHeaders instanceof HttpHeaders
-                ? ((HttpHeaders) responseHeaders).getFirstHeaderStringValue(UPLOAD_ID_HEADER)
-                : String.valueOf(responseHeaders);
+        String uploadId = null;
+        String range = null;
+        if (responseHeaders != null) {
+          uploadId = responseHeaders.getFirstHeaderStringValue(UPLOAD_ID_HEADER);
+          range = responseHeaders.getContentRange();
+        }
         logger.atInfo().atMostEvery(10, TimeUnit.SECONDS).log(
-            "Detected high latency for %s. durationMs=%d; upload_id=%s",
-            streamPath, cumulativeTransferDurationMs, uploadId);
+            "Detected high latency for %s. durationMs=%d; upload_id=%s; range=%s",
+            streamPath, cumulativeTransferDurationMs, uploadId, range);
       }
       GoogleCloudStorageEventBus.postReadMetricEvent(
           GcsReadMetricEvent.ofDataTransfer(

--- a/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GcsReadMetricEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import java.net.URI;
+
+/** Event for providing GCS read metrics. */
+public class GcsReadMetricEvent {
+
+  /** Types of read metric events. */
+  public enum Type {
+    CONNECTION,
+    DATA_TRANSFER
+  }
+
+  private final Type type;
+  private final long durationMs;
+  private final URI streamPath;
+  private final boolean latencyThresholdBreached;
+
+  public static GcsReadMetricEvent ofConnection(long durationMs, URI streamPath) {
+    return new GcsReadMetricEvent(Type.CONNECTION, durationMs, streamPath, false);
+  }
+
+  public static GcsReadMetricEvent ofDataTransfer(
+      long durationMs, URI streamPath, boolean latencyThresholdBreached) {
+    return new GcsReadMetricEvent(
+        Type.DATA_TRANSFER, durationMs, streamPath, latencyThresholdBreached);
+  }
+
+  private GcsReadMetricEvent(
+      Type type, long durationMs, URI streamPath, boolean latencyThresholdBreached) {
+    this.type = type;
+    this.durationMs = durationMs;
+    this.streamPath = streamPath;
+    this.latencyThresholdBreached = latencyThresholdBreached;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public long getDurationMs() {
+    return durationMs;
+  }
+
+  public URI getStreamPath() {
+    return streamPath;
+  }
+
+  public boolean isLatencyThresholdBreached() {
+    return latencyThresholdBreached;
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -48,6 +48,11 @@ public class GoogleCloudStorageEventBus {
     eventBus.unregister(obj);
   }
 
+  /** Resets the event bus by creating a new instance. */
+  public static void reset() {
+    eventBus = new EventBus();
+  }
+
   /**
    * Posting Gcs request execution event i.e. request to gcs is being initiated.
    *
@@ -76,6 +81,10 @@ public class GoogleCloudStorageEventBus {
 
   public static void postGcsJsonApiEvent(IGcsJsonApiEvent gcsJsonApiEvent) {
     eventBus.post(gcsJsonApiEvent);
+  }
+
+  public static void postReadMetricEvent(GcsReadMetricEvent gcsReadMetricEvent) {
+    eventBus.post(gcsReadMetricEvent);
   }
 
   public static void postWriteChecksumFailure() {

--- a/util/src/main/java/com/google/cloud/hadoop/util/IoExceptionHelper.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/IoExceptionHelper.java
@@ -18,8 +18,10 @@ package com.google.cloud.hadoop.util;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedByInterruptException;
 import javax.net.ssl.SSLException;
 
 /**
@@ -77,5 +79,25 @@ public final class IoExceptionHelper {
    */
   public static boolean isReadTimedOut(IOException e) {
     return e instanceof SocketTimeoutException && e.getMessage().equalsIgnoreCase("Read timed out");
+  }
+
+  /**
+   * Determines if a given {@link Throwable} is caused by a thread interruption.
+   *
+   * <p>Recursively checks {@code getCause()} if outer exception isn't an instance of the correct
+   * class.
+   *
+   * @param throwable The {@link Throwable} to check.
+   * @return True if the {@link Throwable} is a result of a thread interruption.
+   */
+  public static boolean isInterrupted(Throwable throwable) {
+    if (throwable instanceof InterruptedException
+        || throwable instanceof ClosedByInterruptException
+        || (throwable instanceof InterruptedIOException
+            && !(throwable instanceof SocketTimeoutException))) {
+      return true;
+    }
+    Throwable cause = throwable.getCause();
+    return cause != null && isInterrupted(cause);
   }
 }

--- a/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/GcsReadDurationTrackerStreamTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.common.eventbus.Subscribe;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GcsReadDurationTrackerStreamTest {
+
+  private final List<GcsReadMetricEvent> events = new ArrayList<>();
+  private final URI path = URI.create("gs://bucket/obj");
+
+  @Before
+  public void setUp() {
+    GoogleCloudStorageEventBus.reset();
+    GoogleCloudStorageEventBus.register(
+        new Object() {
+          @Subscribe
+          public void onGcsReadMetricEvent(GcsReadMetricEvent event) {
+            if (event.getType() == GcsReadMetricEvent.Type.DATA_TRANSFER) {
+              events.add(event);
+            }
+          }
+        });
+  }
+
+  @Test
+  public void testDurationTracking() throws IOException {
+    byte[] data = new byte[100];
+    ByteArrayInputStream bais =
+        new ByteArrayInputStream(data) {
+          @Override
+          public synchronized int read(byte[] b, int off, int len) {
+            try {
+              Thread.sleep(100);
+            } catch (InterruptedException e) {
+              // ignore
+            }
+            return super.read(b, off, len);
+          }
+        };
+
+    GcsReadDurationTrackerStream stream = new GcsReadDurationTrackerStream(bais, path, null, 1000L);
+    stream.read(new byte[10]);
+    stream.close();
+
+    assertThat(events).hasSize(1);
+    GcsReadMetricEvent event = events.get(0);
+    assertThat(event.getDurationMs()).isAtLeast(100L);
+    assertThat(event.getStreamPath()).isEqualTo(path);
+  }
+
+  @Test
+  public void testLatencyThresholdBreached() throws IOException {
+    ByteArrayInputStream bais =
+        new ByteArrayInputStream(new byte[10]) {
+          @Override
+          public synchronized int read(byte[] b, int off, int len) {
+            try {
+              Thread.sleep(1100);
+            } catch (InterruptedException e) {
+              // ignore
+            }
+            return super.read(b, off, len);
+          }
+        };
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("x-guploader-uploadid", "test-upload-id");
+
+    GcsReadDurationTrackerStream stream =
+        new GcsReadDurationTrackerStream(bais, path, headers, 1000L);
+    stream.read(new byte[1]);
+    stream.close();
+
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).isLatencyThresholdBreached()).isTrue();
+  }
+}

--- a/util/src/test/java/com/google/cloud/hadoop/util/IoExceptionHelperTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/IoExceptionHelperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedByInterruptException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IoExceptionHelperTest {
+
+  @Test
+  public void testIsInterrupted() {
+    assertThat(IoExceptionHelper.isInterrupted(new InterruptedException())).isTrue();
+    assertThat(IoExceptionHelper.isInterrupted(new ClosedByInterruptException())).isTrue();
+    assertThat(IoExceptionHelper.isInterrupted(new InterruptedIOException())).isTrue();
+
+    // SocketTimeoutException should NOT be treated as interrupt
+    assertThat(IoExceptionHelper.isInterrupted(new SocketTimeoutException())).isFalse();
+
+    // Regular IOException should NOT be treated as interrupt
+    assertThat(IoExceptionHelper.isInterrupted(new IOException())).isFalse();
+
+    // Nested interruptions should be detected
+    assertThat(IoExceptionHelper.isInterrupted(new IOException(new InterruptedException())))
+        .isTrue();
+    assertThat(
+            IoExceptionHelper.isInterrupted(new RuntimeException(new ClosedByInterruptException())))
+        .isTrue();
+
+    // Nested non-interruptions
+    assertThat(IoExceptionHelper.isInterrupted(new IOException(new SocketTimeoutException())))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
The following commits are ported as part of this change. All the ports were clean and no merge conflicts happened

```
commit c9e6ba1c3beb1a9dc684a9b4aaad2b7f870fee0d
Author: Syed Shameerur Rahman <rhmanns@google.com>
Date:   Tue May 12 12:35:08 2026 +0000

    Log requested byte range in high latency logs


commit 81b0a069b2825d1709859d9b37aabe99962e19d0
Author: Syed Shameerur Rahman <syedthameem1@gmail.com>
Date:   Tue Apr 28 17:55:16 2026 +0530

    Add Additional Metrics to track thread_wait, TTFB and data transfer (#1659)


commit c8099157afe71e4c4d4f5e90cfb8824cc63cf185
Author: Syed Shameerur Rahman <syedthameem1@gmail.com>
Date:   Thu Apr 2 09:20:44 2026 +0530

    Fix zombie threads and background resource leaks in vectored reads (#1670)

commit 491de91b451593ade2b855b1f38e03230a95c0c1
Author: Syed Shameerur Rahman <syedthameem1@gmail.com>
Date:   Wed Apr 1 13:19:53 2026 +0530

    Dynamically Set VectorIO Threads Based On Available vCPU  (#1660)

commit b984c08f331ca8d6c61b711fb434cbd5dee21610
Author: Ravi Singh <singhravidutt@gmail.com>
Date:   Mon Feb 16 09:51:36 2026 +0530

    fix thread Local metrics (#1621)
```