### PR TITLE
Add caffeine dependency to shaded artifact set in pom.xml

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -238,6 +238,7 @@
                   <include>io.opentelemetry.semconv</include>
                   <include>io.perfmark</include>
                   <include>org.apache.httpcomponents</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.threeten:threetenbp</include>
                 </includes>
               </artifactSet>
@@ -275,6 +276,7 @@
                     <include>com.google.storage.**</include>
                     <include>com.google.thirdparty.**</include>
                     <include>com.google.type.**</include>
+                    <include>com.github.benmanes.caffeine.**</include>
                     <include>com.lmax.disruptor.**</include>
                   </includes>
                   <excludes>


### PR DESCRIPTION
Add caffeine dependency to shaded artifact set in pom.xml. This is needed for the analytics-core version upgrade to `1.4.0`