### PR TITLE
Backport #1731 to branch-4.0.x: Fix byte-size config properties to use getLongBytes for Hadoop 3.5.0 compatibility

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -312,7 +312,7 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
 
     globAlgorithm = GCS_GLOB_ALGORITHM.get(config, config::getEnum);
     checksumType = GCS_FILE_CHECKSUM_TYPE.get(config, config::getEnum);
-    defaultBlockSize = BLOCK_SIZE.get(config, config::getLong);
+    defaultBlockSize = BLOCK_SIZE.get(config, config::getLongBytes);
     reportedPermissions = new FsPermission(PERMISSIONS_TO_REPORT.get(config, config::get));
 
     initializeFsRoot();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -391,16 +391,16 @@ public class GoogleHadoopFileSystemConfiguration {
               GoogleCloudStorageReadOptions.DEFAULT.getLatencyLoggingThreshold());
 
   /** Minimum distance that will be seeked without merging the ranges together. */
-  public static final HadoopConfigurationProperty<Integer> GCS_VECTORED_READ_RANGE_MIN_SEEK =
+  public static final HadoopConfigurationProperty<Long> GCS_VECTORED_READ_RANGE_MIN_SEEK =
       new HadoopConfigurationProperty<>(
           "fs.gs.vectored.read.min.range.seek.size",
-          VectoredReadOptions.DEFAULT.getMinSeekVectoredReadSize());
+          (long) VectoredReadOptions.DEFAULT.getMinSeekVectoredReadSize());
 
   /** Maximum size allowed for a merged range request. */
-  public static final HadoopConfigurationProperty<Integer> GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE =
+  public static final HadoopConfigurationProperty<Long> GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE =
       new HadoopConfigurationProperty<>(
           "fs.gs.vectored.read.merged.range.max.size",
-          VectoredReadOptions.DEFAULT.getMergeRangeMaxSize());
+          (long) VectoredReadOptions.DEFAULT.getMergeRangeMaxSize());
 
   /** Maximum threads to process individual FileRange requests */
   public static final HadoopConfigurationProperty<Integer> GCS_VECTORED_READ_THREADS =
@@ -663,8 +663,10 @@ public class GoogleHadoopFileSystemConfiguration {
     }
     logger.atInfo().log("Using %d threads for vectored reads", readThreads);
     return VectoredReadOptions.builder()
-        .setMinSeekVectoredReadSize(GCS_VECTORED_READ_RANGE_MIN_SEEK.get(config, config::getInt))
-        .setMergeRangeMaxSize(GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.get(config, config::getInt))
+        .setMinSeekVectoredReadSize(
+            toIntExact(GCS_VECTORED_READ_RANGE_MIN_SEEK.get(config, config::getLongBytes)))
+        .setMergeRangeMaxSize(
+            toIntExact(GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.get(config, config::getLongBytes)))
         .setReadThreads(readThreads);
   }
 
