### PR TITLE
Add option to disable footer caching to allow for large stream size without causing OOM in fadvise=RANDOM

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -3,6 +3,10 @@
 ## Next
 1. Add listStatusStartingFrom API.
 
+1. Add `fs.gs.inputstream.footer.cache.enable` to disable the in-memory footer cache for HTTP
+   and gRPC read channels when a large `fs.gs.inputstream.min.range.request.size` would otherwise
+   allocate a very large `byte[]` for the tail.
+
 1. Add AUTO_RANDOM as new fadvise mode.
 
 1. Add getFileStatusWithHint() API

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -494,6 +494,15 @@ Knobs configure the vectoredRead API
     Minimum size in bytes of the read range for Cloud Storage request when
     opening a new stream to read an object.
 
+*   `fs.gs.inputstream.footer.cache.enable` (default: `true`)
+
+    When true, the connector may read the last range of a non-gzip object into
+    one in-memory **footer cache** and reuse it for reads in that tail. Set to
+    `false` to skip that cache and stream tail bytes from storage instead (useful
+    when `fs.gs.inputstream.min.range.request.size` is very large, for example with
+    `fs.gs.inputstream.fadvise=RANDOM` and non-columnar formats). When disabled, an
+    INFO log may be emitted when a read skips populating the footer cache.
+
 ### gRPC configuration
 
 gRPC is an optimized way to connect with gcs backend. It offers

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -381,6 +381,16 @@ public class GoogleHadoopFileSystemConfiguration {
           GoogleCloudStorageReadOptions.DEFAULT.getMinRangeRequestSize());
 
   /**
+   * When true (default), the connector may read the tail of a non-gzip object (up to the configured
+   * minimum range request size) into one in-memory footer cache and reuse it for reads in that tail.
+   * Set to false to avoid that allocation.
+   */
+  public static final HadoopConfigurationProperty<Boolean> GCS_INPUT_STREAM_FOOTER_CACHE_ENABLE =
+      new HadoopConfigurationProperty<>(
+          "fs.gs.inputstream.footer.cache.enable",
+          GoogleCloudStorageReadOptions.DEFAULT.isFooterCacheEnabled());
+
+  /**
    * Threshold for data transfer latency, if the transfer takes longer than this threshold, then a
    * high latency warning will be logged.
    */
@@ -760,6 +770,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setInplaceSeekLimit(GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.get(config, config::getLongBytes))
         .setMinRangeRequestSize(
             GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.get(config, config::getLongBytes))
+        .setFooterCacheEnabled(
+            GCS_INPUT_STREAM_FOOTER_CACHE_ENABLE.get(config, config::getBoolean))
         .setBlockSize(BLOCK_SIZE.get(config, config::getLong))
         .setFadviseRequestTrackCount(GCS_FADVISE_REQUEST_TRACK_COUNT.get(config, config::getInt))
         .setBidiThreadCount(GCS_BIDI_THREAD_COUNT.get(config, config::getInt))

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -370,6 +370,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
     config.setInt("fs.gs.bidi.thread.count", 5);
     config.setBoolean("fs.gs.bidi.enable", true);
     config.setInt("fs.gs.bidi.client.timeout", 6);
+    config.setBoolean("fs.gs.inputstream.footer.cache.enable", false);
 
     GoogleCloudStorageReadOptions options =
         GoogleHadoopFileSystemConfiguration.getReadChannelOptions(config);
