### PR TITLE
Fix IllegalArgumentException when reading GCS objects with special URI characters in their name

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -50,7 +50,6 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
@@ -998,7 +997,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       response = getObject.executeMedia();
       GoogleCloudStorageEventBus.postReadMetricEvent(
           GcsReadMetricEvent.ofConnection(
-              System.currentTimeMillis() - startTime, URI.create(resourceId.toString())));
+              System.currentTimeMillis() - startTime,
+              UriPaths.fromResourceId(resourceId, /* allowEmptyObjectName= */ false)));
       // TODO(b/110832992): validate response range header against expected/request range
     } catch (IOException e) {
       if (!metadataInitialized && errorExtractor.rangeNotSatisfiable(e) && currentPosition == 0) {
@@ -1120,7 +1120,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
 
       return new GcsReadDurationTrackerStream(
           contentStream,
-          URI.create(resourceId.toString()),
+          UriPaths.fromResourceId(resourceId, /* allowEmptyObjectName= */ false),
           response.getHeaders(),
           readOptions.getLatencyLoggingThreshold());
     } catch (IOException e) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -44,6 +44,8 @@ import com.google.api.client.util.DateTime;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
+import com.google.cloud.hadoop.util.ApiErrorExtractor;
+import com.google.cloud.hadoop.util.ClientRequestHelper;
 import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
@@ -55,6 +57,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -934,6 +937,35 @@ public class GoogleCloudStorageReadChannelTest {
         .isEqualTo(
             "Unexpected end of stream trying to skip 10 bytes to seek to position 10,"
                 + " size: 9223372036854775807 for 'gs://foo-bucket/bar-object'");
+  }
+
+  @Test
+  public void read_objectNameWithSpecialUriChars_doesNotThrow() throws IOException {
+    // GCS object names may legally contain characters (e.g. double quotes) that are invalid
+    // in a URI string. URI.create(resourceId.toString()) would throw IllegalArgumentException;
+    // UriPaths.fromResourceId() percent-encodes them correctly.
+    String objectName = "path/to/file\"with\"quotes.parquet";
+    byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+    StorageObject object =
+        newStorageObject(BUCKET_NAME, objectName).setSize(BigInteger.valueOf(data.length));
+    MockHttpTransport transport =
+        mockTransport(jsonDataResponse(object), dataRangeResponse(data, 0, data.length));
+
+    Storage storage = new Storage(transport, new GsonFactory(), r -> {});
+
+    GoogleCloudStorageReadChannel readChannel =
+        new GoogleCloudStorageReadChannel(
+            storage,
+            new StorageResourceId(BUCKET_NAME, objectName),
+            ApiErrorExtractor.INSTANCE,
+            new ClientRequestHelper<>(),
+            GoogleCloudStorageReadOptions.DEFAULT);
+
+    ByteBuffer buf = ByteBuffer.allocate(data.length);
+    int bytesRead = readChannel.read(buf);
+
+    assertThat(bytesRead).isEqualTo(data.length);
+    assertThat(buf.array()).isEqualTo(data);
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -942,8 +942,7 @@ public class GoogleCloudStorageReadChannelTest {
   @Test
   public void read_objectNameWithSpecialUriChars_doesNotThrow() throws IOException {
     // GCS object names may legally contain characters (e.g. double quotes) that are invalid
-    // in a URI string. URI.create(resourceId.toString()) would throw IllegalArgumentException;
-    // UriPaths.fromResourceId() percent-encodes them correctly.
+    // in a URI string.
     String objectName = "path/to/file\"with\"quotes.parquet";
     byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
     StorageObject object =
@@ -951,21 +950,21 @@ public class GoogleCloudStorageReadChannelTest {
     MockHttpTransport transport =
         mockTransport(jsonDataResponse(object), dataRangeResponse(data, 0, data.length));
 
-    Storage storage = new Storage(transport, new GsonFactory(), r -> {});
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), r -> {});
 
-    GoogleCloudStorageReadChannel readChannel =
+    try (GoogleCloudStorageReadChannel readChannel =
         new GoogleCloudStorageReadChannel(
             storage,
             new StorageResourceId(BUCKET_NAME, objectName),
             ApiErrorExtractor.INSTANCE,
             new ClientRequestHelper<>(),
-            GoogleCloudStorageReadOptions.DEFAULT);
+            GoogleCloudStorageReadOptions.DEFAULT)) {
+      ByteBuffer buf = ByteBuffer.allocate(data.length);
+      int bytesRead = readChannel.read(buf);
 
-    ByteBuffer buf = ByteBuffer.allocate(data.length);
-    int bytesRead = readChannel.read(buf);
-
-    assertThat(bytesRead).isEqualTo(data.length);
-    assertThat(buf.array()).isEqualTo(data);
+      assertThat(bytesRead).isEqualTo(data.length);
+      assertThat(buf.array()).isEqualTo(data);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #1732

Reading from a GCS object whose name contains characters illegal in a URI (e.g. a double
quote `"`) failed with `IllegalArgumentException` inside `openStream()`. Two call sites
in `GoogleCloudStorageReadChannel` used `URI.create(resourceId.toString())`, which rejects
unencoded characters. Both sites are used only for metrics/event-bus purposes, not for
actual HTTP requests.

Replace both with `UriPaths.fromResourceId(resourceId, /* allowEmptyObjectName= */ false)`,
which percent-encodes path components via the multi-argument `URI` constructor.

## Test plan

- [x] Added `read_objectNameWithSpecialUriChars_doesNotThrow` to
      `GoogleCloudStorageReadChannelTest`: creates a channel for an object whose name
      contains double quotes, reads from it, and asserts success. Verified the test fails
      without the fix (`IllegalArgumentException`) and passes with it.