### PR TITLE
Backport(staging-2.2.x): Fast fail fix in grpc and handling additional bytes 

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -300,6 +300,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // in the first read. Therefore, loop till we either read the required number of
       // bytes or we reach end-of-stream.
       while (dst.hasRemaining()) {
+
         int remainingBeforeRead = dst.remaining();
         try {
           if (byteChannel == null) {
@@ -429,8 +430,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
       setChannelBoundaries(bytesToRead);
 
+      logger.atFiner().log(
+          "Opening lazy gRPC channel for '%s' from %d to %d",
+          resourceId, contentChannelCurrentPosition, contentChannelEnd);
+
       ReadableByteChannel readableByteChannel =
-          getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
+          initializeMetadataAndValidateChannel(
+              getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd), bytesToRead);
 
       logger.atFiner().log(
           "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
@@ -446,6 +452,100 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
         return serveFooterContent();
       }
       return readableByteChannel;
+    }
+
+    private ReadableByteChannel initializeMetadataAndValidateChannel(
+        ReadableByteChannel readableByteChannel, long bytesToRead) throws IOException {
+      try {
+        if (!metadataInitialized) {
+          logger.atFine().log(
+              "Metadata not initialized. Forcing lazy channel connection with 0-byte read for '%s'",
+              resourceId);
+
+          // The 0-byte read triggers the actual ReadObjectRequest over the network
+          readableByteChannel.read(ByteBuffer.allocate(0));
+          // Extract the headers to populate objectSize
+          ensureMetadataInitialized(readableByteChannel);
+
+          logger.atFiner().log(
+              "Metadata extracted! True objectSize is now %d for '%s'", objectSize, resourceId);
+
+          ReadableByteChannel eofChannel = validateEndOfFile(readableByteChannel);
+          if (eofChannel != null) {
+            return eofChannel;
+          }
+
+          ReadableByteChannel gzipChannel = handleGzipDiscovery(readableByteChannel, bytesToRead);
+          if (gzipChannel != null) {
+            return gzipChannel;
+          }
+        }
+
+        if (contentChannelEnd == Long.MAX_VALUE && objectSize != -1) {
+          contentChannelEnd = getRangeRequestEnd(contentChannelCurrentPosition, bytesToRead);
+          logger.atFiner().log(
+              "Recalculated contentChannelEnd to %d for '%s'", contentChannelEnd, resourceId);
+        }
+
+        return readableByteChannel;
+
+      } catch (IOException | RuntimeException e) {
+        logger.atWarning().withCause(e).log(
+            "Exception occurred during metadata initialization for '%s'. Attempting to safely close orphaned channel.",
+            resourceId);
+        try {
+          if (readableByteChannel != null && readableByteChannel.isOpen()) {
+            readableByteChannel.close();
+            logger.atFine().log("Successfully closed orphaned channel for '%s'", resourceId);
+          }
+        } catch (IOException closeException) {
+          logger.atWarning().withCause(closeException).log(
+              "Failed to close orphaned channel for '%s' during cleanup", resourceId);
+          e.addSuppressed(closeException);
+        }
+        // Directly re-throw the exception exactly as it was caught.
+        // This prevents RuntimeExceptions (like NPEs) from being masked as IOExceptions!
+        throw e;
+      }
+    }
+
+    private ReadableByteChannel validateEndOfFile(ReadableByteChannel readableByteChannel)
+        throws IOException {
+      if (objectSize != -1) {
+        if (currentPosition > objectSize) {
+          // We just fetched the metadata and realized the user's initial seek was invalid
+          // Intercept it and throw the standard Invalid Seek error.
+          readableByteChannel.close();
+          GoogleCloudStorageEventBus.postOnException();
+          throw new EOFException(
+              String.format(
+                  "Invalid seek offset: position value (%d) must be between 0 and %d for '%s'",
+                  currentPosition, objectSize, resourceId));
+        } else if (currentPosition == objectSize) {
+          // User seeked exactly to the end of the file. Return a clean EOF.
+          readableByteChannel.close();
+          contentChannelCurrentPosition = currentPosition;
+          contentChannelEnd = currentPosition;
+          return Channels.newChannel(new ByteArrayInputStream(new byte[0]));
+        }
+      }
+      return null;
+    }
+
+    private ReadableByteChannel handleGzipDiscovery(
+        ReadableByteChannel readableByteChannel, long bytesToRead) throws IOException {
+      if (gzipEncoded) {
+        if (currentPosition != 0) {
+          // We guessed the boundary wrong for a GZIP file. Reopen it properly.
+          readableByteChannel.close();
+          // Reset channel boundaries
+          contentChannelCurrentPosition = -1;
+          contentChannelEnd = -1;
+          return openByteChannel(bytesToRead);
+        }
+        contentChannelEnd = objectSize;
+      }
+      return null;
     }
 
     private void ensureMetadataInitialized(ReadableByteChannel readableByteChannel)
@@ -490,7 +590,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
     }
 
     private void setChannelBoundaries(long bytesToRead) {
-      contentChannelCurrentPosition = getRangeRequestStart();
+      contentChannelCurrentPosition = getRangeRequestStart(bytesToRead);
       contentChannelEnd = getRangeRequestEnd(contentChannelCurrentPosition, bytesToRead);
       checkState(
           contentChannelEnd >= contentChannelCurrentPosition,
@@ -541,11 +641,32 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       return Channels.newChannel(new ByteArrayInputStream(footerContent, offset, length));
     }
 
-    private long getRangeRequestStart() {
+    private long getRangeRequestStart(long bytesToRead) {
       if (gzipEncoded) {
         return 0;
       }
+<<<<<<< HEAD
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL && isFooterRead()) {
+=======
+
+      // Guess the start boundary if the size is unknown
+      if (objectSize == -1) {
+        if (readOptions.getFadvise() == Fadvise.SEQUENTIAL
+            || bytesToRead >= readOptions.getMinRangeRequestSize()) {
+          return currentPosition;
+        }
+        // Prefetch footer (bytes before 'currentPosition') lazily.
+        // Max prefetch size is (minRangeRequestSize / 2) bytes.
+        if (bytesToRead <= readOptions.getMinRangeRequestSize() / 2) {
+          return Math.max(0, currentPosition - readOptions.getMinRangeRequestSize() / 2);
+        }
+        return Math.max(0, currentPosition - (readOptions.getMinRangeRequestSize() - bytesToRead));
+      }
+
+      if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
+          && isFooterRead()
+          && !readOptions.isReadExactRequestedBytesEnabled()) {
+>>>>>>> ede7779d (Fast Fail Bug Fix during gRPC Reads (#1685))
         // Prefetch footer and adjust start position to footerStart.
         return max(0, objectSize - readOptions.getMinRangeRequestSize());
       }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -652,6 +652,21 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       if (gzipEncoded) {
         return 0;
       }
+
+      // Guess the start boundary if the size is unknown
+      if (objectSize == -1) {
+        if (readOptions.getFadvise() == Fadvise.SEQUENTIAL
+            || bytesToRead >= readOptions.getMinRangeRequestSize()) {
+          return currentPosition;
+        }
+        // Prefetch footer (bytes before 'currentPosition') lazily.
+        // Max prefetch size is (minRangeRequestSize / 2) bytes.
+        if (bytesToRead <= readOptions.getMinRangeRequestSize() / 2) {
+          return Math.max(0, currentPosition - readOptions.getMinRangeRequestSize() / 2);
+        }
+        return Math.max(0, currentPosition - (readOptions.getMinRangeRequestSize() - bytesToRead));
+      }
+
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL && isFooterRead()) {
         // Prefetch footer and adjust start position to footerStart.
         return max(0, objectSize - readOptions.getMinRangeRequestSize());

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -652,28 +652,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       if (gzipEncoded) {
         return 0;
       }
-<<<<<<< HEAD
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL && isFooterRead()) {
-=======
-
-      // Guess the start boundary if the size is unknown
-      if (objectSize == -1) {
-        if (readOptions.getFadvise() == Fadvise.SEQUENTIAL
-            || bytesToRead >= readOptions.getMinRangeRequestSize()) {
-          return currentPosition;
-        }
-        // Prefetch footer (bytes before 'currentPosition') lazily.
-        // Max prefetch size is (minRangeRequestSize / 2) bytes.
-        if (bytesToRead <= readOptions.getMinRangeRequestSize() / 2) {
-          return Math.max(0, currentPosition - readOptions.getMinRangeRequestSize() / 2);
-        }
-        return Math.max(0, currentPosition - (readOptions.getMinRangeRequestSize() - bytesToRead));
-      }
-
-      if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
-          && isFooterRead()
-          && !readOptions.isReadExactRequestedBytesEnabled()) {
->>>>>>> ede7779d (Fast Fail Bug Fix during gRPC Reads (#1685))
         // Prefetch footer and adjust start position to footerStart.
         return max(0, objectSize - readOptions.getMinRangeRequestSize());
       }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -341,13 +341,36 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
               contentChannelEnd = currentPosition;
             }
 
-            if (currentPosition != contentChannelEnd && currentPosition != objectSize) {
+            if (currentPosition < contentChannelEnd && currentPosition < objectSize) {
               GoogleCloudStorageEventBus.postOnException();
               throw new IOException(
                   String.format(
-                      "Received end of stream result before all requestedBytes were received;"
-                          + "EndOf stream signal received at offset: %d where as stream was suppose to end at: %d for resource: %s of size: %d",
+                      "Received end of stream result before all requestedBytes were received; "
+                          + "at offset: %d where as stream was supposed to end at: %d for resource: "
+                          + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
+
+            } else if (currentPosition > objectSize) {
+              GoogleCloudStorageEventBus.postOnException();
+              throw new IOException(
+                  String.format(
+                      "Received end of stream result beyond the object size; at offset: %d "
+                          + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                      currentPosition, contentChannelEnd, resourceId, objectSize));
+            } else if (currentPosition > contentChannelEnd) {
+              logger.atWarning().log(
+                  "Received end of stream result after the channel end; at offset: %d "
+                      + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                  currentPosition, contentChannelEnd, resourceId, objectSize);
+              // Dropping additional bytes.
+              int overshoot = (int) (currentPosition - contentChannelEnd);
+              dst.position(dst.position() - overshoot);
+              currentPosition = contentChannelEnd;
+              totalBytesRead -= overshoot;
+              contentChannelCurrentPosition -= overshoot;
+
+              closeContentChannel();
+              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -408,6 +431,10 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
 
       ReadableByteChannel readableByteChannel =
           getStorageReadChannel(contentChannelCurrentPosition, contentChannelEnd);
+
+      logger.atFiner().log(
+          "Storage ReadChannel opened at, contentChannelCurrentPosition: %d, contentChannelEnd: %d",
+          contentChannelCurrentPosition, contentChannelEnd);
 
       if (contentChannelEnd == objectSize
           && (contentChannelEnd - contentChannelCurrentPosition)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -350,28 +350,6 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                           + "at offset: %d where as stream was supposed to end at: %d for resource: "
                           + "%s of size: %d",
                       currentPosition, contentChannelEnd, resourceId, objectSize));
-
-            } else if (currentPosition > objectSize) {
-              GoogleCloudStorageEventBus.postOnException();
-              throw new IOException(
-                  String.format(
-                      "Received end of stream result beyond the object size; at offset: %d "
-                          + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
-                      currentPosition, contentChannelEnd, resourceId, objectSize));
-            } else if (currentPosition > contentChannelEnd) {
-              logger.atWarning().log(
-                  "Received end of stream result after the channel end; at offset: %d "
-                      + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
-                  currentPosition, contentChannelEnd, resourceId, objectSize);
-              // Dropping additional bytes.
-              int overshoot = (int) (currentPosition - contentChannelEnd);
-              dst.position(dst.position() - overshoot);
-              currentPosition = contentChannelEnd;
-              totalBytesRead -= overshoot;
-              contentChannelCurrentPosition -= overshoot;
-
-              closeContentChannel();
-              continue;
             }
             // If we have reached an end of a contentChannel but not an end of an object.
             // then close contentChannel and continue reading an object if necessary.
@@ -391,6 +369,35 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
                   + " after successful read",
               contentChannelCurrentPosition,
               currentPosition);
+
+          // Fail fast if the server sent data past the total object size
+          if (objectSize != -1 && currentPosition > objectSize) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received data beyond the object size; at offset: %d "
+                        + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, objectSize));
+          }
+
+          // Handle the overshoot immediately in the successful read case
+          if (contentChannelEnd >= 0
+              && contentChannelEnd != objectSize
+              && currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received data after the channel end; at offset: %d "
+                    + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, objectSize);
+
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            dst.position(dst.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            contentChannelCurrentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+
+            // Close the channel so the next iteration opens a cleanly aligned stream
+            closeContentChannel();
+          }
         } catch (Exception e) {
           int partialBytes = partiallyReadBytes(remainingBeforeRead, dst);
           totalBytesRead += partialBytes;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -323,21 +323,35 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             size = currentPosition;
             contentChannelEnd = currentPosition;
           }
-          // Check that we didn't get a premature End of Stream signal by checking the
-          // number of
-          // bytes read against the stream size. Unfortunately we don't have information
-          // about the
-          // actual size of the data stream when stream compression is used, so we can
-          // only ignore
-          // this case here.
-          checkIOPrecondition(
-              currentPosition == contentChannelEnd || currentPosition == size,
-              String.format(
-                  "Received end of stream result before all the file data has been received; "
-                      + "totalBytesRead: %d, currentPosition: %d,"
-                      + " contentChannelEnd %d, size: %d, object: '%s'",
-                  totalBytesRead, currentPosition, contentChannelEnd, size, resourceId));
+          if (currentPosition > contentChannelEnd && currentPosition < size) {
+            logger.atWarning().log(
+                "Received end of stream result after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
 
+            // Dropping additional bytes.
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+            contentChannelPosition -= overshoot;
+          } else if (currentPosition < contentChannelEnd && currentPosition < size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received end of stream result before all requestedBytes were received; "
+                        + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                        + "%s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+
+          } else if (currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received end of stream result beyond the object size; at offset: %d "
+                        + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          }
           // If we have reached an end of a contentChannel but not an end of an object
           // then close contentChannel and continue reading an object if necessary.
           if (contentChannelEnd != size && currentPosition == contentChannelEnd) {
@@ -711,6 +725,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     }
 
     contentChannel = Channels.newChannel(objectContentStream);
+
+    logger.atFiner().log(
+        "Storage ReadChannel opened at, contentChannelPosition: %d, contentChannelEnd: %d",
+        contentChannelPosition, contentChannelEnd);
+
     checkState(
         contentChannelPosition == currentPosition,
         "contentChannelPosition (%s) should be equal to currentPosition (%s) for '%s'",

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -323,7 +323,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             size = currentPosition;
             contentChannelEnd = currentPosition;
           }
-<<<<<<< HEAD
           if (currentPosition > contentChannelEnd && currentPosition < size) {
             logger.atWarning().log(
                 "Received end of stream result after the channel end; at offset: %d "
@@ -337,13 +336,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             totalBytesRead -= overshoot;
             contentChannelPosition -= overshoot;
           } else if (currentPosition < contentChannelEnd && currentPosition < size) {
-=======
-          // Check that we didn't get a premature End of Stream signal by checking the
-          // number of bytes read against the stream size. Unfortunately we don't have information
-          // about the actual size of the data stream when stream compression is used, so we can
-          // only ignore this case here.
-          if (currentPosition < contentChannelEnd && currentPosition < size) {
->>>>>>> 2bbe3566 (fix : Fix edge case for GCS Overshoot bytes bug in Connector (#1721))
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -323,6 +323,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             size = currentPosition;
             contentChannelEnd = currentPosition;
           }
+<<<<<<< HEAD
           if (currentPosition > contentChannelEnd && currentPosition < size) {
             logger.atWarning().log(
                 "Received end of stream result after the channel end; at offset: %d "
@@ -336,20 +337,19 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             totalBytesRead -= overshoot;
             contentChannelPosition -= overshoot;
           } else if (currentPosition < contentChannelEnd && currentPosition < size) {
+=======
+          // Check that we didn't get a premature End of Stream signal by checking the
+          // number of bytes read against the stream size. Unfortunately we don't have information
+          // about the actual size of the data stream when stream compression is used, so we can
+          // only ignore this case here.
+          if (currentPosition < contentChannelEnd && currentPosition < size) {
+>>>>>>> 2bbe3566 (fix : Fix edge case for GCS Overshoot bytes bug in Connector (#1721))
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(
                     "Received end of stream result before all requestedBytes were received; "
-                        + "at offset: %d where as stream was suppose to end at: %d for resource: "
+                        + "at offset: %d whereas stream was suppose to end at: %d for resource: "
                         + "%s of size: %d",
-                    currentPosition, contentChannelEnd, resourceId, size));
-
-          } else if (currentPosition > size) {
-            GoogleCloudStorageEventBus.postOnException();
-            throw new IOException(
-                String.format(
-                    "Received end of stream result beyond the object size; at offset: %d "
-                        + "where as stream was suppose to end at: %d for resource: %s of size: %d",
                     currentPosition, contentChannelEnd, resourceId, size));
           }
           // If we have reached an end of a contentChannel but not an end of an object
@@ -371,6 +371,35 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
                   + " after successful read",
               contentChannelPosition,
               currentPosition);
+
+          // Fail fast if the server sent data past the total object size
+          if (size != -1 && currentPosition > size) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Received data beyond the object size; at offset: %d "
+                        + "whereas stream was supposed to end at: %d for resource: %s of size: %d",
+                    currentPosition, contentChannelEnd, resourceId, size));
+          }
+
+          // Handle the overshoot immediately in the successful read case
+          if (contentChannelEnd >= 0
+              && contentChannelEnd != size
+              && currentPosition > contentChannelEnd) {
+            logger.atWarning().log(
+                "Received data after the channel end; at offset: %d "
+                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
+                currentPosition, contentChannelEnd, resourceId, size);
+
+            int overshoot = (int) (currentPosition - contentChannelEnd);
+            buffer.position(buffer.position() - overshoot);
+            currentPosition = contentChannelEnd;
+            contentChannelPosition = contentChannelEnd;
+            totalBytesRead -= overshoot;
+
+            // Close the channel so the next iteration opens a cleanly aligned stream
+            closeContentChannel();
+          }
         }
 
         if (retriesAttempted != 0) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -323,19 +323,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             size = currentPosition;
             contentChannelEnd = currentPosition;
           }
-          if (currentPosition > contentChannelEnd && currentPosition < size) {
-            logger.atWarning().log(
-                "Received end of stream result after the channel end; at offset: %d "
-                    + "where as stream was suppose to end at: %d for resource: %s of size: %d",
-                currentPosition, contentChannelEnd, resourceId, size);
-
-            // Dropping additional bytes.
-            int overshoot = (int) (currentPosition - contentChannelEnd);
-            buffer.position(buffer.position() - overshoot);
-            currentPosition = contentChannelEnd;
-            totalBytesRead -= overshoot;
-            contentChannelPosition -= overshoot;
-          } else if (currentPosition < contentChannelEnd && currentPosition < size) {
+          if (currentPosition < contentChannelEnd && currentPosition < size) {
             GoogleCloudStorageEventBus.postOnException();
             throw new IOException(
                 String.format(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FakeReadChannel.java
@@ -35,7 +35,9 @@ public class FakeReadChannel implements ReadChannel {
     READ_EXCEPTION,
     PARTIAL_READ,
     NEGATIVE_READ,
-    ZERO_READ
+    ZERO_READ,
+    MORE_THAN_CHANNEL_LENGTH,
+    MORE_THAN_OBJECT_SIZE
   }
 
   private final List<REQUEST_TYPE> orderRequestsList;
@@ -90,14 +92,18 @@ public class FakeReadChannel implements ReadChannel {
   }
 
   private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead) {
-    if (currentPosition >= limit) {
+    return readInternal(dst, startIndex, bytesToRead, false);
+  }
+
+  private int readInternal(ByteBuffer dst, long startIndex, long bytesToRead, boolean ignoreLimit) {
+    if (!ignoreLimit && currentPosition >= limit) {
       return -1;
     }
     long readStart = startIndex;
     long readEnd =
         min(
             min(startIndex + bytesToRead, startIndex + dst.remaining()),
-            min(content.size(), limit));
+            ignoreLimit ? content.size() : min(content.size(), limit));
     ByteString messageData = content.substring(toIntExact(readStart), toIntExact(readEnd));
     for (Byte messageDatum : messageData) {
       dst.put(messageDatum);
@@ -119,11 +125,17 @@ public class FakeReadChannel implements ReadChannel {
       case NEGATIVE_READ:
         bytesRead = -1;
         break;
+      case MORE_THAN_CHANNEL_LENGTH:
+        bytesRead =
+            readInternal(dst, currentPosition, toIntExact(limit - currentPosition + 1), true);
+        break;
+      case MORE_THAN_OBJECT_SIZE:
+        bytesRead = content.size() + 1;
+        break;
       case READ_EXCEPTION:
         throw new IOException("Exception occurred in read");
       case PARTIAL_READ:
         bytesRead = readInternal(dst, currentPosition, dst.remaining() / 2);
-        currentPosition += bytesRead;
         throw new IOException("Partial Read Exception");
       default:
         bytesRead = readInternal(dst, currentPosition, CHUNK_SIZE);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -33,6 +33,9 @@ import com.google.cloud.hadoop.gcsio.FakeReadChannel.REQUEST_TYPE;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
 import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -769,9 +772,10 @@ public class GoogleCloudStorageClientReadChannelTest {
   @Test
   public void testLazyMetadataFetch_emptyObject_returnsEofCleanly() throws Exception {
     GoogleCloudStorageReadOptions readOptions =
-        DEFAULT_READ_OPTION.toBuilder()
-            .setFastFailOnNotFoundEnabled(false)
-            .setGzipEncodingSupportEnabled(true)
+        DEFAULT_READ_OPTION
+            .toBuilder()
+            .setFastFailOnNotFound(false)
+            .setSupportGzipEncoding(true)
             .build();
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getSize()).thenReturn(0L);
@@ -800,7 +804,7 @@ public class GoogleCloudStorageClientReadChannelTest {
   @Test
   public void testRead_whenLazyInitFails_closesOrphanedChannel() throws Exception {
     GoogleCloudStorageReadOptions readOptions =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(false).build();
     Storage mockStorage = mock(Storage.class);
     ReadChannel mockReadChannel = mock(ReadChannel.class);
     when(mockStorage.reader(any(), any())).thenReturn(mockReadChannel);
@@ -827,7 +831,7 @@ public class GoogleCloudStorageClientReadChannelTest {
   @Test
   public void testLazyMetadataFetch_normalForwardRead_fetchesMetadataMidFlight() throws Exception {
     GoogleCloudStorageReadOptions readOptions =
-        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFound(false).build();
     BlobInfo mockBlobInfo = mock(BlobInfo.class);
     when(mockBlobInfo.getSize()).thenReturn((long) OBJECT_SIZE);
     when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
@@ -859,9 +863,10 @@ public class GoogleCloudStorageClientReadChannelTest {
   @Test
   public void testLazyMetadataFetch_gzipEncoded_recoversFromBadGuess() throws Exception {
     GoogleCloudStorageReadOptions readOptions =
-        DEFAULT_READ_OPTION.toBuilder()
-            .setFastFailOnNotFoundEnabled(false)
-            .setGzipEncodingSupportEnabled(true)
+        DEFAULT_READ_OPTION
+            .toBuilder()
+            .setFastFailOnNotFound(false)
+            .setSupportGzipEncoding(true)
             .build();
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getSize()).thenReturn((long) OBJECT_SIZE);
@@ -892,7 +897,7 @@ public class GoogleCloudStorageClientReadChannelTest {
   @Test
   public void testLazyMetadataFetch_seekPastEof_throwsEofException() throws Exception {
     GoogleCloudStorageReadOptions readOptions =
-        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFound(false).build();
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getSize()).thenReturn(10L);
     when(mockBlob.getContentEncoding()).thenReturn(null);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -268,6 +268,48 @@ public class GoogleCloudStorageClientReadChannelTest {
   }
 
   @Test
+  public void read_withOvershoot_handlesBoundaryWithoutCrashing() throws IOException {
+    // Queue READ_CHUNK for the first read, then MORE_THAN_CHANNEL_LENGTH for the second read
+    // to force the underlying channel to overshoot the limit by exactly 1 byte.
+    fakeReadChannel =
+        spy(
+            new FakeReadChannel(
+                CONTENT,
+                ImmutableList.of(REQUEST_TYPE.READ_CHUNK, REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    // Enforce a minimum chunk size of 10 bytes
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setMinRangeRequestSize(10).build();
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
+    readChannel.position(0);
+
+    // First read (Requesting 5 bytes)
+    // The channel is opened with a boundary of 10.
+    // It successfully reads 5 bytes, leaving 5 valid bytes before the boundary.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+
+    // Second read (Requesting 6 bytes)
+    // The FakeReadChannel will return 6 bytes (overshooting the 10-byte limit by 1 byte).
+    // With the immediate correction fix, it detects the 1-byte overshoot right away,
+    // rewinds the buffer, closes the channel, and automatically opens the next stream
+    // to fetch the remaining 1 byte.
+    ByteBuffer buffer2 = ByteBuffer.allocate(6);
+    int bytesRead2 = readChannel.read(buffer2);
+    assertThat(bytesRead2).isEqualTo(6);
+
+    // Third read
+    // We pass a fresh buffer
+    // Previously, the EOF block would trigger the retroactive overshoot logic
+    // and crash with an IllegalArgumentException.
+    // Now, it cleanly reads the next 5 bytes from the properly opened second stream!
+    ByteBuffer buffer3 = ByteBuffer.allocate(5);
+    int bytesRead3 = readChannel.read(buffer3);
+    assertThat(bytesRead3).isEqualTo(5);
+  }
+
+  @Test
   public void fadviseAutoRandom_onSequentialRead_switchToSequential() throws IOException {
     long blockSize = CHUNK_SIZE;
     GoogleCloudStorageReadOptions readOptions =
@@ -949,10 +991,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     IOException e =
         assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
 
-    assertThat(e)
-        .hasCauseThat()
-        .hasMessageThat()
-        .contains("Received end of stream result beyond the object size;");
+    assertThat(e).hasCauseThat().hasMessageThat().contains("Received data beyond the object size;");
   }
 
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -739,6 +739,58 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
   }
 
+  @Test
+  public void readBeyondChannelLength() throws IOException {
+    // Queue READ_CHUNK for the first read, then MORE_THAN_CHANNEL_LENGTH for the second read
+    // so it overshoots the channel limit.
+    fakeReadChannel =
+        spy(
+            new FakeReadChannel(
+                CONTENT,
+                ImmutableList.of(REQUEST_TYPE.READ_CHUNK, REQUEST_TYPE.MORE_THAN_CHANNEL_LENGTH)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+
+    // Enforce a chunk size so that contentChannelEnd is smaller than the full object size
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setMinRangeRequestSize(10).build();
+
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, readOptions);
+
+    readChannel.position(0);
+
+    // 1. First read of 5 bytes. This will open the channel with limit = max(5, 10) = 10.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+
+    // 2. Second read of 10 bytes. The channel limit is still 10.
+    // The FakeReadChannel will return 10 - 5 + 1 = 6 bytes, so currentPosition becomes 11.
+    // Since 11 > 10, it will hit the overshoot block in GoogleCloudStorageClientReadChannel.
+    ByteBuffer buffer2 = ByteBuffer.allocate(10);
+    int bytesRead2 = readChannel.read(buffer2);
+
+    assertThat(bytesRead2).isEqualTo(10);
+    assertThat(readChannel.position()).isEqualTo(15);
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    fakeReadChannel =
+        spy(new FakeReadChannel(CONTENT, ImmutableList.of(REQUEST_TYPE.MORE_THAN_OBJECT_SIZE)));
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeReadChannel);
+    readChannel = getJavaStorageChannel(DEFAULT_ITEM_INFO, DEFAULT_READ_OPTION);
+
+    int startPosition = 0;
+    readChannel.position(startPosition);
+    IOException e =
+        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.allocate(CHUNK_SIZE)));
+
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
   private void verifyContent(ByteBuffer buffer, int startPosition, int length) {
     assertThat(buffer.position()).isEqualTo(length);
     assertByteArrayEquals(
@@ -754,10 +806,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     }
     return new GoogleCloudStorageClientReadChannel(
         mockedStorage,
-        new StorageResourceId(
-            objectInfo.getBucketName(),
-            objectInfo.getObjectName(),
-            objectInfo.getContentGeneration()),
+        objectInfo.getResourceId(),
         objectInfo,
         readOptions,
         GrpcErrorTypeExtractor.INSTANCE,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -596,7 +596,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     verify(mockedStorage, times(0)).get(any(com.google.cloud.storage.BlobId.class));
 
     // Mock storage.get for the fallback/lazy fetch
-    com.google.cloud.storage.Blob mockBlob = mock(com.google.cloud.storage.Blob.class);
+    Blob mockBlob = mock(Blob.class);
     when(mockBlob.getSize()).thenReturn((long) OBJECT_SIZE);
     when(mockBlob.getContentEncoding()).thenReturn("text/plain");
     when(mockedStorage.get(any(com.google.cloud.storage.BlobId.class), any())).thenReturn(mockBlob);
@@ -722,6 +722,170 @@ public class GoogleCloudStorageClientReadChannelTest {
     buffer.clear();
     bytesRead = readChannel.read(buffer);
     assertThat(bytesRead).isEqualTo(10);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_emptyObject_returnsEofCleanly() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder()
+            .setFastFailOnNotFoundEnabled(false)
+            .setGzipEncodingSupportEnabled(true)
+            .build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(0L);
+    when(mockBlob.getContentEncoding()).thenReturn(null);
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(ByteString.EMPTY, mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(0);
+    assertThat(readChannel.size()).isEqualTo(0L);
+  }
+
+  @Test
+  public void testRead_whenLazyInitFails_closesOrphanedChannel() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    Storage mockStorage = mock(Storage.class);
+    ReadChannel mockReadChannel = mock(ReadChannel.class);
+    when(mockStorage.reader(any(), any())).thenReturn(mockReadChannel);
+    when(mockReadChannel.isOpen()).thenReturn(true);
+    when(mockReadChannel.read(any(ByteBuffer.class)))
+        .thenThrow(new IOException("Simulated Connection Error"));
+    GoogleCloudStorageClientReadChannel channel =
+        new GoogleCloudStorageClientReadChannel(
+            mockStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> channel.read(ByteBuffer.allocate(10)));
+
+    assertThat(thrown).hasMessageThat().contains("Error reading");
+    assertThat(thrown).hasCauseThat().hasMessageThat().contains("Simulated Connection Error");
+    verify(mockReadChannel, times(1)).close();
+  }
+
+  @Test
+  public void testLazyMetadataFetch_normalForwardRead_fetchesMetadataMidFlight() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+    BlobInfo mockBlobInfo = mock(BlobInfo.class);
+    when(mockBlobInfo.getSize()).thenReturn((long) OBJECT_SIZE);
+    when(mockBlobInfo.getContentEncoding()).thenReturn("text/plain");
+    when(mockBlobInfo.getGeneration()).thenReturn(1L);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(CONTENT, mockBlobInfo);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Read from the beginning (offset 0)
+    int readBytes = 100;
+    ByteBuffer buffer = ByteBuffer.allocate(readBytes);
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(readBytes);
+    assertThat(readChannel.size()).isEqualTo(OBJECT_SIZE);
+
+    buffer.flip();
+    byte[] expectedContent = CONTENT.substring(0, readBytes).toByteArray();
+    assertThat(buffer.array()).isEqualTo(expectedContent);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_gzipEncoded_recoversFromBadGuess() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder()
+            .setFastFailOnNotFoundEnabled(false)
+            .setGzipEncodingSupportEnabled(true)
+            .build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn((long) OBJECT_SIZE);
+    when(mockBlob.getContentEncoding()).thenReturn("gzip");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel = new MockStorageReadChannel(CONTENT, mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Seek to a random offset (simulating a bad guess before GZIP is discovered)
+    readChannel.position(100);
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+    int bytesRead = readChannel.read(buffer);
+
+    assertThat(bytesRead).isEqualTo(10);
+    assertThat(readChannel.size()).isEqualTo(-1L);
+  }
+
+  @Test
+  public void testLazyMetadataFetch_seekPastEof_throwsEofException() throws Exception {
+    GoogleCloudStorageReadOptions readOptions =
+        DEFAULT_READ_OPTION.toBuilder().setFastFailOnNotFoundEnabled(false).build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getSize()).thenReturn(10L);
+    when(mockBlob.getContentEncoding()).thenReturn(null);
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockedStorage.get(any(BlobId.class), org.mockito.Mockito.<Storage.BlobGetOption>any()))
+        .thenReturn(mockBlob);
+    MockStorageReadChannel fakeChannel =
+        new MockStorageReadChannel(ByteString.copyFromUtf8("0123456789"), mockBlob);
+    when(mockedStorage.reader(any(), any())).thenReturn(fakeChannel);
+    readChannel =
+        new GoogleCloudStorageClientReadChannel(
+            mockedStorage,
+            RESOURCE_ID,
+            null,
+            readOptions,
+            GrpcErrorTypeExtractor.INSTANCE,
+            GoogleCloudStorageOptions.DEFAULT.toBuilder().build());
+
+    // Seek to position 15 (which is > objectSize 10)
+    // Because fast fail is disabled, the connector doesn't know this is out of bounds yet.
+    readChannel.position(15);
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+
+    // Once read() is called, the lazy fetch retrieves the actual size (10L).
+    // validateEndOfFile will realize position (15) > objectSize (10) and throw an EOFException.
+    IOException thrown = assertThrows(IOException.class, () -> readChannel.read(buffer));
+
+    assertThat(thrown).hasCauseThat().isInstanceOf(EOFException.class);
+
+    assertThat(thrown)
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("Invalid seek offset: position value (15) must be between 0 and 10");
+
+    assertThat(readChannel.size()).isEqualTo(10L);
   }
 
   // A fake ReadChannel that mimics StorageReadChannel by having a getObject method

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -45,7 +45,6 @@ import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
-import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -708,99 +707,6 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
-  public void read_gzipped_withExceptionThrownDuringRead() throws IOException {
-    byte[] testDataBatch = new byte[1024];
-    new Random().nextBytes(testDataBatch);
-    // Throw exception after 2GiB byte that caused data duplication before
-    long exceptionByte = 2L * 1024 * 1024 * 1024 + testDataBatch.length;
-    long maxLength = exceptionByte + testDataBatch.length;
-
-    long generation = 3419;
-
-    MockHttpTransport transport =
-        mockTransport(
-            jsonDataResponse(
-                newStorageObject(BUCKET_NAME, OBJECT_NAME)
-                    .setContentEncoding("gzip")
-                    // gzipped object size is smaller than uncompressed data
-                    .setSize(BigInteger.valueOf(maxLength / 2))
-                    .setGeneration(generation)),
-            inputStreamResponse(
-                    new InputStream() {
-                      long bytesRead = 0;
-                      boolean streamFailed;
-
-                      @Override
-                      public int read() throws IOException {
-                        if (streamFailed) {
-                          return -1;
-                        }
-                        if (bytesRead == exceptionByte) {
-                          throw new IOException(
-                              String.format("Read exception at %d byte", exceptionByte));
-                        }
-                        return testDataBatch[(int) (bytesRead++ % testDataBatch.length)] & 255;
-                      }
-                    })
-                .addHeader("Content-Encoding", "gzip")
-                // gzipped object size is smaller than uncompressed data
-                .addHeader("Content-Length", String.valueOf(maxLength / 2)),
-            inputStreamResponse(
-                    new InputStream() {
-                      long bytesRead = 0;
-
-                      @Override
-                      public int read() {
-                        return bytesRead < maxLength
-                            ? testDataBatch[(int) (bytesRead++ % testDataBatch.length)] & 255
-                            : -1;
-                      }
-                    })
-                .addHeader("Content-Encoding", "gzip")
-                // gzipped object size is smaller than uncompressed data
-                .addHeader("Content-Length", String.valueOf(maxLength / 2)));
-
-    List<HttpRequest> requests = new ArrayList<>();
-
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
-
-    GoogleCloudStorageReadOptions options =
-        GoogleCloudStorageReadOptions.builder()
-            .setFadvise(Fadvise.SEQUENTIAL)
-            .setGzipEncodingSupportEnabled(true)
-            .build();
-
-    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
-
-    assertThat(readChannel.size()).isEqualTo(Long.MAX_VALUE);
-
-    byte[] readBytes = new byte[testDataBatch.length];
-    long totalBytesRead = 0;
-    long bytesRead;
-    while ((bytesRead = readChannel.read(ByteBuffer.wrap(readBytes))) > 0) {
-      totalBytesRead += bytesRead;
-      assertThat(bytesRead).isEqualTo(testDataBatch.length);
-      assertThat(readBytes).isEqualTo(testDataBatch);
-      readBytes = new byte[testDataBatch.length];
-    }
-    assertThat(totalBytesRead).isEqualTo(maxLength);
-
-    List<String> rangeHeaders =
-        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
-    assertThat(rangeHeaders).containsExactly(null, null, null).inOrder();
-
-    List<String> requestStrings =
-        requests.stream().map(r -> r.getRequestMethod() + ":" + r.getUrl()).collect(toList());
-    assertThat(requestStrings)
-        .containsExactly(
-            getRequestString(
-                BUCKET_NAME, OBJECT_NAME, /* fields= */ "contentEncoding,generation,size"),
-            getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation),
-            getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation))
-        .inOrder();
-  }
-
-  @Test
   public void readBeyondObjectSize() throws IOException {
     long objectSize = 10L;
     byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
@@ -816,7 +722,7 @@ public class GoogleCloudStorageReadChannelTest {
             // Ensure content-length accommodates the over-read
             inputStreamResponse(
                 CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
-    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+    GoogleCloudStorage gcs = mockedGcs(transport);
 
     GoogleCloudStorageReadChannel readChannel =
         (GoogleCloudStorageReadChannel)
@@ -862,7 +768,7 @@ public class GoogleCloudStorageReadChannelTest {
             // 2. Mock the second read for the remaining bytes
             dataRangeResponse(restData, 12, objectSize));
 
-    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+    GoogleCloudStorage gcs = mockedGcs(transport);
 
     GoogleCloudStorageReadChannel readChannel =
         (GoogleCloudStorageReadChannel)
@@ -912,7 +818,7 @@ public class GoogleCloudStorageReadChannelTest {
             dataRangeResponse(overshootData, 0, objectSize),
             // Mock the second stream fetching the rest of the data from the correct boundary
             dataRangeResponse(restData, 10, objectSize));
-    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+    GoogleCloudStorage gcs = mockedGcs(transport);
     GoogleCloudStorageReadChannel readChannel =
         (GoogleCloudStorageReadChannel)
             gcs.open(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -44,11 +44,8 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
-<<<<<<< HEAD
-=======
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
->>>>>>> f834c65b (Log and drop while receiving the additional bytes from server (#1694))
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -158,7 +158,7 @@ public class GoogleCloudStorageReadChannelTest {
     MockHttpTransport transport =
         mockTransport(
             // 1st read request response
-            dataRangeResponse(testData2, seekPosition, testData2.length),
+            dataRangeResponse(testData2, seekPosition, testData.length),
             // 2nd read request response
             dataRangeResponse(testData, 0, testData.length));
 
@@ -838,9 +838,7 @@ public class GoogleCloudStorageReadChannelTest {
               }
             });
 
-    assertThat(e)
-        .hasMessageThat()
-        .contains("Received end of stream result beyond the object size;");
+    assertThat(e).hasMessageThat().contains("Received data beyond the object size");
   }
 
   @Test
@@ -891,6 +889,64 @@ public class GoogleCloudStorageReadChannelTest {
     // limit 20) = 15
     assertThat(bytesRead).isEqualTo(15);
     assertThat(readChannel.position()).isEqualTo(20);
+  }
+
+  @Test
+  public void read_withOvershoot_handlesBoundaryWithoutCrashing() throws Exception {
+    long objectSize = 20L;
+    // Full expected data for the object
+    byte[] testData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+    // The server overshoots the 10-byte limit by sending 12 bytes instead
+    byte[] overshootData = Arrays.copyOfRange(testData, 0, 12);
+    // The subsequent request should start from the correct boundary (offset 10)
+    byte[] restData = Arrays.copyOfRange(testData, 10, 20);
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // Mock the stream returning the 12 overshot bytes
+            dataRangeResponse(overshootData, 0, objectSize),
+            // Mock the second stream fetching the rest of the data from the correct boundary
+            dataRangeResponse(restData, 10, objectSize));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder()
+                    .setFadvise(Fadvise.RANDOM)
+                    .setMinRangeRequestSize(10) // Force requested range to end at 10
+                    .build());
+    readChannel.setMaxRetries(1);
+
+    // First read (Requesting 5 bytes)
+    // The stream is opened with boundary 10. The mock returns 12 bytes.
+    // The channel reads 5 bytes and leaves 7 in the open stream.
+    ByteBuffer buffer1 = ByteBuffer.allocate(5);
+    int bytesRead1 = readChannel.read(buffer1);
+    assertThat(bytesRead1).isEqualTo(5);
+    assertThat(buffer1.array()).isEqualTo(Arrays.copyOfRange(testData, 0, 5));
+
+    // Second read (Requesting 7 bytes)
+    // The channel reads the remaining 7 bytes from the first stream.
+    // The immediate correction logic intercepts the 2-byte overshoot, rewinds the buffer,
+    // closes the channel, and opens the second stream to fetch the remaining 2 bytes.
+    ByteBuffer buffer2 = ByteBuffer.allocate(7);
+    int bytesRead2 = readChannel.read(buffer2);
+    assertThat(bytesRead2).isEqualTo(7);
+    assertThat(buffer2.array()).isEqualTo(Arrays.copyOfRange(testData, 5, 12));
+
+    // Third read (Requesting 5 bytes)
+    // Previously, this caused an IllegalArgumentException crash.
+    // Now, it simply reads the next 5 bytes from the properly opened second stream!
+    ByteBuffer buffer3 = ByteBuffer.allocate(5);
+    int bytesRead3 = readChannel.read(buffer3);
+    assertThat(bytesRead3).isEqualTo(5);
+    assertThat(buffer3.array()).isEqualTo(Arrays.copyOfRange(testData, 12, 17));
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -44,6 +44,11 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
+<<<<<<< HEAD
+=======
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+>>>>>>> f834c65b (Log and drop while receiving the additional bytes from server (#1694))
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -703,6 +708,192 @@ public class GoogleCloudStorageReadChannelTest {
     byte[] byte3 = new byte[1];
     assertThat(readChannel.read(ByteBuffer.wrap(byte3))).isEqualTo(1);
     assertThat(byte3).isEqualTo(new byte[] {testData[3]});
+  }
+
+  @Test
+  public void read_gzipped_withExceptionThrownDuringRead() throws IOException {
+    byte[] testDataBatch = new byte[1024];
+    new Random().nextBytes(testDataBatch);
+    // Throw exception after 2GiB byte that caused data duplication before
+    long exceptionByte = 2L * 1024 * 1024 * 1024 + testDataBatch.length;
+    long maxLength = exceptionByte + testDataBatch.length;
+
+    long generation = 3419;
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                newStorageObject(BUCKET_NAME, OBJECT_NAME)
+                    .setContentEncoding("gzip")
+                    // gzipped object size is smaller than uncompressed data
+                    .setSize(BigInteger.valueOf(maxLength / 2))
+                    .setGeneration(generation)),
+            inputStreamResponse(
+                    new InputStream() {
+                      long bytesRead = 0;
+                      boolean streamFailed;
+
+                      @Override
+                      public int read() throws IOException {
+                        if (streamFailed) {
+                          return -1;
+                        }
+                        if (bytesRead == exceptionByte) {
+                          throw new IOException(
+                              String.format("Read exception at %d byte", exceptionByte));
+                        }
+                        return testDataBatch[(int) (bytesRead++ % testDataBatch.length)] & 255;
+                      }
+                    })
+                .addHeader("Content-Encoding", "gzip")
+                // gzipped object size is smaller than uncompressed data
+                .addHeader("Content-Length", String.valueOf(maxLength / 2)),
+            inputStreamResponse(
+                    new InputStream() {
+                      long bytesRead = 0;
+
+                      @Override
+                      public int read() {
+                        return bytesRead < maxLength
+                            ? testDataBatch[(int) (bytesRead++ % testDataBatch.length)] & 255
+                            : -1;
+                      }
+                    })
+                .addHeader("Content-Encoding", "gzip")
+                // gzipped object size is smaller than uncompressed data
+                .addHeader("Content-Length", String.valueOf(maxLength / 2)));
+
+    List<HttpRequest> requests = new ArrayList<>();
+
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        GoogleCloudStorageReadOptions.builder()
+            .setFadvise(Fadvise.SEQUENTIAL)
+            .setGzipEncodingSupportEnabled(true)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+
+    assertThat(readChannel.size()).isEqualTo(Long.MAX_VALUE);
+
+    byte[] readBytes = new byte[testDataBatch.length];
+    long totalBytesRead = 0;
+    long bytesRead;
+    while ((bytesRead = readChannel.read(ByteBuffer.wrap(readBytes))) > 0) {
+      totalBytesRead += bytesRead;
+      assertThat(bytesRead).isEqualTo(testDataBatch.length);
+      assertThat(readBytes).isEqualTo(testDataBatch);
+      readBytes = new byte[testDataBatch.length];
+    }
+    assertThat(totalBytesRead).isEqualTo(maxLength);
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+    assertThat(rangeHeaders).containsExactly(null, null, null).inOrder();
+
+    List<String> requestStrings =
+        requests.stream().map(r -> r.getRequestMethod() + ":" + r.getUrl()).collect(toList());
+    assertThat(requestStrings)
+        .containsExactly(
+            getRequestString(
+                BUCKET_NAME, OBJECT_NAME, /* fields= */ "contentEncoding,generation,size"),
+            getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation),
+            getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation))
+        .inOrder();
+  }
+
+  @Test
+  public void readBeyondObjectSize() throws IOException {
+    long objectSize = 10L;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // Ensure content-length accommodates the over-read
+            inputStreamResponse(
+                CONTENT_LENGTH, (long) testData.length, new ByteArrayInputStream(testData)));
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder().setFadvise(Fadvise.SEQUENTIAL).build());
+
+    readChannel.setMaxRetries(0);
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> {
+              ByteBuffer buffer = ByteBuffer.allocate(testData.length + 1);
+              while (buffer.hasRemaining()) {
+                if (readChannel.read(buffer) < 0) {
+                  break;
+                }
+              }
+            });
+
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Received end of stream result beyond the object size;");
+  }
+
+  @Test
+  public void readBeyondChannelLength() throws Exception {
+    long objectSize = 200L;
+    // First response overshoots the 10 byte limit by 2 bytes
+    byte[] overshootData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B};
+    // Second response provides the rest of the object size
+    byte[] restData = {0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(objectSize))
+                    .setGeneration(1L)),
+            // 1. Mock first read returning 12 bytes
+            dataRangeResponse(overshootData, 0, objectSize),
+            // 2. Mock the second read for the remaining bytes
+            dataRangeResponse(restData, 12, objectSize));
+
+    GoogleCloudStorage gcs = mockedGcsImpl(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder()
+                    .setFadvise(Fadvise.RANDOM)
+                    .setMinRangeRequestSize(10) // Force requested range to be 10
+                    .build());
+
+    readChannel.setMaxRetries(1);
+
+    // First read of 5 bytes
+    ByteBuffer buffer = ByteBuffer.allocate(30);
+    buffer.limit(5);
+    int bytesRead = readChannel.read(buffer);
+    assertThat(bytesRead).isEqualTo(5);
+
+    // Second read to trigger overshoot and then EOF
+    buffer.limit(20);
+    bytesRead = readChannel.read(buffer);
+
+    // total read should be 7 (remaining in overshootData) + 8 (from second mock to fill buffer
+    // limit 20) = 15
+    assertThat(bytesRead).isEqualTo(15);
+    assertThat(readChannel.position()).isEqualTo(20);
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientGrpcTracingIntercep
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageTracingFields;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
@@ -261,7 +262,10 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
     GoogleCloudStorageOptions storageOption = GCS_TRACE_OPTIONS.toBuilder().build();
     GoogleCloudStorage gcsImpl = getGCSClientImpl(storageOption);
     GoogleCloudStorageReadOptions readOptions =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(false).build();
+        GoogleCloudStorageReadOptions.builder()
+            .setFastFailOnNotFound(false)
+            .setFadvise(Fadvise.AUTO)
+            .build();
     assertingHandler.flush();
 
     // Execute Parquet-style suffix read

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -47,6 +47,8 @@ import com.google.storage.v2.WriteObjectRequest;
 import com.google.storage.v2.WriteObjectResponse;
 import io.grpc.Status;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -247,6 +249,63 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
     Map<String, Object> readObjectCloseStatusRecord = assertingHandler.getLogRecordAtIndex(5);
     verifyCloseStatus(readObjectCloseStatusRecord, "ReadObject", streamInvocationId, Status.OK);
     gcsImpl.close();
+  }
+
+  @Test
+  public void testGrpcReadLogs_fastFailDisabled_perfectFooterCache() throws Exception {
+    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());
+    int partitionsCount = 1;
+    // Write a 2MB file to simulate a Parquet block
+    byte[] partition =
+        writeObject(helperGcs, resourceId, /* partitionSize= */ 2 * 1024 * 1024, partitionsCount);
+    GoogleCloudStorageOptions storageOption =
+        GCS_TRACE_OPTIONS.toBuilder().setBidiEnabled(false).build();
+    GoogleCloudStorage gcsImpl = getGCSClientImpl(storageOption);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+    assertingHandler.flush();
+
+    // Execute Parquet-style suffix read
+    try (SeekableByteChannel channel = gcsImpl.open(resourceId, readOptions)) {
+      // Read last 8 bytes (triggers the 1MB backward guess + 0-byte metadata fetch)
+      channel.position(partition.length - 8);
+      ByteBuffer magicBuffer = ByteBuffer.allocate(8);
+      channel.read(magicBuffer);
+      // Seek backward by 64KB and read (should be satisfied entirely from RAM)
+      channel.position(partition.length - 65536);
+      ByteBuffer footerBuffer = ByteBuffer.allocate(65536);
+      channel.read(footerBuffer);
+    }
+
+    // A single gRPC network stream generates exactly 3 logs (request, response, onClose)
+    // We expect exactly 1 stream to be opened, therefore we expect 3 logs!
+    assertingHandler.assertLogCount(3);
+    List<Map<String, Object>> allLogs = assertingHandler.getAllLogRecords();
+    long getObjectCount =
+        allLogs.stream()
+            .filter(
+                log ->
+                    "GetObject"
+                        .equals(
+                            String.valueOf(
+                                log.get(GoogleCloudStorageTracingFields.RPC_METHOD.name))))
+            .count();
+    long readObjectCount =
+        allLogs.stream()
+            .filter(
+                log -> {
+                  String method =
+                      String.valueOf(log.get(GoogleCloudStorageTracingFields.RPC_METHOD.name));
+                  String streamOp = String.valueOf(log.get("streamOperation"));
+                  // ONLY count when the stream is initially opened ("request"),
+                  // and ignore "response" and "onClose".
+                  return method != null
+                      && method.contains("ReadObject")
+                      && "request".equals(streamOp);
+                })
+            .count();
+    assertThat(getObjectCount).isEqualTo(0);
+    assertThat(readObjectCount).isEqualTo(1);
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -258,11 +258,10 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
     // Write a 2MB file to simulate a Parquet block
     byte[] partition =
         writeObject(helperGcs, resourceId, /* partitionSize= */ 2 * 1024 * 1024, partitionsCount);
-    GoogleCloudStorageOptions storageOption =
-        GCS_TRACE_OPTIONS.toBuilder().setBidiEnabled(false).build();
+    GoogleCloudStorageOptions storageOption = GCS_TRACE_OPTIONS.toBuilder().build();
     GoogleCloudStorage gcsImpl = getGCSClientImpl(storageOption);
     GoogleCloudStorageReadOptions readOptions =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(false).build();
     assertingHandler.flush();
 
     // Execute Parquet-style suffix read


### PR DESCRIPTION
* Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1694)
* Original [PR](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1685)
* Original [PR](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1721)