@@ -385,6 +386,15 @@ public class GoogleHadoopFileSystemConfigurationTest {
     assertThat(options.getMinRangeRequestSize()).isEqualTo(4L);
     assertThat(options.getBidiThreadCount()).isEqualTo(5);
     assertThat(options.getBidiClientTimeout()).isEqualTo(6);
+    assertThat(options.isFooterCacheEnabled()).isFalse();
+  }
+
+  @Test
+  public void readChannelOptions_footerCache_defaults() {
+    Configuration config = new Configuration();
+    GoogleCloudStorageReadOptions options =
+        GoogleHadoopFileSystemConfiguration.getReadChannelOptions(config);
+    assertThat(options.isFooterCacheEnabled()).isTrue();
   }
 
   @Test

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
@@ -385,7 +385,7 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
       return;
     }
     if (!readOptions.isFooterCacheEnabled()) {
-      logger.atInfo().log(
+      logger.atFiner().log(
           "Footer cache disabled via read options: not holding the last %d-byte tail in"
               + " memory for '%s'",
           footerSize, resourceId);
@@ -459,7 +459,7 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
     if (eligibleForFooterCache && !readOptions.isFooterCacheEnabled()) {
       long tailSliceByteCount =
           objectSize - max(0L, objectSize - readOptions.getMinRangeRequestSize());
-      logger.atInfo().log(
+      logger.atFiner().log(
           "Footer cache disabled via read options: not holding the last %d-byte tail in memory"
               + " for '%s'",
           tailSliceByteCount, resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageBidiReadChannel.java
@@ -384,6 +384,13 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
     if (footerSize <= 0) {
       return;
     }
+    if (!readOptions.isFooterCacheEnabled()) {
+      logger.atInfo().log(
+          "Footer cache disabled via read options: not holding the last %d-byte tail in"
+              + " memory for '%s'",
+          footerSize, resourceId);
+      return;
+    }
 
     logger.atFiner().log(
         "Prefetching footer for '%s'. Position: %d, Size: %d",
@@ -443,13 +450,23 @@ public final class GoogleCloudStorageBidiReadChannel implements ReadVectoredSeek
     }
 
     // The footer is not cached, but we should fetch it as position is in range.
-    boolean shouldPrefetchFooter =
+    boolean eligibleForFooterCache =
         !gzipEncoded
             && footerContent == null
             && isFooterRead()
             && !readOptions.isReadExactRequestedBytesEnabled();
 
-    if (shouldPrefetchFooter) {
+    if (eligibleForFooterCache && !readOptions.isFooterCacheEnabled()) {
+      long tailSliceByteCount =
+          objectSize - max(0L, objectSize - readOptions.getMinRangeRequestSize());
+      logger.atInfo().log(
+          "Footer cache disabled via read options: not holding the last %d-byte tail in memory"
+              + " for '%s'",
+          tailSliceByteCount, resourceId);
+      return Optional.empty();
+    }
+
+    if (eligibleForFooterCache) {
       try {
         cacheFooter();
         // After caching, read the requested part from the new cache.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -449,7 +449,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
           if (readOptions.isFooterCacheEnabled()) {
             cacheFooter(readableByteChannel);
           } else {
-            logger.atInfo().log(
+            logger.atFiner().log(
                 "Footer cache disabled via read options: not holding the last %d-byte tail in"
                     + " memory for '%s'; streaming from offset %d (object size %d)",
                 footerRangeBytes, resourceId, contentChannelCurrentPosition, objectSize);
@@ -662,6 +662,9 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
             || bytesToRead >= readOptions.getMinRangeRequestSize()) {
           return currentPosition;
         }
+        if (!readOptions.isFooterCacheEnabled()) {
+          return currentPosition;
+        }
         // Prefetch footer (bytes before 'currentPosition') lazily.
         // Max prefetch size is (minRangeRequestSize / 2) bytes.
         if (bytesToRead <= readOptions.getMinRangeRequestSize() / 2) {
@@ -671,6 +674,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       }
 
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
+          && readOptions.isFooterCacheEnabled()
           && isFooterRead()
           && !readOptions.isReadExactRequestedBytesEnabled()) {
         // Prefetch footer and adjust start position to footerStart.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -444,10 +444,21 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
           && (contentChannelEnd - contentChannelCurrentPosition)
               <= readOptions.getMinRangeRequestSize()) {
 
+        long footerRangeBytes = contentChannelEnd - contentChannelCurrentPosition;
         if (footerContent == null) {
-          cacheFooter(readableByteChannel);
+          if (readOptions.isFooterCacheEnabled()) {
+            cacheFooter(readableByteChannel);
+          } else {
+            logger.atInfo().log(
+                "Footer cache disabled via read options: not holding the last %d-byte tail in"
+                    + " memory for '%s'; streaming from offset %d (object size %d)",
+                footerRangeBytes, resourceId, contentChannelCurrentPosition, objectSize);
+          }
         }
-        return serveFooterContent();
+        if (footerContent != null) {
+          return serveFooterContent();
+        }
+        return readableByteChannel;
       }
       return readableByteChannel;
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -1052,49 +1052,57 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         "contentChannelEnd should be initialized already for '%s'",
         resourceId);
 
+    long footerRangeBytes = contentChannelEnd - contentChannelPosition;
     if (!gzipEncoded
         && readOptions.getFadvise() != Fadvise.SEQUENTIAL
         && contentChannelEnd == size
-        && contentChannelEnd - contentChannelPosition <= readOptions.getMinRangeRequestSize()) {
-      for (int retriesCount = 0; retriesCount < maxRetries; retriesCount++) {
-        try {
-          cacheFooter(response);
-          if (retriesCount != 0) {
-            logger.atInfo().log(
-                "Successfully cached footer after %d retries for '%s'", retriesCount, resourceId);
-          }
-          break;
-        } catch (IOException footerException) {
-          GoogleCloudStorageEventBus.postOnException();
-          if (IoExceptionHelper.isInterrupted(footerException)) {
-            Thread.currentThread().interrupt();
-            throw footerException;
-          }
-          logger.atInfo().withCause(footerException).log(
-              "Failed to prefetch footer (retry #%d/%d) for '%s'",
-              retriesCount + 1, maxRetries, resourceId);
-          if (retriesCount == 0) {
-            readBackOff.get().reset();
-          }
-          if (retriesCount == maxRetries) {
-            resetContentChannel();
-            throw footerException;
-          }
+        && footerRangeBytes <= readOptions.getMinRangeRequestSize()) {
+      if (!readOptions.isFooterCacheEnabled()) {
+        logger.atInfo().log(
+            "Footer cache disabled via read options: not holding the last %d-byte tail in"
+                + " memory for '%s'; streaming from offset %d (object size %d)",
+            footerRangeBytes, resourceId, contentChannelPosition, size);
+      } else {
+        for (int retriesCount = 0; retriesCount < maxRetries; retriesCount++) {
           try {
-            response = getObject.executeMedia();
-            // TODO(b/110832992): validate response range header against
-            // expected/request range.
-          } catch (IOException e) {
-            response = handleExecuteMediaException(e);
+            cacheFooter(response);
+            if (retriesCount != 0) {
+              logger.atInfo().log(
+                  "Successfully cached footer after %d retries for '%s'", retriesCount, resourceId);
+            }
+            break;
+          } catch (IOException footerException) {
+            GoogleCloudStorageEventBus.postOnException();
+            if (IoExceptionHelper.isInterrupted(footerException)) {
+              Thread.currentThread().interrupt();
+              throw footerException;
+            }
+            logger.atInfo().withCause(footerException).log(
+                "Failed to prefetch footer (retry #%d/%d) for '%s'",
+                retriesCount + 1, maxRetries, resourceId);
+            if (retriesCount == 0) {
+              readBackOff.get().reset();
+            }
+            if (retriesCount == maxRetries) {
+              resetContentChannel();
+              throw footerException;
+            }
+            try {
+              response = getObject.executeMedia();
+              // TODO(b/110832992): validate response range header against
+              // expected/request range.
+            } catch (IOException e) {
+              response = handleExecuteMediaException(e);
+            }
           }
         }
+        checkState(
+            footerContent != null,
+            "footerContent should not be null after successful footer prefetch for '%s'",
+            resourceId);
+        resetContentChannel();
+        return openFooterStream();
       }
-      checkState(
-          footerContent != null,
-          "footerContent should not be null after successful footer prefetch for '%s'",
-          resourceId);
-      resetContentChannel();
-      return openFooterStream();
     }
 
     try {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -941,8 +941,10 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       contentChannelEnd = size;
     } else {
       contentChannelPosition =
-          readOptions.getFadvise() != Fadvise.SEQUENTIAL && isFooterRead()
-              // Pre-fetch footer if reading end of file.
+          readOptions.getFadvise() != Fadvise.SEQUENTIAL
+                  && readOptions.isFooterCacheEnabled()
+                  && isFooterRead()
+              // Pre-fetch footer if reading end of file (only when footer will be cached).
               ? Math.max(0, size - readOptions.getMinRangeRequestSize())
               : currentPosition;
 
@@ -1058,7 +1060,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         && contentChannelEnd == size
         && footerRangeBytes <= readOptions.getMinRangeRequestSize()) {
       if (!readOptions.isFooterCacheEnabled()) {
-        logger.atInfo().log(
+        logger.atFiner().log(
             "Footer cache disabled via read options: not holding the last %d-byte tail in"
                 + " memory for '%s'; streaming from offset %d (object size %d)",
             footerRangeBytes, resourceId, contentChannelPosition, size);
@@ -1149,6 +1151,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
   private long getContentChannelPositionForFirstRead(long bytesToRead) {
     if (readOptions.getFadvise() == Fadvise.SEQUENTIAL
         || bytesToRead >= readOptions.getMinRangeRequestSize()) {
+      return currentPosition;
+    }
+    if (!readOptions.isFooterCacheEnabled()) {
       return currentPosition;
     }
     // Prefetch footer (bytes before 'currentPosition' in case of last byte read) lazily.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -61,7 +61,8 @@ public abstract class GoogleCloudStorageReadOptions {
         .setReadExactRequestedBytesEnabled(false)
         .setBidiThreadCount(16)
         .setBidiClientTimeout(30)
-        .setLatencyLoggingThreshold(10000L);
+        .setLatencyLoggingThreshold(10000L)
+        .setFooterCacheEnabled(true);
   }
 
   public abstract Builder toBuilder();
@@ -123,6 +124,14 @@ public abstract class GoogleCloudStorageReadOptions {
 
   /** See {@link Builder#setLatencyLoggingThreshold(long)}. */
   public abstract long getLatencyLoggingThreshold();
+
+  /**
+   * When {@code true} (default), the connector may read the last {@link #getMinRangeRequestSize()}
+   * bytes of a non-gzip object into a single in-memory footer cache and serve further reads in that
+   * tail from it (fewer round-trips for backward seeks near EOF). When {@code false}, that cache is
+   * never used; tail reads stream from storage instead.
+   */
+  public abstract boolean isFooterCacheEnabled();
 
   /** Mutable builder for GoogleCloudStorageReadOptions. */
   @AutoValue.Builder
@@ -243,6 +252,12 @@ public abstract class GoogleCloudStorageReadOptions {
      * threshold, then a high latency warning will be logged.
      */
     public abstract Builder setLatencyLoggingThreshold(long latencyLoggingThresholdMillis);
+
+    /**
+     * Enables or disables the in-memory footer cache for HTTP and gRPC read channels (see {@link
+     * #isFooterCacheEnabled()}).
+     */
+    public abstract Builder setFooterCacheEnabled(boolean footerCacheEnabled);
 
     abstract GoogleCloudStorageReadOptions autoBuild();
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -359,6 +359,51 @@ public class GoogleCloudStorageReadChannelTest {
     assertThat(rangeHeaders).containsExactly("bytes=8-9", "bytes=7-8").inOrder();
   }
 
+  /**
+   * When footer cache is disabled, reads in the last {@code minRangeRequestSize} bytes must not
+   * align the HTTP range to {@code size - minRangeRequestSize} (which would download and discard a
+   * large tail prefix).
+   */
+  @Test
+  public void footerRangeAlignment_skippedWhenFooterCacheDisabled() throws IOException {
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+    int minRange = 8;
+
+    MockHttpTransport transport =
+        mockTransport(
+            dataRangeResponse(new byte[] {testData[9]}, 9, testData.length),
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, 8, testData.length), 8, testData.length));
+
+    List<HttpRequest> requests = new ArrayList<>();
+
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        newLazyReadOptionsBuilder()
+            .setFadvise(Fadvise.RANDOM)
+            .setMinRangeRequestSize(minRange)
+            .setFooterCacheEnabled(false)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+
+    byte[] oneByte = new byte[1];
+    readChannel.position(9);
+    assertThat(readChannel.read(ByteBuffer.wrap(oneByte))).isEqualTo(1);
+    assertThat(oneByte[0]).isEqualTo(testData[9]);
+
+    readChannel.position(8);
+    byte[] twoBytes = new byte[2];
+    assertThat(readChannel.read(ByteBuffer.wrap(twoBytes))).isEqualTo(2);
+    assertThat(twoBytes).isEqualTo(Arrays.copyOfRange(testData, 8, testData.length));
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+
+    assertThat(rangeHeaders).containsExactly("bytes=9-16", "bytes=8-9").inOrder();
+  }
+
   @Test
   public void read_onlyRequestedRange() throws IOException {
     int rangeSize = 2;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -309,6 +309,57 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
+  public void footerPrefetch_skippedWhenDisabled() throws IOException {
+    int footerSize = 2;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+    int footerStart = testData.length - footerSize;
+
+    MockHttpTransport transport =
+        mockTransport(
+            // First read at end of object
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, footerStart, testData.length),
+                footerStart,
+                testData.length),
+            // Second read after backward seek without footer cache
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, footerStart - 1, footerStart + 1),
+                footerStart - 1,
+                testData.length));
+
+    List<HttpRequest> requests = new ArrayList<>();
+
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        newLazyReadOptionsBuilder()
+            .setFadvise(Fadvise.RANDOM)
+            .setMinRangeRequestSize(footerSize)
+            .setFooterCacheEnabled(false)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+    assertThat(requests).isEmpty();
+
+    byte[] readBytes = new byte[2];
+
+    readChannel.position(footerStart);
+    assertThat(readChannel.read(ByteBuffer.wrap(readBytes))).isEqualTo(2);
+    assertThat(readBytes).isEqualTo(Arrays.copyOfRange(testData, footerStart, testData.length));
+
+    readChannel.position(footerStart - 1);
+
+    assertThat(readChannel.read(ByteBuffer.wrap(readBytes))).isEqualTo(2);
+    assertThat(readBytes)
+        .isEqualTo(Arrays.copyOfRange(testData, footerStart - 1, testData.length - 1));
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+
+    assertThat(rangeHeaders).containsExactly("bytes=8-9", "bytes=7-8").inOrder();
+  }
+
+  @Test
   public void read_onlyRequestedRange() throws IOException {
     int rangeSize = 2;
     int seekPosition = 0;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptionsTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptionsTest.java
@@ -38,4 +38,15 @@ public class GoogleCloudStorageReadOptionsTest {
         .hasMessageThat()
         .isEqualTo("inplaceSeekLimit must be non-negative! Got " + inplaceSeekLimit);
   }
+
+  @Test
+  public void footerCacheEnabled_defaultsTrue() {
+    assertThat(GoogleCloudStorageReadOptions.DEFAULT.isFooterCacheEnabled()).isTrue();
+    assertThat(
+            GoogleCloudStorageReadOptions.DEFAULT.toBuilder()
+                .setFooterCacheEnabled(false)
+                .build()
+                .isFooterCacheEnabled())
+        .isFalse();
+  }
 }


### PR DESCRIPTION
# Context

Fixes #1734.

The connector by default assumes the file being read with `fadvise=RANDOM` is a columnar format, which has metadata like schema, row-index, etc. at the footer. Hence caches the footer in memory, but this becomes an issue if

- File is not a columnar format
- `fs.gs.inputstream.min.range.request.size` is a big size, such as 2GB, it'll allocate `byte[]` of size 2GB per thread (or total read-channels opened) which reads the footer.

Therefore causing OOM.

# Changes

Introduces option `fs.gs.inputstream.footer.cache.enable` (default: true) to allow disabling the footer cache via the configuration option when not required.