@@ -755,7 +757,7 @@ public class GoogleHadoopFileSystemConfiguration {
         .setInplaceSeekLimit(GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.get(config, config::getLongBytes))
         .setMinRangeRequestSize(
             GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.get(config, config::getLongBytes))
-        .setBlockSize(BLOCK_SIZE.get(config, config::getLong))
+        .setBlockSize(BLOCK_SIZE.get(config, config::getLongBytes))
         .setFadviseRequestTrackCount(GCS_FADVISE_REQUEST_TRACK_COUNT.get(config, config::getInt))
         .setBidiThreadCount(GCS_BIDI_THREAD_COUNT.get(config, config::getInt))
         .setBidiClientTimeout(GCS_BIDI_CLIENT_INITIALIZATION_TIMEOUT.get(config, config::getInt))

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -71,8 +71,8 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.encryption.key.hash", null);
           put("fs.gs.glob.algorithm", GlobAlgorithm.CONCURRENT);
           put("fs.gs.vectored.read.threads", 16);
-          put("fs.gs.vectored.read.merged.range.max.size", 8 * 1024 * 1024);
-          put("fs.gs.vectored.read.min.range.seek.size", 4 * 1024);
+          put("fs.gs.vectored.read.merged.range.max.size", 8 * 1024 * 1024L);
+          put("fs.gs.vectored.read.min.range.seek.size", 4 * 1024L);
           put("fs.gs.grpc.checkinterval.timeout", 1_000L);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.directpath.enable", true);
@@ -432,6 +432,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
   @Test
   public void sizeProperties_sizeSuffixes() {
     Configuration config = new Configuration();
+    config.set("fs.gs.block.size", "128m");
     config.set("fs.gs.inputstream.inplace.seek.limit", "2048");
     config.set("fs.gs.inputstream.min.range.request.size", "300K");
     config.set("fs.gs.outputstream.buffer.size", "40k");
@@ -439,10 +440,15 @@ public class GoogleHadoopFileSystemConfigurationTest {
     config.set("fs.gs.outputstream.upload.cache.size", "512M");
     config.set("fs.gs.outputstream.upload.chunk.size", "16m");
     config.set("fs.gs.rewrite.max.chunk.size", "2g");
+    config.set("fs.gs.vectored.read.min.range.seek.size", "8k");
+    config.set("fs.gs.vectored.read.merged.range.max.size", "4m");
 
     GoogleCloudStorageOptions options =
         GoogleHadoopFileSystemConfiguration.getGcsOptionsBuilder(config).build();
+    VectoredReadOptions vectoredOptions =
+        GoogleHadoopFileSystemConfiguration.getVectoredReadOptionBuilder(config).build();
 
+    assertThat(options.getReadChannelOptions().getBlockSize()).isEqualTo(128 * 1024 * 1024L);
     assertThat(options.getReadChannelOptions().getInplaceSeekLimit()).isEqualTo(2048);
     assertThat(options.getReadChannelOptions().getMinRangeRequestSize()).isEqualTo(300 * 1024);
     assertThat(options.getWriteChannelOptions().getBufferSize()).isEqualTo(40 * 1024);
@@ -450,6 +456,8 @@ public class GoogleHadoopFileSystemConfigurationTest {
     assertThat(options.getWriteChannelOptions().getUploadCacheSize()).isEqualTo(512 * 1024 * 1024);
     assertThat(options.getWriteChannelOptions().getUploadChunkSize()).isEqualTo(16 * 1024 * 1024);
     assertThat(options.getMaxRewriteChunkSize()).isEqualTo(2 * 1024 * 1024 * 1024L);
+    assertThat(vectoredOptions.getMinSeekVectoredReadSize()).isEqualTo(8 * 1024);
+    assertThat(vectoredOptions.getMergeRangeMaxSize()).isEqualTo(4 * 1024 * 1024);
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.STREAM_READ_OPERATIONS;
 import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.STREAM_WRITE_OPERATIONS;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.BLOCK_SIZE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_CLIENT_TYPE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem;
 import static com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage.getInMemoryGoogleCloudStorageOptions;
@@ -473,6 +474,18 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
 
     // Assert that instrumentation is null after close
     assertThat(instrumentationField.get(ghfs)).isNull();
+  }
+
+  @Test
+  public void blockSize_sizeSuffix() throws Exception {
+    Configuration config = new Configuration();
+    config.set(BLOCK_SIZE.getKey(), "128m");
+    config.setBoolean("fs.gs.lazy.init.enable", true);
+    config.setEnum(GCS_CLIENT_TYPE.toString(), storageClientType);
+    GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem();
+    fs.initialize(new URI("gs://test-bucket/"), config);
+    assertThat(fs.getDefaultBlockSize()).isEqualTo(128 * 1024 * 1024L);
+    fs.close();
   }
 
   // -----------------------------------------------------------------


### PR DESCRIPTION
Backport of #1731 to `branch-4.0.x`.

Hadoop 3.5.0 sets several GCS-related config keys in `core-default.xml` using human-readable byte suffixes (e.g. `"64m"`). The connector was reading these with `getLong()`/`getInt()`, which cannot parse suffixed values and throws a `NumberFormatException` at startup.

Changes:
- `fs.gs.block.size`: `getLong` → `getLongBytes` in both `GoogleHadoopFileSystem` and `GoogleHadoopFileSystemConfiguration`
- `fs.gs.vectored.read.min.range.seek.size` / `fs.gs.vectored.read.merged.range.max.size`: `getInt` → `getLongBytes` (with `toIntExact` cast at the Hadoop API boundary); property type widened from `Integer` to `Long`