### PR TITLE
Integrate and map Analytics Core fadvise

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -79,16 +79,7 @@ final class AnalyticsCoreConfigMapper {
   static Map<String, String> mapConfigs(Configuration config, String prefix) {
     Map<String, String> mappedProperties = config.getValByRegex("^" + prefix.replace(".", "\\."));
 
-    // Pre-process fadvise configuration to match FileAccessPattern expected by Analytics Core
-    String fadvise =
-        mappedProperties.get(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey());
-    if (fadvise != null) {
-      mappedProperties.put(
-          GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(),
-          toFileAccessPattern(fadvise));
-    }
-
-    // Direct 1:1 mappings from Connector to Analytics Core
+    // Direct mappings from Connector to Analytics Core
     HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS.forEach(
         (hadoopKey, analyticsKey) ->
             mapAndRemoveSource(hadoopKey, mappedProperties, prefix + analyticsKey));
@@ -104,6 +95,9 @@ final class AnalyticsCoreConfigMapper {
       String hadoopKey, Map<String, String> map, String analyticsCoreKey) {
     String value = map.remove(hadoopKey);
     if (value != null) {
+      if (hadoopKey.equals(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey())) {
+        value = toFileAccessPattern(value);
+      }
       map.put(analyticsCoreKey, value);
     }
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -29,6 +29,11 @@ final class AnalyticsCoreConfigMapper {
   static final String MAX_MERGE_SIZE_KEY =
       "analytics-core.read.vectored.range.merged-size.max-bytes";
   static final String USER_AGENT_KEY = "user-agent";
+  static final String FILE_ACCESS_PATTERN_KEY = "analytics-core.read.file-access-pattern";
+  static final String INPLACE_SEEK_LIMIT_KEY = "analytics-core.read.inplace-seek-limit-bytes";
+  static final String RANDOM_READ_MIN_REQ_SIZE_KEY = "analytics-core.random-read.min-request-size";
+  static final String ADAPTIVE_READ_SEQ_THRESHOLD_KEY =
+      "analytics-core.adaptive-read.sequential-read-threshold";
 
   private static final ImmutableMap<String, String> HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS =
       ImmutableMap.<String, String>builder()
@@ -45,6 +50,18 @@ final class AnalyticsCoreConfigMapper {
           .put(
               GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
               MAX_MERGE_SIZE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey(),
+              INPLACE_SEEK_LIMIT_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey(),
+              RANDOM_READ_MIN_REQ_SIZE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey(),
+              ADAPTIVE_READ_SEQ_THRESHOLD_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(),
+              FILE_ACCESS_PATTERN_KEY)
           .build();
 
   private AnalyticsCoreConfigMapper() {
@@ -61,6 +78,15 @@ final class AnalyticsCoreConfigMapper {
    */
   static Map<String, String> mapConfigs(Configuration config, String prefix) {
     Map<String, String> mappedProperties = config.getValByRegex("^" + prefix.replace(".", "\\."));
+
+    // Pre-process fadvise configuration to match FileAccessPattern expected by Analytics Core
+    String fadvise =
+        mappedProperties.get(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey());
+    if (fadvise != null) {
+      mappedProperties.put(
+          GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(),
+          toFileAccessPattern(fadvise));
+    }
 
     // Direct 1:1 mappings from Connector to Analytics Core
     HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS.forEach(
@@ -79,6 +105,21 @@ final class AnalyticsCoreConfigMapper {
     String value = map.remove(hadoopKey);
     if (value != null) {
       map.put(analyticsCoreKey, value);
+    }
+  }
+
+  private static String toFileAccessPattern(String fadvise) {
+    switch (fadvise.toUpperCase()) {
+      case "AUTO":
+        return "AUTO_SEQUENTIAL";
+      case "AUTO_RANDOM":
+        return "AUTO_RANDOM";
+      case "SEQUENTIAL":
+        return "SEQUENTIAL";
+      case "RANDOM":
+        return "RANDOM";
+      default:
+        return "AUTO_SEQUENTIAL";
     }
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
@@ -46,6 +46,14 @@ public class AnalyticsCoreConfigMapperTest {
         .isEqualTo("1024");
     assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.MAX_MERGE_SIZE_KEY))
         .isEqualTo("2048");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("RANDOM");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.INPLACE_SEEK_LIMIT_KEY))
+        .isEqualTo("50");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.RANDOM_READ_MIN_REQ_SIZE_KEY))
+        .isEqualTo("100");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.ADAPTIVE_READ_SEQ_THRESHOLD_KEY))
+        .isEqualTo("5");
     assertThat(mapped).containsAtLeastEntriesIn(EXPECTED_MANDATORY_MAPPINGS);
   }
 
@@ -74,6 +82,53 @@ public class AnalyticsCoreConfigMapperTest {
                 GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE
                     .getKey()))
         .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE
+                    .getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey()))
+        .isFalse();
+  }
+
+  @Test
+  public void mapConfigs_mapsFadviseModesCorrectly() {
+    Configuration config = new Configuration();
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "SEQUENTIAL");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("SEQUENTIAL");
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "RANDOM");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("RANDOM");
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "AUTO");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("AUTO_SEQUENTIAL");
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "AUTO_RANDOM");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("AUTO_RANDOM");
   }
 
   @Test
@@ -127,6 +182,13 @@ public class AnalyticsCoreConfigMapperTest {
     config.set(
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
         "2048");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "RANDOM");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey(), "50");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey(),
+        "100");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey(), "5");
     return config;
   }
 }


### PR DESCRIPTION
This PR integrates and maps the Analytics Core `fadvise` configurations while utilizing its default values as mentioned [here](https://github.com/GoogleCloudPlatform/gcs-analytics-core/blob/main/CONFIGURATION.md).