### PR TITLE
[Backport branch-3.1.x] Keep gcs-connector published POM full for unshaded artifact

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -324,6 +324,7 @@
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Backport of #1745 to `branch-3.1.x`.

Keeps the published `gcs-connector` Maven POM full for the main unshaded artifact by disabling dependency-reduced POM generation in the shade execution.

This is relevant for consumers that cannot move to 4.x but need the next 3.1.x release with the corrected unshaded POM.

Context: #1744

Validation:
- `./mvnw -B -pl gcs -am clean package -DskipTests`
